### PR TITLE
test(stellar): add token-registry unit tests for lib/stellar/config.ts

### DIFF
--- a/tests/lib/stellar/config.test.ts
+++ b/tests/lib/stellar/config.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as config from "../../../lib/stellar/config";
+
+describe("Stellar Configuration Module", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  // Test Case 1: Default Token Configuration
+  it("should return the first supported token configuration as the default token", () => {
+    const defaultToken = config.defaultToken();
+
+    // Assert that defaultToken() is strictly equal to SUPPORTED_TOKENS[0]
+    expect(defaultToken).toBe(config.SUPPORTED_TOKENS[0]);
+    expect(typeof defaultToken).toBe("object");
+    expect(defaultToken).not.toBeNull();
+  });
+
+  // Test Case 2: Decimal Verification for Specific Tokens
+  it("should assert that USDC and XLM tokens declare 7 decimals", () => {
+    const usdcConfig = config.tokenForContract(config.USDC_CONTRACT_ID);
+    const xlmConfig = config.tokenForContract(config.NATIVE_ASSET_CONTRACT_ID);
+
+    expect(usdcConfig).toBeDefined();
+    expect(usdcConfig?.decimals).toBe(7);
+
+    expect(xlmConfig).toBeDefined();
+    expect(xlmConfig?.decimals).toBe(7);
+  });
+
+  // Test Case 3: Token Resolution Functionality
+  it("should correctly resolve token configurations by contract ID", () => {
+    // Test USDC resolution
+    const usdcResolved = config.tokenForContract(config.USDC_CONTRACT_ID);
+    expect(usdcResolved?.symbol).toBe("USDC");
+    expect(usdcResolved?.contractId).toBe(config.USDC_CONTRACT_ID);
+
+    // Test XLM resolution
+    const xlmResolved = config.tokenForContract(config.NATIVE_ASSET_CONTRACT_ID);
+    expect(xlmResolved?.symbol).toBe("XLM");
+    expect(xlmResolved?.contractId).toBe(config.NATIVE_ASSET_CONTRACT_ID);
+  });
+
+  it("should return undefined when tokenForContract receives an unknown contract ID", () => {
+    const unknownId = "unknown_contract_id";
+    const result = config.tokenForContract(unknownId);
+    expect(result).toBeUndefined();
+  });
+
+  // Test Case 4: Native Asset Identification
+  it("should correctly identify the native asset (XLM) as having isNative set to true", () => {
+    const xlmToken = config.SUPPORTED_TOKENS.find((t) => t.symbol === "XLM");
+
+    expect(xlmToken).toBeDefined();
+    expect(xlmToken?.isNative).toBe(true);
+  });
+
+  // Test Case 5: Environment Variable Override and Dynamic Import
+  it("should dynamically load and reflect configuration changes when environment variables are overridden", async () => {
+    const newUsdcId = "0xNEW_USDC_CONTRACT_ID";
+    const newNativeId = "0xNEW_NATIVE_ASSET_CONTRACT_ID";
+
+    // 1. Stub the environment variables
+    vi.stubEnv("NEXT_PUBLIC_USDC_CONTRACT_ID", newUsdcId);
+    vi.stubEnv("NEXT_PUBLIC_NATIVE_ASSET_CONTRACT_ID", newNativeId);
+
+    // 2. Reset modules to force re-evaluation of the configuration file with new env vars
+    vi.resetModules();
+
+    // 3. Re-import the module to capture the new state
+    const dynamicConfig = await import("../../../lib/stellar/config");
+
+    // 4. Verify the configuration reflects the overrides
+    expect(dynamicConfig.USDC_CONTRACT_ID).toBe(newUsdcId);
+    expect(dynamicConfig.NATIVE_ASSET_CONTRACT_ID).toBe(newNativeId);
+
+    // 5. Verify tokenForContract reflects the new IDs
+    const resolvedUsdc = dynamicConfig.tokenForContract(newUsdcId);
+    expect(resolvedUsdc?.symbol).toBe("USDC");
+    expect(resolvedUsdc?.contractId).toBe(newUsdcId);
+
+    const resolvedXlm = dynamicConfig.tokenForContract(newNativeId);
+    expect(resolvedXlm?.symbol).toBe("XLM");
+    expect(resolvedXlm?.contractId).toBe(newNativeId);
+  });
+});

