### PR TITLE
ci: add workflow-level least-privilege permissions (closes #102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: "20"
   RUST_VERSION: "1.91.0"


### PR DESCRIPTION
### Context
Closes #102

### Summary
- Adds `permissions: contents: read` at the top level of `.github/workflows/ci.yml` to adhere to least-privilege security best practices.
- All CI jobs only require read access for checking out code, caching, and scanning.

### Verification
- Validated workflow syntax and structure.