### PR TITLE
docs: align CONTRIBUTING testing guidelines with tests tree (#113)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,6 @@ npm run test:ui
 
 **Test file locations:**
 - Unit tests: `tests/lib/` for library functions
-- Component tests: `tests/components/` for React components
 - Tests should be named `*.test.ts` or `*.test.tsx`
 
 **What to test:**


### PR DESCRIPTION
Closes #113

### Summary
Update `CONTRIBUTING.md` test file locations to reference only `tests/lib/` for unit tests, removing reference to nonexistent `tests/components/` until component tests are introduced.

### Changes
- In `CONTRIBUTING.md`, removed `- Component tests: \`tests/components/\` for React components` so documented locations match the actual `tests/` tree.

### Acceptance Criteria
- [x] Documented test locations match the tracked `tests/` tree.