### PR TITLE
ci: add per-job timeout-minutes to all CI jobs (closes #101)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
   frontend:
     name: Frontend (Lint, Type Check, Test, Build)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -55,6 +56,7 @@ jobs:
   contracts:
     name: Soroban Contracts (Build, Test)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -92,6 +94,7 @@ jobs:
   security:
     name: Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -116,6 +119,7 @@ jobs:
   rust-security:
     name: Rust Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -139,6 +143,7 @@ jobs:
     name: CI Success
     needs: [frontend, contracts, security]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: always()
 
     steps:


### PR DESCRIPTION
### Context
Closes #101

### Summary
- Adds explicit `timeout-minutes` to each job block under `jobs:` in `.github/workflows/ci.yml`.
- Frontend & Security jobs: 15 minutes
- Contracts & Rust security jobs: 30 minutes
- CI success aggregator job: 10 minutes
- Prevents hung compilation or remote calls from exhausting default runner budgets while providing generous headroom for legitimate slow runs.

### Verification
- Validated YAML syntax and job timeout configurations.