### PR TITLE
[Bounty: $55] Remove unused placeholder fs dependency from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@stellar/stellar-sdk": "^16.2.0",
         "@supabase/supabase-js": "^2.112.3",
         "@vercel/og": "^0.6.2",
-        "fs": "^0.0.1-security",
         "next": "14.2.5",
         "next-auth": "^4.24.7",
         "nextjs-toploader": "^1.6.12",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@stellar/stellar-sdk": "^16.2.0",
     "@supabase/supabase-js": "^2.112.3",
     "@vercel/og": "^0.6.2",
-    "fs": "^0.0.1-security",
     "next": "14.2.5",
     "next-auth": "^4.24.7",
     "nextjs-toploader": "^1.6.12",


### PR DESCRIPTION
Removes the unused `fs@^0.0.1-security` npm placeholder from `package.json` dependencies and drops the matching top-level entry in `package-lock.json`.

This package is the registry's empty security-holding stub for Node's built-in `fs`. A source search finds no `from 'fs'` or `require('fs')` imports, so it is dead weight that confuses contributors and audit scanners.

Fixes #16
patch_sha256=1473f8b46f5b2770ad33bceceffa35e857082ce3d56dd97b5ea10f67a819c169