### PR TITLE
docs: replace yourusername placeholder issues URL in troubleshooting guide (#114)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -279,7 +279,7 @@ Common issues and solutions for Mova Store development and production.
 
 If you can't resolve an issue:
 
-1. **Search existing issues:** [GitHub Issues](https://github.com/yourusername/mova-store/issues)
+1. **Search existing issues:** [GitHub Issues](https://github.com/Movalabs-crew/mova-store/issues)
 2. **Check Stellar docs:** [developers.stellar.org](https://developers.stellar.org)
 3. **Ask in Discord:** [Stellar Discord](https://discord.gg/stellar)
 4. **Open a new issue** with:


### PR DESCRIPTION
## Summary
Fixes #114

Replaces the unreplaced `yourusername` placeholder issues URL in `docs/TROUBLESHOOTING.md` with the official repository URL (`https://github.com/Movalabs-crew/mova-store/issues`).

## Changes
- Updated the 'Search existing issues' link in `docs/TROUBLESHOOTING.md` to point to `https://github.com/Movalabs-crew/mova-store/issues`.

## Verification
- Verified no other `yourusername` placeholders exist in `docs/` or `README.md`.
