### PR TITLE
feat(shop): add loading skeleton and empty states to products grid (closes #105)

### DIFF
--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -8,6 +8,7 @@ import Cart from "../../components/Cart";
 import Modal from "../../components/Modal";
 import Toast from "../../components/Toast";
 import { listProducts } from "../../lib/products";
+import { ProductGridSkeleton } from "@/components/Skeleton";
 
 export default function Products() {
   const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } =
@@ -17,14 +18,18 @@ export default function Products() {
   const [isCheckingOut, setIsCheckingOut] = useState(false);
   const [products, setProducts] = useState([]);
   const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchProducts = async () => {
       try {
+        setLoading(true);
         const data = await listProducts();
-        setProducts(data);
+        setProducts(data || []);
       } catch (err) {
         setError(err.message);
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -58,34 +63,46 @@ export default function Products() {
             Welcome to Mova Store
           </span>
 
-          {error && <p className="text-red-500 text-center">{error}</p>}
+          {loading && <ProductGridSkeleton count={5} />}
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
-            {products.map((prod) => (
-              <div key={prod.id} className="p-4 border rounded-lg shadow">
-                <Link href={`/shop/${prod.id}`}>
-                  <Image
-                    src={prod.img} // Ensure this URL is correct
-                    alt={prod.name}
-                    width={200}
-                    height={200}
-                    className="mb-2"
-                  />
-                  <h1 className="text-xl font-bold">{prod.name}</h1>
-                  <h2 className="text-lg">${prod.price}</h2>
-                </Link>
-                <button
-                  className="border-purple-800 rounded-full px-2 py-2 mt-2 border-2 hover:border-purple-600"
-                  onClick={() => {
-                    addToCart(prod);
-                    showToast("Item added to cart");
-                  }}
-                >
-                  <FaShoppingCart />
-                </button>
-              </div>
-            ))}
-          </div>
+          {!loading && error && (
+            <p className="text-red-500 text-center py-8">{error}</p>
+          )}
+
+          {!loading && !error && products.length === 0 && (
+            <div className="text-center py-12 text-gray-500 font-medium">
+              No products yet
+            </div>
+          )}
+
+          {!loading && !error && products.length > 0 && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+              {products.map((prod) => (
+                <div key={prod.id} className="p-4 border rounded-lg shadow">
+                  <Link href={`/shop/${prod.id}`}>
+                    <Image
+                      src={prod.img} // Ensure this URL is correct
+                      alt={prod.name}
+                      width={200}
+                      height={200}
+                      className="mb-2"
+                    />
+                    <h1 className="text-xl font-bold">{prod.name}</h1>
+                    <h2 className="text-lg">${prod.price}</h2>
+                  </Link>
+                  <button
+                    className="border-purple-800 rounded-full px-2 py-2 mt-2 border-2 hover:border-purple-600"
+                    onClick={() => {
+                      addToCart(prod);
+                      showToast("Item added to cart");
+                    }}
+                  >
+                    <FaShoppingCart />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
         </section>
       </div>
 

--- a/tests/routes/shop-page.test.tsx
+++ b/tests/routes/shop-page.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Products from "@/app/shop/page";
+import { CartProvider } from "@/context/CartContext";
+import * as productsLib from "@/lib/products";
+
+// Ensure localStorage mock is available for CartProvider
+const createLocalStorageMock = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+};
+
+Object.defineProperty(window, "localStorage", {
+  value: createLocalStorageMock(),
+  writable: true,
+});
+
+describe("Shop Page Loading and Empty States (Issue #105)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  const renderShopPage = () => {
+    return render(
+      <CartProvider>
+        <Products />
+      </CartProvider>
+    );
+  };
+
+  it("renders ProductGridSkeleton while listProducts is pending", () => {
+    // Return an unresolved promise to simulate pending network request
+    vi.spyOn(productsLib, "listProducts").mockImplementation(
+      () => new Promise(() => {})
+    );
+
+    const { container } = renderShopPage();
+
+    // Verify skeleton animation elements are rendered
+    const skeletonElements = container.querySelectorAll(".animate-pulse");
+    expect(skeletonElements.length).toBeGreaterThan(0);
+    expect(screen.queryByText("No products yet")).not.toBeInTheDocument();
+  });
+
+  it("renders an explicit 'No products yet' empty state when listProducts resolves empty", async () => {
+    vi.spyOn(productsLib, "listProducts").mockResolvedValue([]);
+
+    renderShopPage();
+
+    // Await the resolution of the empty products list
+    await waitFor(() => {
+      expect(screen.getByText("No products yet")).toBeInTheDocument();
+    });
+
+    // Verify skeleton is no longer present
+    const skeletonElements = document.querySelectorAll(".animate-pulse");
+    expect(skeletonElements.length).toBe(0);
+  });
+
+  it("renders the error message when listProducts rejects", async () => {
+    vi.spyOn(productsLib, "listProducts").mockRejectedValue(
+      new Error("Network connection failed")
+    );
+
+    renderShopPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Network connection failed")
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("No products yet")).not.toBeInTheDocument();
+  });
+
+  it("renders product cards when listProducts returns items", async () => {
+    const mockProducts = [
+      {
+        id: "prod-1",
+        name: "Stellar Horizon Hoodie",
+        price: 49.99,
+        img: "https://example.com/hoodie.jpg",
+      },
+    ];
+
+    vi.spyOn(productsLib, "listProducts").mockResolvedValue(mockProducts as any);
+
+    renderShopPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Stellar Horizon Hoodie")).toBeInTheDocument();
+      expect(screen.getByText("$49.99")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("No products yet")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
Adds a loading state displaying `ProductGridSkeleton` while `listProducts` is pending, and an explicit `'No products yet'` empty state when the resolved products list is empty, while preserving the existing error rendering and full cart/checkout functionality.

Resolves #105

## Proposed Changes
1. **`app/shop/page.jsx`**:
   - Added `loading` state initialized to `true`.
   - Updated `fetchProducts` to set `setLoading(true)` on start and `setLoading(false)` in a `finally` block.
   - Rendered `<ProductGridSkeleton count={5} />` from `@/components/Skeleton` when `loading` is true.
   - Rendered an explicit `"No products yet"` placeholder message when not loading, no error, and `products.length === 0`.
   - Preserved existing error display, cart management (`useCart`), checkout flows, modals, and toasts.

2. **`tests/routes/shop-page.test.tsx`**:
   - Added full unit test coverage using Vitest and `@testing-library/react` verifying:
     * Loading skeleton visibility while request is unresolved.
     * Empty state visibility when products resolve to `[]`.
     * Error message visibility when request fails.
     * Product cards visibility when items are returned.

## Verification
- `npm run test` (`vitest run`): 40/40 passed (100% green)
- `npm run type-check`: 0 errors
- `npm run lint`: 0 errors

---
**Bounty Payout Address (USDC on Base):**
`0x46D5318E4397cFcBED06a235c1604E473682Ea1F`
