### PR TITLE
build(node): add .nvmrc and harmonize Node version requirements (closes #109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,11 @@ Install the following before getting started:
 
 | Tool             | Version / Notes                                              | Install                                     |
 | ---------------- | ------------------------------------------------------------ | ------------------------------------------- |
+<<<<<<< HEAD
 | **Node.js**      | 18.18+ (Node 20 recommended, see `.nvmrc`)                 | https://nodejs.org or `nvm use`            |
+=======
+| **Node.js**      | 18.18+ (Node 20 recommended, see `.nvmrc`, bundles `npm`)    | https://nodejs.org                          |
+>>>>>>> fc03e29 (build(node): add .nvmrc and harmonize Node version requirements)
 | **Rust**         | stable, with the `wasm32v1-none` target                      | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` |
 | **Stellar CLI**  | latest (`stellar --version`)                                 | `brew install stellar-cli` or via [cargo/docs](https://github.com/stellar/stellar-cli) |
 | **Freighter**    | browser wallet extension (Chrome / Firefox)                  | https://freighter.app                       |
@@ -258,6 +262,7 @@ cd mova-store
 ### 2. Install dependencies
 
 ```bash
+nvm use             # optional: load Node 20 via .nvmrc
 npm install
 ```
 

--- a/tests/lib/node-version.test.ts
+++ b/tests/lib/node-version.test.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+
+describe("Node Version Consistency (Issue #109)", () => {
+  const rootDir = path.resolve(__dirname, "../../");
+  const packageJsonPath = path.join(rootDir, "package.json");
+  const nvmrcPath = path.join(rootDir, ".nvmrc");
+  const readmePath = path.join(rootDir, "README.md");
+  const ciPath = path.join(rootDir, ".github/workflows/ci.yml");
+
+  it("ensures .nvmrc exists and specifies Node 20", () => {
+    expect(fs.existsSync(nvmrcPath)).toBe(true);
+    const nvmrcContent = fs.readFileSync(nvmrcPath, "utf-8").trim();
+    expect(nvmrcContent).toBe("20");
+  });
+
+  it("ensures package.json engines specifies node >=18.18.0", () => {
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+    expect(pkg.engines).toBeDefined();
+    expect(pkg.engines.node).toBe(">=18.18.0");
+  });
+
+  it("ensures CI NODE_VERSION matches .nvmrc", () => {
+    const ciContent = fs.readFileSync(ciPath, "utf-8");
+    const nvmrcContent = fs.readFileSync(nvmrcPath, "utf-8").trim();
+    expect(ciContent).toContain(`NODE_VERSION: "${nvmrcContent}"`);
+  });
+
+  it("ensures README mentions .nvmrc and nvm use", () => {
+    const readmeContent = fs.readFileSync(readmePath, "utf-8");
+    expect(readmeContent).toContain(".nvmrc");
+    expect(readmeContent).toContain("nvm use");
+  });
+});


### PR DESCRIPTION
Adds a root `.nvmrc` pinned to Node 20 (matching CI `NODE_VERSION`), updates `package.json` engines to `>=18.18.0` to align with Next.js 14 and README prerequisites, and adds `.nvmrc` / `nvm use` instructions to the README.

Fixes #109

---
**Bounty Payout Address (USDC on Base):**
`0x46D5318E4397cFcBED06a235c1604E473682Ea1F`
