### PR TITLE
docs: remove duplicated garbled sentence in environment setup (#59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,6 @@ Copy the template and fill in your values:
 cp .env.local.example .env.local
 ```
 
-A minimal Stellar-only configuration (the rest of the app runs with the existing
 A minimal Stellar-only configuration (fill Supabase values for auth/catalog):
 
 ```bash


### PR DESCRIPTION
Closes #59

### Proposed Changes
- Remove the duplicated/truncated sentence fragment between the `cp` code fence and the environment snippet in `README.md`

### Verification
- `grep 'minimal Stellar-only configuration' README.md` returns exactly one line
- Text flows grammatically and cleanly into the code block