### PR TITLE
fix(stellar): reject invalid hex characters in hexToBytes (#8)

### DIFF
--- a/lib/stellar/scval.ts
+++ b/lib/stellar/scval.ts
@@ -22,8 +22,7 @@ export function i128ToScVal(value: bigint | number | string): xdr.ScVal {
  * Build a BytesN<32> ScVal from a Uint8Array (or hex string).
  */
 export function bytes32ToScVal(bytes: Uint8Array | string): xdr.ScVal {
-  const buf =
-    typeof bytes === "string" ? Buffer.from(hexToBytes(bytes)) : Buffer.from(bytes);
+  const buf = typeof bytes === "string" ? Buffer.from(hexToBytes(bytes)) : Buffer.from(bytes);
   if (buf.length !== 32) {
     throw new Error(`order_id must be exactly 32 bytes (got ${buf.length})`);
   }
@@ -100,18 +99,36 @@ function bigintSafeReplacer(_key: string, value: unknown) {
   return typeof value === "bigint" ? value.toString() : value;
 }
 
+/**
+ * Convert a hexadecimal string to a Uint8Array byte array.
+ *
+ * @param hex - Hexadecimal string, optionally prefixed with 0x or 0X.
+ * @returns Decoded byte array as Uint8Array.
+ * @throws {Error} If the hex string has an odd length or contains invalid hex characters.
+ */
 export function hexToBytes(hex: string): Uint8Array {
   const clean = hex.replace(/^0x/i, "");
   if (clean.length % 2 !== 0) {
     throw new Error("invalid hex string (odd length)");
   }
   const out = new Uint8Array(clean.length / 2);
-  for (let i = 0; i < out.length; i++) {
-    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  for (let i = 0; i < clean.length; i += 2) {
+    const chunk = clean.slice(i, i + 2);
+    const invalidChar = chunk.match(/[^0-9a-fA-F]/)?.[0];
+    if (invalidChar !== undefined) {
+      throw new Error(`invalid hex character: "${invalidChar}"`);
+    }
+    out[i / 2] = parseInt(chunk, 16);
   }
   return out;
 }
 
+/**
+ * Convert a Uint8Array byte array to a lowercase hexadecimal string.
+ *
+ * @param bytes - Byte array to encode.
+ * @returns Lowercase hexadecimal string.
+ */
 export function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes)
     .map((b) => b.toString(16).padStart(2, "0"))

--- a/tests/lib/stellar/scval.test.ts
+++ b/tests/lib/stellar/scval.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import {
+  hexToBytes,
+  bytesToHex,
+  bytes32ToScVal,
+  i128ToScVal,
+  addressToScVal,
+  symbolToScVal,
+  scValToString,
+  scValToNativeSafe,
+  hashOrderId,
+} from "@/lib/stellar/scval";
+
+describe("hexToBytes and bytesToHex", () => {
+  it("converts empty string to empty Uint8Array", () => {
+    const result = hexToBytes("");
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(0);
+    expect(bytesToHex(result)).toBe("");
+  });
+
+  it("handles 0x and 0X prefix case-insensitively and parses valid hex", () => {
+    const withoutPrefix = hexToBytes("deadbeef");
+    const withPrefixLower = hexToBytes("0xdeadbeef");
+    const withPrefixUpper = hexToBytes("0XDEADBEEF");
+
+    expect(Array.from(withoutPrefix)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+    expect(Array.from(withPrefixLower)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+    expect(Array.from(withPrefixUpper)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+  });
+
+  it("round-trips mixed-case hex case-insensitively and emits lowercase output", () => {
+    expect(bytesToHex(hexToBytes("a1B2c3"))).toBe("a1b2c3");
+    expect(bytesToHex(hexToBytes("0xA1B2C3D4"))).toBe("a1b2c3d4");
+  });
+
+  it("throws error for odd-length hex strings", () => {
+    expect(() => hexToBytes("123")).toThrow("invalid hex string (odd length)");
+    expect(() => hexToBytes("0x12345")).toThrow("invalid hex string (odd length)");
+  });
+
+  it("throws error for invalid hex characters naming offending character", () => {
+    expect(() => hexToBytes("gggg")).toThrow('invalid hex character: "g"');
+    expect(() => hexToBytes("0xzz")).toThrow('invalid hex character: "z"');
+    expect(() => hexToBytes("12g4")).toThrow('invalid hex character: "g"');
+    expect(() => hexToBytes("0x1234xy")).toThrow('invalid hex character: "x"');
+  });
+
+  it("handles byte boundary values from 00 to ff", () => {
+    const allHex = "007f80ff";
+    const bytes = hexToBytes(allHex);
+    expect(Array.from(bytes)).toEqual([0x00, 0x7f, 0x80, 0xff]);
+    expect(bytesToHex(bytes)).toBe(allHex);
+  });
+});
+
+describe("bytes32ToScVal", () => {
+  it("builds BytesN<32> ScVal for valid 32-byte hex string or buffer", () => {
+    const hex32 = "ab".repeat(32);
+    const scValFromHex = bytes32ToScVal(hex32);
+    expect(scValFromHex).toBeDefined();
+    expect(scValToString(scValFromHex)).toBe("ab".repeat(32));
+
+    const bytes32 = new Uint8Array(32).fill(0xcd);
+    const scValFromBytes = bytes32ToScVal(bytes32);
+    expect(scValFromBytes).toBeDefined();
+    expect(scValToString(scValFromBytes)).toBe("cd".repeat(32));
+  });
+
+  it("throws error if byte buffer length is not exactly 32 bytes", () => {
+    expect(() => bytes32ToScVal("00".repeat(31))).toThrow(
+      "order_id must be exactly 32 bytes (got 31)"
+    );
+    expect(() => bytes32ToScVal("00".repeat(33))).toThrow(
+      "order_id must be exactly 32 bytes (got 33)"
+    );
+  });
+
+  it("throws error when given a 64-character non-hex string instead of producing zero bytes", () => {
+    const invalid64 = "g".repeat(64);
+    expect(() => bytes32ToScVal(invalid64)).toThrow('invalid hex character: "g"');
+  });
+});
+
+describe("scval helpers", () => {
+  it("constructs and converts i128 values correctly", () => {
+    const value = 12345678901234567890n;
+    const scVal = i128ToScVal(value);
+    expect(scValToString(scVal)).toBe("12345678901234567890");
+    expect(scValToNativeSafe(scVal)).toBe(value);
+  });
+
+  it("constructs and converts symbols correctly", () => {
+    const scVal = symbolToScVal("USDC");
+    expect(scValToString(scVal)).toBe("USDC");
+  });
+
+  it("constructs address ScVal correctly", () => {
+    const testAddress = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+    const scVal = addressToScVal(testAddress);
+    expect(scVal).toBeDefined();
+  });
+
+  it("hashes orderId with SHA-256 to 32 bytes", async () => {
+    const digest = await hashOrderId("order_test_123");
+    expect(digest).toBeInstanceOf(Uint8Array);
+    expect(digest.length).toBe(32);
+  });
+});


### PR DESCRIPTION
Resolves #8

### Summary
- Validates each two-character chunk in `hexToBytes` against valid hexadecimal characters (`/[^0-9a-fA-F]/`).
- Throws a descriptive `Error` naming the invalid character when malformed input (e.g. `"gggg"`, `"0xzz"`) is passed instead of returning zero bytes via `NaN` coercion.
- Preserves existing odd-length check, `0x`/`0X` prefix stripping, and lowercase output formatting in `bytesToHex`.
- Adds comprehensive Vitest unit tests in `tests/lib/stellar/scval.test.ts` covering valid round-trips, empty string handling, odd lengths, invalid hex characters, and `bytes32ToScVal` 32-byte guard.

### Acceptance Criteria Checklist
- [x] `hexToBytes("gggg")` and `hexToBytes("0xzz")` throw an `Error` naming the offending character instead of returning zero bytes.
- [x] A 64-character non-hex string passed to `bytes32ToScVal` throws rather than silently producing a 32-byte zero buffer.
- [x] Round-trip parses case-insensitively and emits lowercase output: `bytesToHex(hexToBytes("a1B2c3")) === "a1b2c3"`.
- [x] Empty string returns an empty `Uint8Array`; odd-length input still throws `"invalid hex string (odd length)"`.
- [x] Valid-hex behaviour is unchanged and `npm run test`, `npm run lint`, `npm run type-check`, and `npm run build` pass locally.

## Payout Routing
- **EVM (Base/Arbitrum/Polygon/ETH):** `0xF46C9F6d70C50BF81ef3588AB523a90a594a2F89`
- **Stellar:** `GCL6OXAMLD75BMTINA6EMRUDWK5THQUSHMYNLSNBCJAPZJHNYJTUNIBC`
