### PR TITLE
docs: remove unimplemented debug mode localStorage instructions (#115)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -292,13 +292,6 @@ If you can't resolve an issue:
 
 ## Debug Mode
 
-Enable verbose logging:
-
-```javascript
-// In browser console
-localStorage.setItem('debug', 'mova-store:*');
-```
-
 Check Stellar transaction details:
 
 ```bash


### PR DESCRIPTION
Closes #115

### Summary
Remove unimplemented `localStorage.setItem('debug', 'mova-store:*')` instructions from `docs/TROUBLESHOOTING.md` as no debug logger reads that key.

### Changes
- In `docs/TROUBLESHOOTING.md`, removed the `Enable verbose logging` snippet referencing unimplemented localStorage debug flag.

### Acceptance Criteria
- [x] No doc step instructs using an unimplemented console flag.