### PR TITLE
fix(newsletter): validate email input and clear state after submit (#74)

### DIFF
--- a/app/(landingpage)/newsletter.jsx
+++ b/app/(landingpage)/newsletter.jsx
@@ -1,5 +1,6 @@
 import Toast from "../../components/Toast";
 import { useState } from "react";
+import { validateEmail } from "../../lib/validation";
 
 export default function Newsletter() {
   const [toast, setToast] = useState({ show: false, message: "" });
@@ -11,11 +12,14 @@ export default function Newsletter() {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (email.length !== 0) {
-      showToast("Thank you for subscribing!");
-    } else {
-      showToast("Please enter your email!");
+    const result = validateEmail(email);
+    if (!result.isValid) {
+      showToast(result.error || "Please enter a valid email address");
+      return;
     }
+
+    showToast("Thank you for subscribing!");
+    setEmail("");
     e.target.reset();
   };
 
@@ -25,18 +29,15 @@ export default function Newsletter() {
         Stay in the Loop
       </h2>
       <p className="text-lg sm:text-xl text-gray-600 mb-8 text-center max-w-xl">
-        New shoe drops, Stellar integration updates, and insights on crypto
-        commerce — straight to your inbox. No spam, unsubscribe anytime.
+        New shoe drops, Stellar integration updates, and insights on crypto commerce — straight to
+        your inbox. No spam, unsubscribe anytime.
       </p>
-      <form
-        className="w-full max-w-md"
-        onSubmit={handleSubmit}
-        noValidate={true}
-      >
+      <form className="w-full max-w-md" onSubmit={handleSubmit}>
         <div className="flex items-center border-b border-purple-700 py-2">
           <input
             type="email"
             name="email"
+            value={email}
             className="appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none"
             placeholder="Enter your email"
             aria-label="Email"


### PR DESCRIPTION
### Summary
Fixes the newsletter subscription form in `app/(landingpage)/newsletter.jsx`:
1. Uses `validateEmail` from `lib/validation.ts` to ensure only valid email formats trigger a success toast.
2. Controlled input bound to `value={email}` and resets `email` state via `setEmail("")` upon successful submission.
3. Removed `noValidate={true}` so browser validation works alongside custom validation.
4. Consecutive submits with an empty input show the error toast instead of a false success.

- Resolves #74
- Formatted cleanly with Prettier