### PR TITLE
test: add unit tests for shortAddress and WalletError in lib/stellar/freighter

### DIFF
--- a/tests/lib/stellar/freighter.test.ts
+++ b/tests/lib/stellar/freighter.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@stellar/freighter-api", () => ({
+  getAddress: vi.fn().mockResolvedValue({ address: "G" + "A".repeat(55) }),
+  getNetwork: vi.fn().mockResolvedValue({ passphrase: "Test SDF" }),
+  isConnected: vi.fn().mockResolvedValue({ isConnected: true }),
+  requestAccess: vi.fn().mockResolvedValue({ success: true, addresses: [] }),
+  signTransaction: vi.fn().mockResolvedValue({ signedTxXdr: "AQ" }),
+}));
+
+import { WalletError, shortAddress } from "../../../lib/stellar/freighter";
+
+const ADDRESS56 = "G" + "A".repeat(55);
+
+describe("shortAddress", () => {
+  it("returns an empty string for null or empty input", () => {
+    expect(shortAddress(null as unknown as string)).toBe("");
+    expect(shortAddress("")).toBe("");
+  });
+
+  it("returns addresses at or below the threshold unchanged", () => {
+    expect(shortAddress("GABC123")).toBe("GABC123");
+    // default chars = 6 -> threshold is chars * 2 + 3 = 15
+    const exactlyAtThreshold = "G" + "A".repeat(14);
+    expect(shortAddress(exactlyAtThreshold)).toBe(exactlyAtThreshold);
+  });
+
+  it("truncates a 56-char Stellar address to the first and last 6 chars", () => {
+    expect(shortAddress(ADDRESS56)).toBe("GAAAAA…AAAAAA");
+  });
+
+  it("honours a custom chars argument", () => {
+    expect(shortAddress(ADDRESS56, 4)).toBe("GAAA…AAAA");
+  });
+});
+
+describe("WalletError", () => {
+  it("is an Error named WalletError with the default code", () => {
+    const err = new WalletError("wallet not found");
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(WalletError);
+    expect(err.name).toBe("WalletError");
+    expect(err.message).toBe("wallet not found");
+    expect(err.code).toBe("WALLET_ERROR");
+  });
+
+  it("preserves custom codes used by the UI", () => {
+    expect(
+      new WalletError("nope", "FREIGHTER_NOT_FOUND").code
+    ).toBe("FREIGHTER_NOT_FOUND");
+    expect(new WalletError("bad", "INVALID_AMOUNT").code).toBe(
+      "INVALID_AMOUNT"
+    );
+  });
+});


### PR DESCRIPTION
Closes #15

## Change

Adds `tests/lib/stellar/freighter.test.ts` (with `@stellar/freighter-api` mocked at the module level so no browser extension is touched):

- `shortAddress`:
  - `shortAddress(null) === ''` and `shortAddress('') === ''`
  - addresses at or below the `chars * 2 + 3` threshold (15 for the default `chars = 6`) are returned unchanged
  - a 56-char `G...` address becomes `GAAAAA...AAAAAA` (first + last 6 chars)
  - a custom `chars` argument is honoured (`chars = 4`)
- `WalletError`:
  - `instanceof Error`, `name === 'WalletError'`, default `code === 'WALLET_ERROR'`
  - custom codes (`FREIGHTER_NOT_FOUND`, `INVALID_AMOUNT`) are preserved

## Verification

- `npm run test` - 42/42 pass (36 existing + 6 new)
- `npm run type-check` - passes
- `npm run lint` - passes (only pre-existing warnings from main)

## Acceptance criteria (#15)

- [x] shortAddress(null) === '' and shortAddress('') === ''
- [x] Strings shorter than the ellipsis threshold are returned unchanged; a 56-char G... address is truncated; a custom chars argument is honoured
- [x] WalletError instanceof Error, name === 'WalletError', default code 'WALLET_ERROR', custom codes preserved
- [x] The suite passes with freighter-api mocked so no browser extension is touched