### PR TITLE
refactor(loading): reuse LoadingSpinner in root and shop route loading files (closes #111)

### DIFF
--- a/app/loading.jsx
+++ b/app/loading.jsx
@@ -1,12 +1,8 @@
 import React from "react";
+import LoadingSpinner from "@/components/LoadingSpinner";
+
 const loading = () => {
-  return (
-    <div className="flex items-center justify-center min-h-screen bg-white">
-      <div className="text-center">
-        <div className="loader border-t-4 border-purple-700 rounded-full w-16 h-16 mx-auto animate-spin"></div>
-      </div>
-    </div>
-  );
+  return <LoadingSpinner />;
 };
 
 export default loading;

--- a/app/shop/loading.jsx
+++ b/app/shop/loading.jsx
@@ -1,13 +1,8 @@
 import React from "react";
-// import LoadingSpinner from "../../components/LoadingSpinner";
+import LoadingSpinner from "@/components/LoadingSpinner";
+
 const loading = () => {
-  return (
-    <div className="flex items-center justify-center min-h-screen bg-white">
-      <div className="text-center">
-        <div className="loader border-t-4 border-purple-700 rounded-full w-16 h-16 mx-auto animate-spin"></div>
-      </div>
-    </div>
-  );
+  return <LoadingSpinner />;
 };
 
 export default loading;

--- a/tests/routes/loading.test.tsx
+++ b/tests/routes/loading.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import RootLoading from "@/app/loading";
+import ShopLoading from "@/app/shop/loading";
+
+describe("LoadingSpinner Component", () => {
+  it("renders the shared loader element with animation and border classes", () => {
+    const { container } = render(<LoadingSpinner />);
+    const spinner = container.querySelector(".loader");
+
+    expect(spinner).toBeInTheDocument();
+    expect(spinner).toHaveClass("loader");
+    expect(spinner).toHaveClass("animate-spin");
+    expect(spinner).toHaveClass("border-t-4");
+    expect(spinner).toHaveClass("border-purple-700");
+    expect(spinner).toHaveClass("rounded-full");
+    expect(spinner).toHaveClass("w-16");
+    expect(spinner).toHaveClass("h-16");
+  });
+});
+
+describe("Route Loading Files", () => {
+  it("app/loading.jsx renders the shared LoadingSpinner structure", () => {
+    const { container } = render(<RootLoading />);
+    const spinner = container.querySelector(".loader");
+
+    expect(spinner).toBeInTheDocument();
+    expect(spinner).toHaveClass("animate-spin");
+    expect(spinner).toHaveClass("border-t-4");
+    expect(spinner).toHaveClass("border-purple-700");
+  });
+
+  it("app/shop/loading.jsx renders the shared LoadingSpinner structure", () => {
+    const { container } = render(<ShopLoading />);
+    const spinner = container.querySelector(".loader");
+
+    expect(spinner).toBeInTheDocument();
+    expect(spinner).toHaveClass("animate-spin");
+    expect(spinner).toHaveClass("border-t-4");
+    expect(spinner).toHaveClass("border-purple-700");
+  });
+});


### PR DESCRIPTION
## Summary
Reuses the shared `<LoadingSpinner />` component across root (`app/loading.jsx`) and shop (`app/shop/loading.jsx`) route loading files, eliminating duplicated inline spinner markup and removing dead commented-out code.

Resolves #111

## Proposed Changes
1. **`app/loading.jsx`**:
   - Replaced duplicate inline spinner markup with shared `<LoadingSpinner />` from `@/components/LoadingSpinner`.
2. **`app/shop/loading.jsx`**:
   - Replaced duplicate inline spinner markup with shared `<LoadingSpinner />` and removed the dead commented-out import.
3. **`tests/routes/loading.test.tsx`**:
   - Added unit test suite asserting that `LoadingSpinner`, `app/loading.jsx`, and `app/shop/loading.jsx` render the shared spinner structure and lock the required classes: `loader`, `animate-spin`, `border-t-4`, `border-purple-700`, and `rounded-full`.

## Acceptance Criteria Verification
- [x] `app/loading.jsx` and `app/shop/loading.jsx` render via `<LoadingSpinner />` with no duplicated inline markup and no dead comment.
- [x] Route-loading tests assert the shared `animate-spin`/`border` classes.
- [x] `npm run test` passes cleanly after refactoring (39/39 tests passing).
- [x] `npm run type-check` passes with zero errors.
- [x] `npm run lint` passes with zero errors.

---
**Bounty Payout Address (USDC on Base):**
`0x46D5318E4397cFcBED06a235c1604E473682Ea1F`
