### PR TITLE
ci: install cargo-audit via install-action prebuilt binary (closes #104)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,13 +121,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        uses: taiki-e/install-action@cargo-audit
 
       - name: Run cargo audit
         working-directory: contracts/checkout


### PR DESCRIPTION
### Context
Closes #104

### Summary
- Replaces the from-source `cargo install cargo-audit --locked` step in the `rust-security` job with `taiki-e/install-action@cargo-audit`.
- Uses prebuilt binaries to significantly speed up CI turnaround and eliminate unnecessary source compilation on each run.

### Verification
- Validated workflow syntax and integration.