### PR TITLE
docs: fix stale wasm32-unknown-unknown target in deployment and troubleshooting docs (#48)

### DIFF
--- a/docs/MAINNET_DEPLOYMENT.md
+++ b/docs/MAINNET_DEPLOYMENT.md
@@ -50,7 +50,7 @@ cd contracts/checkout
 stellar contract build
 
 # The optimized wasm is at:
-# target/wasm32-unknown-unknown/release/movastore_checkout.wasm
+# target/wasm32v1-none/release/movastore_checkout.wasm
 ```
 
 ### Verify the Build
@@ -60,14 +60,14 @@ stellar contract build
 cargo test
 
 # Check the wasm size (should be under 64KB)
-ls -la target/wasm32-unknown-unknown/release/movastore_checkout.wasm
+ls -la target/wasm32v1-none/release/movastore_checkout.wasm
 ```
 
 ## Step 3: Deploy to Mainnet
 
 ```bash
 stellar contract deploy \
-  --wasm target/wasm32-unknown-unknown/release/movastore_checkout.wasm \
+  --wasm target/wasm32v1-none/release/movastore_checkout.wasm \
   --source-account merchant-mainnet \
   --network mainnet
 ```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -198,7 +198,7 @@ Common issues and solutions for Mova Store development and production.
 **Solutions:**
 1. Install wasm target:
    ```bash
-   rustup target add wasm32-unknown-unknown
+   rustup target add wasm32v1-none
    ```
 2. Update Rust:
    ```bash
@@ -208,7 +208,7 @@ Common issues and solutions for Mova Store development and production.
    ```bash
    cd contracts/checkout
    cargo clean
-   cargo build --target wasm32-unknown-unknown --release
+   cargo build --target wasm32v1-none --release
    ```
 
 ### Deploy fails with "account not found"


### PR DESCRIPTION
Closes #48

### Proposed Changes
- Update `docs/TROUBLESHOOTING.md` target installation and build command to `wasm32v1-none`
- Update `docs/MAINNET_DEPLOYMENT.md` target path comments and deploy argument to `target/wasm32v1-none/release/movastore_checkout.wasm`
- Ensures documentation is completely consistent with CI, deploy scripts, and contracts README.

### Verification
- `grep -rn 'wasm32-unknown-unknown' docs/` returns 0 matches
- Artifact paths match `scripts/deploy-testnet.sh` and `contracts/checkout/README.md`
- `npm run type-check` and `npm run test` pass