### PR TITLE
fix: remove dead sidebar links and align labels with their routes

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -4,10 +4,8 @@ import Link from "next/link";
 import {
   FaHome,
   FaInfoCircle,
-  FaPhone,
   FaShoppingCart,
   FaRunning,
-  FaList,
   FaSearch,
 } from "react-icons/fa";
 import { FaShoePrints } from "react-icons/fa6";
@@ -38,25 +36,7 @@ export default function Sidebar() {
                 className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
               >
                 <FaHome className="mr-3" />
-                Men
-              </Link>
-            </li>
-            <li>
-              <Link
-                href="/about"
-                className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
-              >
-                <FaInfoCircle className="mr-3" />
-                Women
-              </Link>
-            </li>
-            <li>
-              <Link
-                href="/contact"
-                className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
-              >
-                <FaPhone className="mr-3" />
-                Kids
+                Home
               </Link>
             </li>
             <li>
@@ -65,7 +45,7 @@ export default function Sidebar() {
                 className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
               >
                 <FaShoppingCart className="mr-3" />
-                Casual
+                Shop
               </Link>
             </li>
             <li>
@@ -74,7 +54,7 @@ export default function Sidebar() {
                 className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
               >
                 <FcSportsMode className="mr-3" />
-                Sport
+                Collections
               </Link>
             </li>
             <li>
@@ -90,15 +70,6 @@ export default function Sidebar() {
                 ""
               )}
             </li>
-            <li>
-              <Link
-                href="/categories"
-                className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
-              >
-                <FaList className="mr-3" />
-                Categories
-              </Link>
-            </li>
           </ul>
         </nav>
       </aside>
@@ -110,14 +81,6 @@ export default function Sidebar() {
           <ul className="py-6 space-y-14 px-2">
             <li className=" hover:text-white transition-colors duration-200">
               <FaSearch size={20} className="mr-3" />
-            </li>
-            <li>
-              <Link
-                href="/categories"
-                className=" hover:text-white transition-colors duration-200"
-              >
-                <FaList className="mr-3" size={20} />
-              </Link>
             </li>
             <li>
               <Link

--- a/tests/components/Sidebar.test.jsx
+++ b/tests/components/Sidebar.test.jsx
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import Sidebar from "../../components/Sidebar";
+
+vi.mock("../../lib/AuthContext", () => ({
+  useAuth: () => ({ user: null }),
+}));
+
+// Static route table under app/ (product pages /shop/[id] are dynamic).
+const REAL_ROUTES = new Set([
+  "/",
+  "/shop",
+  "/collections",
+  "/admin",
+  "/blog",
+  "/checkout",
+  "/profile/login",
+]);
+
+describe("Sidebar navigation", () => {
+  it("only links to routes that exist under app/", () => {
+    const { container } = render(<Sidebar />);
+    const hrefs = [...container.querySelectorAll("a[href]")].map((a) =>
+      a.getAttribute("href")
+    );
+
+    expect(hrefs.length).toBeGreaterThan(0);
+    for (const href of hrefs) {
+      expect(REAL_ROUTES.has(href), `sidebar links to missing route ${href}`).toBe(
+        true
+      );
+    }
+  });
+
+  it("labels match their destinations", () => {
+    const { container } = render(<Sidebar />);
+    const linkByLabel = (label) =>
+      [...container.querySelectorAll("a")].find((a) =>
+        (a.textContent || "").includes(label)
+      );
+
+    expect(linkByLabel("Home")?.getAttribute("href")).toBe("/");
+    expect(linkByLabel("Shop")?.getAttribute("href")).toBe("/shop");
+    expect(linkByLabel("Collections")?.getAttribute("href")).toBe(
+      "/collections"
+    );
+  });
+
+  it("no longer contains the removed dead entries", () => {
+    const { container } = render(<Sidebar />);
+    const html = container.innerHTML;
+    expect(html).not.toContain("/about");
+    expect(html).not.toContain("/contact");
+    expect(html).not.toContain("/categories");
+  });
+});


### PR DESCRIPTION
Closes #25

## Problem

The `Sidebar` rendered on every shop page via `app/shop/layout.jsx` linked to routes that do not exist under `app/`: `/about` ("Women"), `/contact` ("Kids") and `/categories` (desktop + mobile entries). Clicking them landed on the not-found page, and several labels disagreed with their destinations.

## Change

- Removed the dead entries: `/about` (Women), `/contact` (Kids), `/categories` (desktop "Categories" and the mobile icon link), plus the now-unused `FaPhone` / `FaList` imports.
- Relabelled the remaining entries to match their real destinations, cross-checked against the `app/` route table:
  - `Men -> Home` (`/`)
  - `Casual -> Shop` (`/shop`)
  - `Sport -> Collections` (`/collections`)
  - `Admin` (`/admin`, conditional) kept as-is.
- `tests/components/Sidebar.test.jsx` (new):
  - every rendered sidebar link points at a route that exists under `app/`;
  - labels match their destinations;
  - the removed dead entries are gone.

## Verification

- `npm run test` - 39/39 pass (36 existing + 3 new)
- `npm run type-check` - passes
- `npm run lint` - passes (only pre-existing warnings from main)

## Acceptance criteria (#25)

- [x] Clicking every sidebar link from a shop page never lands on the not-found page
- [x] Each entry's label matches its destination (cross-checked against the app/ route table)
- [x] next lint passes