### PR TITLE
docs: add Step 5b whitelist tokens to deployment TOC (#116)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ buyer ──pay──▶ contract (escrow) ──dispatch──▶ merchant
   - [Step 3 — Set up a testnet identity](#step-3--set-up-a-testnet-identity)
   - [Step 4 — Deploy to testnet](#step-4--deploy-to-testnet)
   - [Step 5 — Initialize with your merchant wallet](#step-5--initialize-with-your-merchant-wallet)
+  - [Step 5b — Whitelist the tokens you accept](#step-5b--whitelist-the-tokens-you-accept)
   - [Step 6 — Wire the deployed contract to the storefront](#step-6--wire-the-deployed-contract-to-the-storefront)
   - [Convenience script](#convenience-script)
 - [Paying with USDC (testnet)](#paying-with-usdc-testnet)


### PR DESCRIPTION
## Summary
Fixes #116

Adds the missing `Step 5b — Whitelist the tokens you accept` section heading to the deployment Table of Contents in `README.md`.

## Changes
- Inserted `Step 5b — Whitelist the tokens you accept` TOC entry between Step 5 and Step 6.
- The link anchor correctly targets `#step-5b--whitelist-the-tokens-you-accept`.

## Verification
- TOC entries now match all section headings under Smart Contract Deployment (Testnet).
- Anchor correctly resolves to the generated heading slug.
