### PR TITLE
docs: fix dead Paying with USDC anchors in README and CONTRIBUTING (#46)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,7 +218,7 @@ npm run build        # Production build must succeed
 
 If your PR touches the Stellar payment flow, describe in the PR how you tested
 it against testnet (Freighter + USDC faucet account). Follow the flow in the
-root [README](README.md#paying-with-usdc-testnet).
+root [README](README.md#paying-with-stellar-testnet).
 
 ## Commit Message Style
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ buyer ──pay──▶ contract (escrow) ──dispatch──▶ merchant
   - [Step 5 — Initialize with your merchant wallet](#step-5--initialize-with-your-merchant-wallet)
   - [Step 6 — Wire the deployed contract to the storefront](#step-6--wire-the-deployed-contract-to-the-storefront)
   - [Convenience script](#convenience-script)
-- [Paying with USDC (testnet)](#paying-with-usdc-testnet)
+- [Paying with Stellar (testnet)](#paying-with-stellar-testnet)
 - [Environment Variables Reference](#environment-variables-reference)
 - [Security Notes](#security-notes)
 - [Contributing](#contributing)


### PR DESCRIPTION
Closes #46

### Proposed Changes
- Rename the TOC entry in `README.md` to `[Paying with Stellar (testnet)](#paying-with-stellar-testnet)` matching the actual `## Paying with Stellar (testnet)` heading
- Update the cross-reference link in `CONTRIBUTING.md` to point to `README.md#paying-with-stellar-testnet`

### Verification
- `grep -rn 'paying-with-usdc-testnet' .` returns 0 matches
- All anchor links now resolve properly to existing headings in rendered markdown