### PR TITLE
fix(stellar): reconcile mainnet RPC defaults across code and docs (#108)

### DIFF
--- a/docs/MAINNET_DEPLOYMENT.md
+++ b/docs/MAINNET_DEPLOYMENT.md
@@ -150,7 +150,7 @@ Update your `.env.local` (or production environment variables):
 NEXT_PUBLIC_STELLAR_NETWORK=mainnet
 
 # Mainnet RPC endpoint (use a reliable provider)
-NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-rpc.mainnet.stellar.gateway.fm
+NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-rpc.stellar.org
 
 # Mainnet passphrase
 NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE=Public Global Stellar Network ; September 2015

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -54,7 +54,7 @@ const STELLAR_DEFAULTS = {
       "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
   },
   mainnet: {
-    rpcUrl: "https://soroban-rpc.mainnet.stellar.gateway.fm",
+    rpcUrl: "https://soroban-rpc.stellar.org",
     networkPassphrase: "Public Global Stellar Network ; September 2015",
     usdcContractId: "", // Must be configured for mainnet
     nativeAssetContractId: "", // Must be configured for mainnet

--- a/tests/lib/env.test.ts
+++ b/tests/lib/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { isAdminEmail, isDevelopment, isProduction } from "../../lib/env";
+import { isAdminEmail, isDevelopment, isProduction, loadStellarConfig } from "../../lib/env";
 
 describe("isAdminEmail", () => {
   beforeEach(() => {
@@ -58,5 +58,34 @@ describe("isProduction", () => {
   it("returns false in development", () => {
     vi.stubEnv("NODE_ENV", "development");
     expect(isProduction()).toBe(false);
+  });
+});
+
+describe("loadStellarConfig", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("resolves the canonical SDF mainnet RPC endpoint when network is mainnet and RPC is unset", () => {
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_NETWORK", "mainnet");
+    delete process.env.NEXT_PUBLIC_STELLAR_RPC_URL;
+    const config = loadStellarConfig();
+    expect(config.network).toBe("mainnet");
+    expect(config.rpcUrl).toBe("https://soroban-rpc.stellar.org");
+  });
+
+  it("resolves the canonical SDF testnet RPC endpoint when network is testnet and RPC is unset", () => {
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_NETWORK", "testnet");
+    delete process.env.NEXT_PUBLIC_STELLAR_RPC_URL;
+    const config = loadStellarConfig();
+    expect(config.network).toBe("testnet");
+    expect(config.rpcUrl).toBe("https://soroban-testnet.stellar.org");
+  });
+
+  it("uses custom RPC endpoint when NEXT_PUBLIC_STELLAR_RPC_URL is provided", () => {
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_NETWORK", "mainnet");
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_RPC_URL", "https://custom-soroban-rpc.example.com");
+    const config = loadStellarConfig();
+    expect(config.rpcUrl).toBe("https://custom-soroban-rpc.example.com");
   });
 });

--- a/tests/lib/rpc-reconciliation.test.ts
+++ b/tests/lib/rpc-reconciliation.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+describe("Mainnet RPC Defaults Reconciliation", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("resolves the canonical SDF mainnet RPC endpoint in lib/env when unset", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_NETWORK", "mainnet");
+    delete process.env.NEXT_PUBLIC_STELLAR_RPC_URL;
+    const { loadStellarConfig } = await import("../../lib/env");
+    const config = loadStellarConfig();
+    expect(config.rpcUrl).toBe("https://soroban-rpc.stellar.org");
+  });
+
+  it("resolves the canonical SDF mainnet RPC endpoint in lib/stellar/config when unset", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_NETWORK", "mainnet");
+    delete process.env.NEXT_PUBLIC_STELLAR_RPC_URL;
+    const { RPC_URL, IS_MAINNET } = await import("../../lib/stellar/config");
+    expect(IS_MAINNET).toBe(true);
+    expect(RPC_URL).toBe("https://soroban-rpc.stellar.org");
+  });
+
+  it("ensures lib/env and lib/stellar/config resolve the exact same RPC URL on mainnet", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_NETWORK", "mainnet");
+    delete process.env.NEXT_PUBLIC_STELLAR_RPC_URL;
+    const { loadStellarConfig } = await import("../../lib/env");
+    const { RPC_URL } = await import("../../lib/stellar/config");
+    expect(loadStellarConfig().rpcUrl).toBe(RPC_URL);
+    expect(loadStellarConfig().rpcUrl).toBe("https://soroban-rpc.stellar.org");
+  });
+
+  it("ensures lib/env and lib/stellar/config resolve the exact same RPC URL on testnet", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_NETWORK", "testnet");
+    delete process.env.NEXT_PUBLIC_STELLAR_RPC_URL;
+    const { loadStellarConfig } = await import("../../lib/env");
+    const { RPC_URL } = await import("../../lib/stellar/config");
+    expect(loadStellarConfig().rpcUrl).toBe(RPC_URL);
+    expect(loadStellarConfig().rpcUrl).toBe("https://soroban-testnet.stellar.org");
+  });
+
+  it("honors custom NEXT_PUBLIC_STELLAR_RPC_URL across both modules", async () => {
+    const customEndpoint = "https://custom-soroban-rpc.example.com";
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_NETWORK", "mainnet");
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_RPC_URL", customEndpoint);
+    const { loadStellarConfig } = await import("../../lib/env");
+    const { RPC_URL } = await import("../../lib/stellar/config");
+    expect(loadStellarConfig().rpcUrl).toBe(customEndpoint);
+    expect(RPC_URL).toBe(customEndpoint);
+  });
+
+  it("verifies MAINNET_DEPLOYMENT.md documents the canonical mainnet endpoint", () => {
+    const deploymentDocPath = path.resolve(__dirname, "../../docs/MAINNET_DEPLOYMENT.md");
+    const content = fs.readFileSync(deploymentDocPath, "utf-8");
+    expect(content).toContain("NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-rpc.stellar.org");
+    expect(content).not.toContain("gateway.fm");
+  });
+});


### PR DESCRIPTION
### Summary
Reconciles divergent mainnet Soroban RPC endpoints across code and documentation so that when `NEXT_PUBLIC_STELLAR_RPC_URL` is unset, all modules resolve to the canonical Stellar Development Foundation (SDF) mainnet endpoint (`https://soroban-rpc.stellar.org`).

### Acceptance Criteria Checklist
- [x] `lib/stellar/config.ts` and `lib/env.ts` resolve the same mainnet RPC (`https://soroban-rpc.stellar.org`) when `NEXT_PUBLIC_STELLAR_RPC_URL` is unset.
- [x] `docs/MAINNET_DEPLOYMENT.md` references the canonical endpoint (`https://soroban-rpc.stellar.org`) that the code actually defaults to.
- [x] Full regression test suite added (`tests/lib/rpc-reconciliation.test.ts` and `tests/lib/env.test.ts`) covering mainnet, testnet, custom RPC overrides, and documentation alignment.
- [x] All automated checks pass (vitest, tsc type-check, next lint, next build).

Closes #108

## Payout Routing
- **EVM (Base/Arbitrum/Polygon/ETH):** `0xF46C9F6d70C50BF81ef3588AB523a90a594a2F89`
- **Stellar:** `GCL6OXAMLD75BMTINA6EMRUDWK5THQUSHMYNLSNBCJAPZJHNYJTUNIBC`