### PR TITLE
fix: navigate home before scrolling when an anchor section is missing from the page

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -26,6 +26,9 @@ function BrandMark() {
 }
 
 function Navbar() {
+  const router = useRouter();
+  const [pendingHash, setPendingHash] = useState(null);
+
   useEffect(() => {
     const handleLinkClick = (event) => {
       event.preventDefault();
@@ -34,6 +37,12 @@ function Navbar() {
       const targetElement = document.getElementById(targetId);
       if (targetElement) {
         targetElement.scrollIntoView({ behavior: "smooth" });
+      } else {
+        // The anchor section (#aboutus / #contact) only exists on the home
+        // page: navigate there first, then scroll once it has rendered
+        // (handled by the pendingHash effect below).
+        setPendingHash(targetId);
+        router.push(`/${href}`);
       }
     };
 
@@ -45,9 +54,19 @@ function Navbar() {
         link.removeEventListener("click", handleLinkClick)
       );
     };
-  }, []);
+  }, [router]);
 
-  const router = useRouter();
+  // After navigating home for an anchor target, scroll to the section once
+  // the home page has rendered.
+  useEffect(() => {
+    if (router.pathname !== "/" || !pendingHash) return;
+    const targetId = pendingHash;
+    const timer = setTimeout(() => {
+      setPendingHash(null);
+      document.getElementById(targetId)?.scrollIntoView({ behavior: "smooth" });
+    }, 150);
+    return () => clearTimeout(timer);
+  }, [router.pathname, pendingHash]);
   const [toast, setToast] = useState({ show: false, message: "" });
   const showToast = (message) => {
     setToast({ show: true, message });

--- a/tests/components/Navbar.test.jsx
+++ b/tests/components/Navbar.test.jsx
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import Navbar from "../../components/Navbar";
+
+const mockRouter = vi.hoisted(() => ({
+  push: vi.fn(),
+  pathname: "/",
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+}));
+
+vi.mock("next/link", () => ({
+  default: (props) => <a {...props} />,
+}));
+
+vi.mock("../../lib/AuthContext", () => ({
+  useAuth: () => ({ user: null }),
+}));
+
+vi.mock("../../lib/auth", () => ({
+  logout: vi.fn(),
+}));
+
+afterEach(() => {
+  mockRouter.push.mockClear();
+  mockRouter.pathname = "/";
+  vi.useRealTimers();
+  document.body.innerHTML = "";
+});
+
+describe("Navbar anchor links", () => {
+  it("smooth-scrolls to the section when it exists on the current page", () => {
+    mockRouter.pathname = "/";
+    const section = document.createElement("section");
+    section.id = "aboutus";
+    section.scrollIntoView = vi.fn();
+    document.body.appendChild(section);
+
+    render(<Navbar />);
+    screen.getByText("About Us").click();
+
+    expect(section.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth" });
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+
+  it("navigates home first when the section is not on the current page", () => {
+    mockRouter.pathname = "/shop";
+    render(<Navbar />);
+    screen.getByText("About Us").click();
+
+    expect(mockRouter.push).toHaveBeenCalledWith("/#aboutus");
+  });
+
+  it("scrolls to the section once the home page has rendered", () => {
+    vi.useFakeTimers();
+    mockRouter.pathname = "/shop";
+    const section = document.createElement("section");
+    section.id = "aboutus";
+    section.scrollIntoView = vi.fn();
+
+    const { rerender } = render(<Navbar />);
+    screen.getByText("About Us").click();
+    expect(mockRouter.push).toHaveBeenCalledWith("/#aboutus");
+
+    // Simulate arriving on the home page with the section rendered.
+    mockRouter.pathname = "/";
+    document.body.appendChild(section);
+    rerender(<Navbar />);
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(section.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth" });
+  });
+});


### PR DESCRIPTION
Closes #83

## Problem

The root-layout `Navbar` attaches a document-level handler to every `a[href^='#']` that calls `preventDefault` and only smooth-scrolls when `document.getElementById` finds the target. The `#aboutus` / `#contact` sections exist only on the home page (`app/(landingpage)/Aboutus.jsx`, `ContactUs.jsx`), so from `/shop`, `/blog` or `/checkout` these clicks were swallowed and nothing happened.

## Change

- When the target element is absent, the handler now stores the pending hash and navigates to `/#aboutus` / `/#contact` instead of swallowing the click.
- A `pendingHash` effect scrolls to the section (smooth) once the home page has rendered.
- On the home page the existing same-page smooth scroll is unchanged.
- `tests/components/Navbar.test.jsx` (new):
  - with the section present: `scrollIntoView({behavior:"smooth"})` is called, no navigation;
  - from `/shop`: clicking About Us calls `router.push("/#aboutus")`;
  - after arriving on the home page with the section rendered, the pending scroll fires.

## Verification

- `npm run test` - 39/39 pass (36 existing + 3 new)
- `npm run type-check` - passes
- `npm run lint` - passes (only pre-existing warnings from main)

## Acceptance criteria (#83)

- [x] From /shop or /blog, clicking About Us lands on the home page's about section
- [x] On the home page the existing same-page smooth scroll still works