### PR TITLE
[Bounty: $90] Reconcile the divergent mainnet RPC defaults across code and docs

### DIFF
--- a/docs/MAINNET_DEPLOYMENT.md
+++ b/docs/MAINNET_DEPLOYMENT.md
@@ -150,7 +150,7 @@ Update your `.env.local` (or production environment variables):
 NEXT_PUBLIC_STELLAR_NETWORK=mainnet
 
 # Mainnet RPC endpoint (use a reliable provider)
-NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-rpc.mainnet.stellar.gateway.fm
+NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-rpc.stellar.org
 
 # Mainnet passphrase
 NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE=Public Global Stellar Network ; September 2015

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -54,7 +54,7 @@ const STELLAR_DEFAULTS = {
       "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
   },
   mainnet: {
-    rpcUrl: "https://soroban-rpc.mainnet.stellar.gateway.fm",
+    rpcUrl: "https://soroban-rpc.stellar.org",
     networkPassphrase: "Public Global Stellar Network ; September 2015",
     usdcContractId: "", // Must be configured for mainnet
     nativeAssetContractId: "", // Must be configured for mainnet

--- a/tests/lib/env.test.ts
+++ b/tests/lib/env.test.ts
@@ -60,3 +60,27 @@ describe("isProduction", () => {
     expect(isProduction()).toBe(false);
   });
 });
+
+describe("loadStellarConfig mainnet RPC default", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("matches config.ts and MAINNET_DEPLOYMENT.md when the env var is unset", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_NETWORK", "mainnet");
+    delete process.env.NEXT_PUBLIC_STELLAR_RPC_URL;
+
+    vi.resetModules();
+
+    const { loadStellarConfig } = await import("../../lib/env");
+    const { RPC_URL } = await import("../../lib/stellar/config");
+    const { readFileSync } = await import("node:fs");
+
+    expect(loadStellarConfig().rpcUrl).toBe(RPC_URL);
+    expect(RPC_URL).toBe("https://soroban-rpc.stellar.org");
+
+    const doc = readFileSync("docs/MAINNET_DEPLOYMENT.md", "utf8");
+    expect(doc).toContain(`NEXT_PUBLIC_STELLAR_RPC_URL=${RPC_URL}`);
+  });
+});


### PR DESCRIPTION
Reconcile the two mainnet Soroban RPC defaults so unset `NEXT_PUBLIC_STELLAR_RPC_URL` resolves to one canonical endpoint.

## Problem
`lib/stellar/config.ts` fell back to `https://soroban-rpc.stellar.org` on mainnet, while `lib/env.ts` (`loadStellarConfig` / `STELLAR_DEFAULTS`) and `docs/MAINNET_DEPLOYMENT.md` Step 6 used `https://soroban-rpc.mainnet.stellar.gateway.fm`.

## Change
Keep the official SDF endpoint already used by `config.ts` and point `STELLAR_DEFAULTS.mainnet.rpcUrl` plus the deployment guide at the same URL.

## Tests
Add a Vitest regression that stubs `NEXT_PUBLIC_STELLAR_NETWORK=mainnet`, clears `NEXT_PUBLIC_STELLAR_RPC_URL`, reloads both modules, and asserts `loadStellarConfig().rpcUrl` equals `RPC_URL` and that `docs/MAINNET_DEPLOYMENT.md` documents that same value.

Fixes #108
patch_sha256=13f242d6727e897651e564cf3287067f494bd829dbd8b2256b1a45434cceab3e