### PR TITLE
ci: pin third-party actions to release tags (closes #103)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: wasm32v1-none
@@ -108,7 +108,7 @@ jobs:
         continue-on-error: true # Report but don't fail yet
 
       - name: Check for secrets
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.97.4
         with:
           extra_args: --only-verified
 
@@ -122,7 +122,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
 


### PR DESCRIPTION
### Context
Closes #103

### Summary
- Pins mutable branch references in `.github/workflows/ci.yml` to released version tags:
  - `dtolnay/rust-toolchain@master` -> `dtolnay/rust-toolchain@v1`
  - `trufflesecurity/trufflehog@main` -> `trufflesecurity/trufflehog@v3.97.4`
- Ensures deterministic and reproducible CI runs isolated from upstream branch changes.

### Verification
- Confirmed tag availability and YAML correctness.