### PR TITLE
fix: keep toast exit timer in effect scope so stale onClose cannot hide a re-shown toast

### DIFF
--- a/components/Notification.tsx
+++ b/components/Notification.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState, useCallback, createContext, useContext } from "react";
+import { useEffect, useState, useCallback, createContext, useContext, useRef } from "react";
 import { MdClose, MdCheckCircle, MdError, MdWarning, MdInfo } from "react-icons/md";
 
 // =============================================================================
@@ -51,8 +51,27 @@ export function useNotification() {
 export function NotificationProvider({ children }: { children: React.ReactNode }) {
   const [notifications, setNotifications] = useState<Notification[]>([]);
 
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map()
+  );
+
   const removeNotification = useCallback((id: string) => {
+    // Cancel the pending auto-removal timer so it cannot outlive the
+    // notification (issue #23: same corrected pattern as Toast).
+    const timer = timersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
     setNotifications((prev) => prev.filter((n) => n.id !== id));
+  }, []);
+
+  // Clear any pending auto-removal timers on unmount.
+  useEffect(() => {
+    return () => {
+      timersRef.current.forEach((timer) => clearTimeout(timer));
+      timersRef.current.clear();
+    };
   }, []);
 
   const addNotification = useCallback(
@@ -66,11 +85,12 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
 
       setNotifications((prev) => [...prev, newNotification]);
 
-      // Auto-remove after duration
+      // Auto-remove after duration (tracked so it can be cancelled)
       if (newNotification.duration && newNotification.duration > 0) {
-        setTimeout(() => {
+        const timer = setTimeout(() => {
           removeNotification(id);
         }, newNotification.duration);
+        timersRef.current.set(id, timer);
       }
 
       return id;

--- a/components/Toast.jsx
+++ b/components/Toast.jsx
@@ -1,24 +1,32 @@
 import { useEffect, useState } from "react";
 
-const Toast = ({ message, show, onClose , time=3000}) => {
+const Toast = ({ message, show, onClose, time = 3000 }) => {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    if (show) {
-      setVisible(true);
-    
-      const timer = setTimeout(() => {
-        setVisible(false);
-        const exitTimer = setTimeout(() => {
-          onClose();
-        }, 300);
-        return () => clearTimeout(exitTimer);
-      }, time);
-      return () => clearTimeout(timer);
-    } else {
+    if (!show) {
       setVisible(false);
+      return;
     }
-  }, [show, onClose]);
+
+    setVisible(true);
+
+    let exitTimer;
+    const timer = setTimeout(() => {
+      setVisible(false);
+      // Keep the exit timer in effect scope (issue #23): the previous version
+      // scheduled it inside the timeout callback, where its cleanup was never
+      // executed, so a stale onClose could hide a freshly re-shown toast.
+      exitTimer = setTimeout(() => {
+        onClose();
+      }, 300);
+    }, time);
+
+    return () => {
+      clearTimeout(timer);
+      if (exitTimer) clearTimeout(exitTimer);
+    };
+  }, [show, onClose, time]);
 
   return (
     <div

--- a/tests/components/Notification.test.tsx
+++ b/tests/components/Notification.test.tsx
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { NotificationProvider, useNotification } from "../../components/Notification";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+let addedId: string | null = null;
+
+function Probe() {
+  const { addNotification, removeNotification } = useNotification();
+  return (
+    <div>
+      <button
+        onClick={() =>
+          (addedId = addNotification({
+            type: "success",
+            message: "payment received",
+            duration: 2000,
+          }))
+        }
+      >
+        add
+      </button>
+      <button onClick={() => addedId && removeNotification(addedId)}>
+        remove
+      </button>
+    </div>
+  );
+}
+
+function renderProbe() {
+  return render(
+    <NotificationProvider>
+      <Probe />
+    </NotificationProvider>
+  );
+}
+
+describe("NotificationProvider auto-removal timers", () => {
+  it("auto-removes a notification after its configured duration", () => {
+    vi.useFakeTimers();
+    renderProbe();
+    fireEvent.click(screen.getByText("add"));
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(1999);
+    });
+    expect(screen.getByRole("alert")).toBeTruthy();
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("manual removal cancels the pending auto-removal", () => {
+    vi.useFakeTimers();
+    renderProbe();
+    fireEvent.click(screen.getByText("add"));
+    fireEvent.click(screen.getByText("remove"));
+    expect(screen.queryByRole("alert")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    }); // no stale timer left to act on
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("unmounting mid-auto-removal does not fire pending timers afterwards", () => {
+    vi.useFakeTimers();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { unmount } = renderProbe();
+    fireEvent.click(screen.getByText("add"));
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    }); // half way through the 2000ms duration
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/tests/components/Toast.test.jsx
+++ b/tests/components/Toast.test.jsx
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+import Toast from "../../components/Toast";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Toast exit-timer cleanup", () => {
+  it("calls onClose after the show duration plus the 300ms exit", () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    const { container } = render(
+      <Toast message="A" show time={1000} onClose={onClose} />
+    );
+
+    expect(container.firstChild.className).toContain("opacity-100");
+    act(() => {
+      vi.advanceTimersByTime(1000 + 299);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire the stale exit timer after a re-show within 300ms", () => {
+    vi.useFakeTimers();
+    const onCloseA = vi.fn();
+    const onCloseB = vi.fn();
+    const { container, rerender } = render(
+      <Toast message="A" show time={1000} onClose={onCloseA} />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    }); // A starts its 300ms exit
+    expect(container.firstChild.className).toContain("opacity-0");
+
+    // A new toast is re-shown inside the exit window (fresh onClose identity,
+    // as the Navbar produces on every render).
+    rerender(<Toast message="B" show time={1000} onClose={onCloseB} />);
+    expect(container.firstChild.className).toContain("opacity-100");
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    }); // A's stale exit point
+    expect(onCloseA).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1000 + 300);
+    }); // B's own lifecycle completes
+    expect(onCloseB).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose after unmounting mid-exit", () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    const { unmount } = render(
+      <Toast message="A" show time={1000} onClose={onClose} />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    }); // exit timer is now pending
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #23

## Problem

In `components/Toast.jsx` the 300ms exit timeout was scheduled *inside* the outer `setTimeout` callback, and its `return () => clearTimeout(exitTimer)` was returned from inside that callback where it is never executed - so the exit timer could never be cancelled. If a new toast was re-shown within that 300ms window (Navbar/Hero/shop pages re-show toasts frequently), the old toast's `onClose` fired and hid the new message. The same untracked-timer pattern was duplicated in `components/Notification.tsx` (auto-removal `setTimeout` never cancelled on manual removal or unmount).

## Change

- `components/Toast.jsx`: restructured the effect so the exit timer is created in effect scope and cleared when `show`/`onClose`/`time` change or the component unmounts (deps now include `time`).
- `components/Notification.tsx`: auto-removal timers are tracked in a ref map, cancelled by `removeNotification`, and all cleared on provider unmount - the same corrected pattern as Toast.
- `tests/components/Toast.test.jsx` (new, fake timers):
  - `onClose` fires only after duration + 300ms exit;
  - re-showing toast B within the 300ms window does **not** fire A's stale `onClose`;
  - unmounting mid-exit does not call `onClose` afterwards.
- `tests/components/Notification.test.tsx` (new, fake timers): auto-removal after the configured duration, manual removal cancels the pending timer, unmount mid-removal leaves no pending timers.

## Verification

- `npm run test` - 42/42 pass (36 existing + 6 new)
- `npm run type-check` - passes
- `npm run lint` - passes (only pre-existing warnings from main)

## Acceptance criteria (#23)

- [x] With fake timers: showing toast A, re-showing toast B within 300ms does not call onClose for B
- [x] Unmounting mid-exit does not call onClose afterwards
- [x] Both Toast.jsx and Notification.tsx implement the same corrected pattern
- [x] npm run test passes