--- a/tests/lib/stellar/config.test.ts
+++ b/tests/lib/stellar/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as config from "../../../lib/stellar/config";
 
-describe("Stellar Configuration Module", () => {
+describe("lib/stellar/config", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -11,81 +11,70 @@ describe("Stellar Configuration Module", () => {
     vi.resetModules();
   });
 
-  // Test Case 1: Default Token Configuration
-  it("should return the first supported token configuration as the default token", () => {
-    const defaultToken = config.defaultToken();
-
-    // Assert that defaultToken() is strictly equal to SUPPORTED_TOKENS[0]
-    expect(defaultToken).toBe(config.SUPPORTED_TOKENS[0]);
-    expect(typeof defaultToken).toBe("object");
-    expect(defaultToken).not.toBeNull();
+  describe("defaultToken", () => {
+    it("returns SUPPORTED_TOKENS[0] and resolves to USDC with 7 decimals", () => {
+      const token = config.defaultToken();
+      expect(token).toBe(config.SUPPORTED_TOKENS[0]);
+      expect(token.symbol).toBe("USDC");
+      expect(token.decimals).toBe(7);
+    });
   });
 
-  // Test Case 2: Decimal Verification for Specific Tokens
-  it("should assert that USDC and XLM tokens declare 7 decimals", () => {
-    const usdcConfig = config.tokenForContract(config.USDC_CONTRACT_ID);
-    const xlmConfig = config.tokenForContract(config.NATIVE_ASSET_CONTRACT_ID);
+  describe("decimals and native asset flags", () => {
+    it("declares 7 decimals for both USDC and XLM", () => {
+      const usdc = config.tokenForContract(config.USDC_CONTRACT_ID);
+      const xlm = config.tokenForContract(config.NATIVE_ASSET_CONTRACT_ID);
 
-    expect(usdcConfig).toBeDefined();
-    expect(usdcConfig?.decimals).toBe(7);
+      expect(usdc?.decimals).toBe(7);
+      expect(xlm?.decimals).toBe(7);
+    });
 
-    expect(xlmConfig).toBeDefined();
-    expect(xlmConfig?.decimals).toBe(7);
+    it("identifies XLM as a native asset", () => {
+      const xlm = config.SUPPORTED_TOKENS.find((t) => t.symbol === "XLM");
+      expect(xlm?.isNative).toBe(true);
+    });
   });
 
-  // Test Case 3: Token Resolution Functionality
-  it("should correctly resolve token configurations by contract ID", () => {
-    // Test USDC resolution
-    const usdcResolved = config.tokenForContract(config.USDC_CONTRACT_ID);
-    expect(usdcResolved?.symbol).toBe("USDC");
-    expect(usdcResolved?.contractId).toBe(config.USDC_CONTRACT_ID);
+  describe("tokenForContract", () => {
+    it("resolves known contract ids", () => {
+      const usdc = config.tokenForContract(config.USDC_CONTRACT_ID);
+      expect(usdc?.symbol).toBe("USDC");
+      expect(usdc?.contractId).toBe(config.USDC_CONTRACT_ID);
 
-    // Test XLM resolution
-    const xlmResolved = config.tokenForContract(config.NATIVE_ASSET_CONTRACT_ID);
-    expect(xlmResolved?.symbol).toBe("XLM");
-    expect(xlmResolved?.contractId).toBe(config.NATIVE_ASSET_CONTRACT_ID);
+      const xlm = config.tokenForContract(config.NATIVE_ASSET_CONTRACT_ID);
+      expect(xlm?.symbol).toBe("XLM");
+      expect(xlm?.contractId).toBe(config.NATIVE_ASSET_CONTRACT_ID);
+    });
+
+    it("returns undefined for unknown contract ids", () => {
+      expect(config.tokenForContract("unknown_contract_id")).toBeUndefined();
+    });
   });
 
-  it("should return undefined when tokenForContract receives an unknown contract ID", () => {
-    const unknownId = "unknown_contract_id";
-    const result = config.tokenForContract(unknownId);
-    expect(result).toBeUndefined();
-  });
+  describe("environment overrides", () => {
+    it("updates registry when contract ids are overridden via env", async () => {
+      const customUsdc = "CCUSTOMUSDCCONTRACTID1234567890";
+      const customNative = "CCUSTOMNATIVECONTRACTID1234567890";
 
-  // Test Case 4: Native Asset Identification
-  it("should correctly identify the native asset (XLM) as having isNative set to true", () => {
-    const xlmToken = config.SUPPORTED_TOKENS.find((t) => t.symbol === "XLM");
+      vi.stubEnv("NEXT_PUBLIC_USDC_CONTRACT_ID", customUsdc);
+      vi.stubEnv("NEXT_PUBLIC_NATIVE_ASSET_CONTRACT_ID", customNative);
+      vi.resetModules();
 
-    expect(xlmToken).toBeDefined();
-    expect(xlmToken?.isNative).toBe(true);
-  });
+      const reloadedConfig = await import("../../../lib/stellar/config");
 
-  // Test Case 5: Environment Variable Override and Dynamic Import
-  it("should dynamically load and reflect configuration changes when environment variables are overridden", async () => {
-    const newUsdcId = "0xNEW_USDC_CONTRACT_ID";
-    const newNativeId = "0xNEW_NATIVE_ASSET_CONTRACT_ID";
+      expect(reloadedConfig.USDC_CONTRACT_ID).toBe(customUsdc);
+      expect(reloadedConfig.NATIVE_ASSET_CONTRACT_ID).toBe(customNative);
 
-    // 1. Stub the environment variables
-    vi.stubEnv("NEXT_PUBLIC_USDC_CONTRACT_ID", newUsdcId);
-    vi.stubEnv("NEXT_PUBLIC_NATIVE_ASSET_CONTRACT_ID", newNativeId);
+      expect(reloadedConfig.SUPPORTED_TOKENS[0].contractId).toBe(customUsdc);
+      expect(reloadedConfig.SUPPORTED_TOKENS[1].contractId).toBe(customNative);
 
-    // 2. Reset modules to force re-evaluation of the configuration file with new env vars
-    vi.resetModules();
+      const resolvedUsdc = reloadedConfig.tokenForContract(customUsdc);
+      expect(resolvedUsdc?.symbol).toBe("USDC");
+      expect(resolvedUsdc?.contractId).toBe(customUsdc);
 
-    // 3. Re-import the module to capture the new state
-    const dynamicConfig = await import("../../../lib/stellar/config");
-
-    // 4. Verify the configuration reflects the overrides
-    expect(dynamicConfig.USDC_CONTRACT_ID).toBe(newUsdcId);
-    expect(dynamicConfig.NATIVE_ASSET_CONTRACT_ID).toBe(newNativeId);
-
-    // 5. Verify tokenForContract reflects the new IDs
-    const resolvedUsdc = dynamicConfig.tokenForContract(newUsdcId);
-    expect(resolvedUsdc?.symbol).toBe("USDC");
-    expect(resolvedUsdc?.contractId).toBe(newUsdcId);
-
-    const resolvedXlm = dynamicConfig.tokenForContract(newNativeId);
-    expect(resolvedXlm?.symbol).toBe("XLM");
-    expect(resolvedXlm?.contractId).toBe(newNativeId);
+      const resolvedXlm = reloadedConfig.tokenForContract(customNative);
+      expect(resolvedXlm?.symbol).toBe("XLM");
+      expect(resolvedXlm?.contractId).toBe(customNative);
+    });
   });
 });


### PR DESCRIPTION
Resolves #86

### Summary
Adds comprehensive unit tests for the token registry in `lib/stellar/config.ts` covering:
- Default token validation (`defaultToken() === SUPPORTED_TOKENS[0]`).
- Decimal accuracy (7 decimals for both USDC and XLM SAC configurations).
- Contract resolution via `tokenForContract` for USDC and XLM, returning `undefined` for unknown contract IDs.
- Native asset identification (`XLM` has `isNative: true`).
- Dynamic environment overrides under `vi.stubEnv` + `vi.resetModules()` testing both `NEXT_PUBLIC_USDC_CONTRACT_ID` and `NEXT_PUBLIC_NATIVE_ASSET_CONTRACT_ID`.
- Strict test isolation with `afterEach(() => { vi.unstubAllEnvs(); vi.resetModules(); })`.

### Verification
- `npm run test` passes (42/42 tests passing across all suites).
- `npx tsc --noEmit --skipLibCheck` passes with 0 errors.
- Prettier code style checks pass.

Payout address (Base L2 USDC): `0x46D5318E4397cFcBED06a235c1604E473682Ea1F`