### PR TITLE
fix(deps): remove stale @types/next devDependency (#56)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
         "@testing-library/react": "^14.2.0",
-        "@types/next": "^9.0.0",
         "@types/node": "^20.19.0",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -2613,16 +2612,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
-    },
-    "node_modules/@types/next": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@types/next/-/next-9.0.0.tgz",
-      "integrity": "sha512-gnBXM8rP1mnCgT1uE2z8SnpFTKRWReJlhbZLZkOLq/CH1ifvTNwjIVtXvsywTy1dwVklf+y/MB0Eh6FOa94yrg==",
-      "deprecated": "This is a stub types definition. next provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "next": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "20.19.43",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",
     "@testing-library/react": "^14.2.0",
-    "@types/next": "^9.0.0",
     "@types/node": "^20.19.0",
     "@types/react": "^18",
     "@types/react-dom": "^18",


### PR DESCRIPTION
### Summary
Removes the legacy and deprecated `@types/next` v9 devDependency from `package.json` and regenerates `package-lock.json`. Next.js 14 ships its own first-party TypeScript definitions and does not require `@types/next`.

- Resolves #56
- `grep @types/next package.json package-lock.json` returns no matches
- `package-lock.json` diff contains strictly the `@types/next` subtree removal