### PR TITLE
fix(stellar): remove Node Buffer globals in client-side lib/stellar modules (#18)

### DIFF
--- a/lib/stellar/events.ts
+++ b/lib/stellar/events.ts
@@ -80,10 +80,9 @@ export function decodePaymentEvent(
       ledger: tx.ledger,
     };
     try {
-      if (event.contractId()) {
-        receipt.contractId = StrKey.encodeContract(
-          Buffer.from(event.contractId() as unknown as Uint8Array)
-        );
+      const contractId = event.contractId();
+      if (contractId) {
+        receipt.contractId = StrKey.encodeContract(contractId as unknown as any);
       }
     } catch {
       // system events have no contract id

--- a/lib/stellar/orders.ts
+++ b/lib/stellar/orders.ts
@@ -25,7 +25,7 @@ import {
   tokenForContract,
 } from "./config";
 import { connectWallet, signWithFreighter } from "./freighter";
-import { hashOrderId, bytesToHex } from "./scval";
+import { hashOrderId, bytesToHex, hexToBytes } from "./scval";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -107,7 +107,7 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
       .addOperation(
         contract.call(
           "order",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHash, "hex"))
+          xdr.ScVal.scvBytes(hexToBytes(orderIdHash) as unknown as any)
         )
       )
       .setTimeout(30)
@@ -170,9 +170,10 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
             break;
           case "token":
             if (val.switch() === xdr.ScValType.scvAddress()) {
-              order.token = StrKey.encodeContract(
-                Buffer.from(val.address().contractId() as unknown as Uint8Array)
-              );
+              const contractId = val.address().contractId();
+              if (contractId) {
+                order.token = StrKey.encodeContract(contractId as unknown as any);
+              }
             }
             break;
           case "timestamp":
@@ -230,7 +231,7 @@ export async function dispatchOrder(
       .addOperation(
         contract.call(
           "dispatch",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHashBytes))
+          xdr.ScVal.scvBytes(orderIdHashBytes as unknown as any)
         )
       )
       .setTimeout(TX_TIMEOUT_SECONDS)
@@ -311,7 +312,7 @@ export async function refundOrder(orderId: string): Promise<OrderActionResult> {
       .addOperation(
         contract.call(
           "refund",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHashBytes))
+          xdr.ScVal.scvBytes(orderIdHashBytes as unknown as any)
         )
       )
       .setTimeout(TX_TIMEOUT_SECONDS)

--- a/lib/stellar/scval.ts
+++ b/lib/stellar/scval.ts
@@ -22,12 +22,11 @@ export function i128ToScVal(value: bigint | number | string): xdr.ScVal {
  * Build a BytesN<32> ScVal from a Uint8Array (or hex string).
  */
 export function bytes32ToScVal(bytes: Uint8Array | string): xdr.ScVal {
-  const buf =
-    typeof bytes === "string" ? Buffer.from(hexToBytes(bytes)) : Buffer.from(bytes);
-  if (buf.length !== 32) {
-    throw new Error(`order_id must be exactly 32 bytes (got ${buf.length})`);
+  const arr = typeof bytes === "string" ? hexToBytes(bytes) : bytes;
+  if (arr.length !== 32) {
+    throw new Error(`order_id must be exactly 32 bytes (got ${arr.length})`);
   }
-  return xdr.ScVal.scvBytes(buf);
+  return xdr.ScVal.scvBytes(arr as unknown as any);
 }
 
 /**

--- a/tests/lib/scval.test.ts
+++ b/tests/lib/scval.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { bytes32ToScVal, hexToBytes } from "../../lib/stellar/scval";
+import { xdr } from "@stellar/stellar-sdk";
+
+describe("bytes32ToScVal Uint8Array vs hex equivalence without Buffer global", () => {
+  it("produces byte-identical XDR for hex string and Uint8Array", () => {
+    const hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const bytes = hexToBytes(hex);
+
+    const scValFromHex = bytes32ToScVal(hex);
+    const scValFromBytes = bytes32ToScVal(bytes);
+
+    const xdrHex = scValFromHex.toXDR("base64");
+    const xdrBytes = scValFromBytes.toXDR("base64");
+
+    expect(xdrHex).toBe(xdrBytes);
+    expect(scValFromHex.switch()).toBe(xdr.ScValType.scvBytes());
+    expect(scValFromHex.bytes().length).toBe(32);
+  });
+
+  it("throws error for invalid byte lengths", () => {
+    expect(() => bytes32ToScVal("0123")).toThrow("order_id must be exactly 32 bytes");
+    expect(() => bytes32ToScVal(new Uint8Array(10))).toThrow("order_id must be exactly 32 bytes");
+  });
+});


### PR DESCRIPTION
### Summary of Changes

Fixes #18

- Removed Node `Buffer` global dependencies across `lib/stellar/scval.ts`, `lib/stellar/events.ts`, and `lib/stellar/orders.ts`.
- Switched to direct `Uint8Array` handling and `hexToBytes` conversions so client-side browser bundles do not fail when Node `Buffer` is undefined.
- Added unit test in `tests/lib/scval.test.ts` asserting that `bytes32ToScVal` produces byte-identical XDR when passed a hex string vs a `Uint8Array`.
- Verified that `grep -rn "Buffer" lib/stellar/` produces 0 matches.

### Validation
- `npm run test` passed (38/38 tests).
- `npm run type-check` passed with 0 errors.
