### PR TITLE
fix(wallet): import connectWallet in StellarWalletButton to fix ReferenceError (#22)

### DIFF
--- a/components/StellarWalletButton.jsx
+++ b/components/StellarWalletButton.jsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from "react";
 
-import { currentAddress, freighterAvailable, WalletError } from "../lib/stellar/freighter";
-import { shortAddress } from "../lib/stellar/freighter";
+import {
+  connectWallet,
+  currentAddress,
+  freighterAvailable,
+  WalletError,
+  shortAddress,
+} from "../lib/stellar/freighter";
 
 /**
  * Connect / disconnect a Freighter wallet and show the connected address.


### PR DESCRIPTION
### Summary of Changes

Fixes #22

- Added the missing `connectWallet` named import from `../lib/stellar/freighter` in `components/StellarWalletButton.jsx`.
- Resolves the runtime `ReferenceError: connectWallet is not defined` triggered when clicking the "Connect Freighter" button in `/admin/orders` and other pages.

### Validation
- `npm run test` passed (36/36 unit tests).
- `npm run type-check` passed.
- `next lint` ran and verified syntax/imports for `components/StellarWalletButton.jsx`.
