### PR TITLE
[Bounty: $90] Compare checkout OTP against a zero-padded 6-digit value instead of loose parseInt

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -21,6 +21,7 @@ import {
 import { BsBank, BsCalendarDate } from "react-icons/bs";
 import { SiKlarna } from "react-icons/si";
 import sendMail from "../../lib/sendmail";
+import { compareOTP, generateOTP } from "../../lib/validation";
 import StellarCheckoutButton from "../../components/StellarCheckoutButton";
 import StellarWalletButton from "../../components/StellarWalletButton";
 import StellarOrderWatch from "../../components/StellarOrderWatch";
@@ -28,7 +29,7 @@ import { SiStellar } from "react-icons/si";
 
 const Checkout = () => {
 
-  const [otp, setOtp] = useState(Math.floor(Math.random() * 1000000) + 1);
+  const [otp] = useState(() => generateOTP());
   const [totalPrice, setTotalPrice] = useState(0);
   const [toast, setToast] = useState({ show: false, message: "" });
   const [stage, setStage] = useState(1);
@@ -97,7 +98,7 @@ const Checkout = () => {
   const handleEmailConfirmationSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsOtpSending(true);
-    if (parseInt(enteredOtp) === otp) {
+    if (compareOTP(enteredOtp, otp)) {
       setStage(3);
       localStorage.clear();
       showToast("OTP confirmed successfully.");
@@ -366,6 +367,9 @@ const Checkout = () => {
                     onChange={handleOtpChange}
                     required
                     placeholder="OTP"
+                    maxLength={6}
+                    inputMode="numeric"
+                    autoComplete="one-time-code"
                     className="w-64 px-3 py-2 border rounded"
                   />
                 </div>

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -278,6 +278,30 @@ export function validateOTP(otp: string): ValidationResult {
   return { isValid: true, sanitized };
 }
 
+/**
+ * Generates a zero-padded 6-digit OTP in the range 000000–999999.
+ * Pass `value` to format a specific number (used by tests).
+ */
+export function generateOTP(
+  value = Math.floor(Math.random() * 1_000_000)
+): string {
+  const n = Math.floor(Math.abs(value)) % 1_000_000;
+  return n.toString().padStart(6, "0");
+}
+
+/**
+ * Compares entered OTP to a stored zero-padded 6-digit code.
+ * Trims and pads the input, requires validateOTP, and uses exact string equality
+ * so trailing junk (e.g. "123x", "123.4") cannot match.
+ */
+export function compareOTP(entered: string, expected: string): boolean {
+  const padded = entered.trim().padStart(6, "0");
+  const result = validateOTP(padded);
+  return Boolean(
+    result.isValid && result.sanitized === padded && padded === expected
+  );
+}
+
 // =============================================================================
 // STELLAR ADDRESS VALIDATION
 // =============================================================================

--- a/tests/lib/validation.test.ts
+++ b/tests/lib/validation.test.ts
@@ -4,6 +4,8 @@ import {
   validateName,
   validatePhone,
   validateOTP,
+  generateOTP,
+  compareOTP,
   validatePrice,
   validateStellarAddress,
   sanitizeText,
@@ -124,6 +126,41 @@ describe("validateOTP", () => {
     const result = validateOTP("12-34-56");
     expect(result.sanitized).toBe("123456");
     expect(result.isValid).toBe(true);
+  });
+});
+
+describe("generateOTP", () => {
+  it("returns a zero-padded 6-digit string", () => {
+    expect(generateOTP(42)).toBe("000042");
+    expect(generateOTP(0)).toBe("000000");
+    expect(generateOTP(999999)).toBe("999999");
+  });
+
+  it("always produces six digits when called without a value", () => {
+    expect(generateOTP()).toMatch(/^\d{6}$/);
+  });
+});
+
+describe("compareOTP", () => {
+  it("rejects a wrong numeric OTP", () => {
+    expect(compareOTP("000043", "000042")).toBe(false);
+    expect(compareOTP("123456", "000042")).toBe(false);
+  });
+
+  it("rejects digits followed by junk characters", () => {
+    expect(compareOTP("000042x", "000042")).toBe(false);
+    expect(compareOTP("123x", "000123")).toBe(false);
+    expect(compareOTP("123.4", "000123")).toBe(false);
+  });
+
+  it("accepts a correct zero-padded OTP such as 000042", () => {
+    expect(compareOTP("000042", "000042")).toBe(true);
+    expect(compareOTP(" 000042 ", "000042")).toBe(true);
+  });
+
+  it("rejects letters-only input", () => {
+    expect(compareOTP("abcdef", "000042")).toBe(false);
+    expect(compareOTP("OTP", "000042")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
Checkout verified email OTP with `parseInt(enteredOtp) === otp`, where `otp` was a number from `Math.floor(Math.random() * 1000000) + 1`. That allowed short codes, trailing junk (`123x`, `123.4`), and other loose numeric parses, and could produce a 7-digit value (`1000000`).

## Changes
- Generate OTP as a zero-padded 6-digit string (`000000`–`999999`) via `generateOTP`.
- Verify with `compareOTP`: trim, pad to 6 digits, `validateOTP`, and exact string equality (rejects junk and letters).
- OTP input: `maxLength={6}` and `inputMode="numeric"`.
- Unit tests for wrong numeric OTP, digits+junk, letters-only, and accepted `000042`.

Fixes https://github.com/Movalabs-crew/mova-store/issues/76
patch_sha256=41cc4e965cd36a77763d67cdaab3b43acd027c7ca3eb45437ec762bc9fb37f97