### PR TITLE
fix(stellar): reject invalid hex characters in hexToBytes (#8)

### DIFF
--- a/lib/stellar/scval.ts
+++ b/lib/stellar/scval.ts
@@ -106,8 +106,14 @@ export function hexToBytes(hex: string): Uint8Array {
     throw new Error("invalid hex string (odd length)");
   }
   const out = new Uint8Array(clean.length / 2);
-  for (let i = 0; i < out.length; i++) {
-    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  for (let i = 0; i < clean.length; i += 2) {
+    const chunk = clean.slice(i, i + 2);
+    const byte = parseInt(chunk, 16);
+    if (Number.isNaN(byte) || !/^[0-9a-fA-F]{2}$/.test(chunk)) {
+      const invalidChar = chunk.match(/[^0-9a-fA-F]/)?.[0] ?? chunk;
+      throw new Error(`invalid hex character: "${invalidChar}"`);
+    }
+    out[i / 2] = byte;
   }
   return out;
 }

--- a/tests/lib/stellar/scval.test.ts
+++ b/tests/lib/stellar/scval.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import {
+  hexToBytes,
+  bytesToHex,
+  bytes32ToScVal,
+  i128ToScVal,
+  addressToScVal,
+  symbolToScVal,
+  scValToString,
+  scValToNativeSafe,
+  hashOrderId,
+} from "@/lib/stellar/scval";
+
+describe("hexToBytes and bytesToHex", () => {
+  it("converts empty string to empty Uint8Array", () => {
+    const result = hexToBytes("");
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(0);
+    expect(bytesToHex(result)).toBe("");
+  });
+
+  it("handles 0x prefix case-insensitively and parses valid hex", () => {
+    const withoutPrefix = hexToBytes("deadbeef");
+    const withPrefixLower = hexToBytes("0xdeadbeef");
+    const withPrefixUpper = hexToBytes("0XDEADBEEF");
+
+    expect(Array.from(withoutPrefix)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+    expect(Array.from(withPrefixLower)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+    expect(Array.from(withPrefixUpper)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+  });
+
+  it("round-trips mixed-case hex case-insensitively and emits lowercase output", () => {
+    expect(bytesToHex(hexToBytes("a1B2c3"))).toBe("a1b2c3");
+    expect(bytesToHex(hexToBytes("0xA1B2C3D4"))).toBe("a1b2c3d4");
+  });
+
+  it("throws error for odd-length hex strings", () => {
+    expect(() => hexToBytes("123")).toThrow("invalid hex string (odd length)");
+    expect(() => hexToBytes("0x12345")).toThrow("invalid hex string (odd length)");
+  });
+
+  it("throws error for invalid hex characters naming offending character", () => {
+    expect(() => hexToBytes("gggg")).toThrow(/invalid hex character/i);
+    expect(() => hexToBytes("0xzz")).toThrow(/invalid hex character/i);
+    expect(() => hexToBytes("12g4")).toThrow(/invalid hex character/i);
+    expect(() => hexToBytes("0x1234xy")).toThrow(/invalid hex character/i);
+  });
+});
+
+describe("bytes32ToScVal", () => {
+  it("builds BytesN<32> ScVal for valid 32-byte hex string or buffer", () => {
+    const hex32 = "00".repeat(32);
+    const scValFromHex = bytes32ToScVal(hex32);
+    expect(scValFromHex).toBeDefined();
+
+    const bytes32 = new Uint8Array(32).fill(0xaa);
+    const scValFromBytes = bytes32ToScVal(bytes32);
+    expect(scValFromBytes).toBeDefined();
+    expect(scValToString(scValFromBytes)).toBe("aa".repeat(32));
+  });
+
+  it("throws error if hex string has length != 64 (not 32 bytes)", () => {
+    expect(() => bytes32ToScVal("00".repeat(31))).toThrow(
+      /order_id must be exactly 32 bytes/,
+    );
+    expect(() => bytes32ToScVal("00".repeat(33))).toThrow(
+      /order_id must be exactly 32 bytes/,
+    );
+  });
+
+  it("throws error when given a 64-character non-hex string instead of producing zero bytes", () => {
+    const invalid64 = "g".repeat(64);
+    expect(() => bytes32ToScVal(invalid64)).toThrow(/invalid hex character/i);
+  });
+});
+
+describe("scval helpers", () => {
+  it("constructs and converts i128 values correctly", () => {
+    const scVal = i128ToScVal(12345678901234567890n);
+    expect(scValToString(scVal)).toBe("12345678901234567890");
+    expect(scValToNativeSafe(scVal)).toBe(12345678901234567890n);
+  });
+
+  it("constructs and converts symbols correctly", () => {
+    const scVal = symbolToScVal("USDC");
+    expect(scValToString(scVal)).toBe("USDC");
+  });
+
+  it("hashes orderId with SHA-256 to 32 bytes", async () => {
+    const digest = await hashOrderId("order_12345");
+    expect(digest).toBeInstanceOf(Uint8Array);
+    expect(digest.length).toBe(32);
+  });
+});


### PR DESCRIPTION
## Summary
Resolves #8

- Validates each 2-character chunk in `hexToBytes` against valid hexadecimal characters (`/^[0-9a-fA-F]{2}$/`).
- Throws a descriptive `Error` naming the invalid character when malformed input (e.g. `"gggg"`, `"0xzz"`) is provided instead of returning zero bytes via `NaN` coercion.
- Preserves existing odd-length check, `0x` prefix handling, and lowercase output formatting in `bytesToHex`.
- Adds unit tests in `tests/lib/stellar/scval.test.ts` covering valid round-trips, empty string handling, odd lengths, invalid hex characters, and `bytes32ToScVal` 32-byte guard.

## Testing
- `npm run test` (all 3 test files, 47 tests pass)
- `npm run lint` and `npm run type-check` pass