### PR TITLE
ci: add concurrency group with cancel-in-progress (#54)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, develop]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   NODE_VERSION: "20"
   RUST_VERSION: "1.91.0"


### PR DESCRIPTION
### Summary
Adds a top-level `concurrency` group configured with `${{ github.workflow }}-${{ github.ref }}` and `cancel-in-progress: true` to `.github/workflows/ci.yml`. This automatically cancels superseded runs on the same branch or PR ref when new commits are pushed, saving runner minutes and preventing race conditions.

- Resolves #54
- Tested YAML syntax validity