### PR TITLE
fix: import connectWallet in StellarWalletButton to fix ReferenceError

### DIFF
--- a/components/StellarWalletButton.jsx
+++ b/components/StellarWalletButton.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { currentAddress, freighterAvailable, WalletError } from "../lib/stellar/freighter";
+import { connectWallet, currentAddress, freighterAvailable, WalletError } from "../lib/stellar/freighter";
 import { shortAddress } from "../lib/stellar/freighter";
 
 /**

--- a/tests/components/StellarWalletButton.test.jsx
+++ b/tests/components/StellarWalletButton.test.jsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent, cleanup } from "@testing-library/react";
+import React from "react";
+
+// 64-char Stellar-style test address (G + 63 base32 chars)
+const TEST_ADDRESS =
+  "GB7XKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2";
+
+vi.mock("@stellar/freighter-api", () => ({
+  isConnected: vi.fn(),
+  requestAccess: vi.fn(),
+  getAddress: vi.fn(),
+  getNetwork: vi.fn(),
+  signTransaction: vi.fn(),
+}));
+
+// Import after the mock is declared.
+import { isConnected, requestAccess, getAddress } from "@stellar/freighter-api";
+import StellarWalletButton from "../../components/StellarWalletButton";
+
+describe("StellarWalletButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Freighter extension is present; not yet connected, so the button shows.
+    // currentAddress() returns null (getAddress -> null), so no auto-connect on mount.
+    isConnected.mockResolvedValue({ isConnected: true });
+    getAddress.mockResolvedValue({ address: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("connects on click instead of throwing ReferenceError for connectWallet", async () => {
+    requestAccess.mockResolvedValue({ address: TEST_ADDRESS });
+    const onConnect = vi.fn();
+    render(<StellarWalletButton onConnect={onConnect} />);
+
+    const button = screen.getByRole("button", { name: /connect freighter/i });
+    // Regression: before the connectWallet import was added, this click
+    // threw "ReferenceError: connectWallet is not defined" and requestAccess
+    // was never reached.
+    await fireEvent.click(button);
+
+    await waitFor(() => expect(requestAccess).toHaveBeenCalledTimes(1));
+    expect(onConnect).toHaveBeenCalledWith(TEST_ADDRESS);
+
+    // After a successful connect the button is replaced by the short address.
+    await waitFor(() =>
+      expect(screen.getByText(new RegExp(TEST_ADDRESS.slice(0, 6)))).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByRole("button", { name: /connect freighter/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the wallet error message when requestAccess is denied", async () => {
+    requestAccess.mockResolvedValue({ error: new Error("User denied") });
+    render(<StellarWalletButton />);
+
+    const button = screen.getByRole("button", { name: /connect freighter/i });
+    await fireEvent.click(button);
+
+    await waitFor(() => expect(screen.getByText(/user denied/i)).toBeInTheDocument());
+    // Still in the not-connected state.
+    expect(
+      screen.getByRole("button", { name: /connect freighter/i })
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #22

## Problem

`components/StellarWalletButton.jsx` imported `currentAddress`, `freighterAvailable`, `WalletError` and `shortAddress` from `lib/stellar/freighter` — but not `connectWallet`, even though `handleConnect` calls `connectWallet()` on click. Clicking **Connect Freighter** on `/checkout` or `/admin/orders` therefore threw `ReferenceError: connectWallet is not defined` and the wallet could never connect. The sibling `StellarCheckoutButton` imports `connectWallet` from the same module, which is what the button was missing.

## Change

- `components/StellarWalletButton.jsx`: add `connectWallet` to the existing `lib/stellar/freighter` import (1 line).
- `tests/components/StellarWalletButton.test.jsx` (new): regression tests with `@stellar/freighter-api` mocked at the module level so the real `connectWallet()` logic is exercised:
  - clicking **Connect Freighter** calls `requestAccess`, connects, invokes `onConnect(address)`, and swaps the button for the short address (this is the exact path that threw the ReferenceError before the fix);
  - a denied `requestAccess` surfaces the wallet error message and stays in the not-connected state.

## Verification

- `npm run test` - 38/38 pass (36 existing + 2 new)
- `npm run type-check` - passes
- `npm run lint` - passes (only pre-existing warnings in the repo)

## Acceptance criteria (#22)

- [x] Clicking 'Connect Freighter' invokes the wallet request instead of throwing a ReferenceError
- [x] After a successful connect the button shows the shortAddress and connected state
- [x] `next lint` passes for the file
