### PR TITLE
fix: point footer links at real destinations and add Terms/Privacy pages

### DIFF
--- a/app/privacy/page.jsx
+++ b/app/privacy/page.jsx
@@ -1,0 +1,64 @@
+export const metadata = {
+  title: "Privacy Policy · Mova Store",
+  description: "Privacy policy for the Mova Store storefront.",
+};
+
+const sections = [
+  {
+    heading: "1. What we collect",
+    body: "Account information you provide when signing in (email address and, if you choose, a display name and avatar). Order information such as shipping address and contact details. Payment happens on the Stellar network via your own wallet (Freighter); we never see your wallet seed or private keys.",
+  },
+  {
+    heading: "2. How we use your data",
+    body: "To fulfill and track your orders, communicate with you about purchases and customer service requests, and improve the Store. We do not sell your personal data.",
+  },
+  {
+    heading: "3. Wallet and on-chain data",
+    body: "Checkouts settle in USDC on the Stellar testnet/mainnet through the Soroban escrow contract. Your wallet address, order id and payment amount are recorded on-chain as part of the public ledger. Transaction hashes are shared with you for verification.",
+  },
+  {
+    heading: "4. Cookies and local storage",
+    body: "The Store uses your browser's local storage to keep your shopping cart between visits and to remember your authenticated session (managed by Supabase Auth). No third-party advertising trackers are used.",
+  },
+  {
+    heading: "5. Sharing",
+    body: "We share the minimum information required to deliver your order (carriers, payment/escrow infrastructure, hosting). We may disclose data when required by law.",
+  },
+  {
+    heading: "6. Retention and security",
+    body: "Order records are kept for accounting and support purposes. We use reasonable technical and organizational measures to protect your data, and session credentials are stored only as encrypted tokens by the auth provider.",
+  },
+  {
+    heading: "7. Your rights",
+    body: "Depending on where you live, you may have rights to access, correct or delete your personal data. To exercise any of these rights, contact customer service through the home page contact section.",
+  },
+  {
+    heading: "8. Changes",
+    body: "We may update this policy from time to time. The latest version will always be published on this page.",
+  },
+];
+
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-screen bg-mova-surface text-slate-900">
+      <div className="container mx-auto max-w-3xl px-6 py-16">
+        <h1 className="text-3xl font-bold text-purple-900 sm:text-4xl">
+          Privacy Policy
+        </h1>
+        <p className="mt-2 text-sm text-slate-500">
+          Last updated: September 4, 2026
+        </p>
+        <div className="mt-10 space-y-8">
+          {sections.map((s) => (
+            <section key={s.heading}>
+              <h2 className="text-lg font-semibold text-purple-900">
+                {s.heading}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-700">{s.body}</p>
+            </section>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/terms/page.jsx
+++ b/app/terms/page.jsx
@@ -1,0 +1,72 @@
+export const metadata = {
+  title: "Terms of Use · Mova Store",
+  description: "Terms of use for the Mova Store storefront.",
+};
+
+const sections = [
+  {
+    heading: "1. Acceptance of terms",
+    body: "By accessing or purchasing from Mova Store (the “Store”), you agree to be bound by these Terms of Use. If you do not agree with any part of these terms, please do not use the Store.",
+  },
+  {
+    heading: "2. Products and listings",
+    body: "We work hard to display our products as accurately as possible, but we cannot guarantee that every detail, color or specification is error-free. All sales are subject to availability of the item.",
+  },
+  {
+    heading: "3. Orders and payments",
+    body: "Orders placed through the Store are confirmed only when the payment is successfully escrowed on the Stellar network (USDC via the Soroban checkout contract) and the order appears in your account. We may decline or cancel an order if we suspect fraud, misrepresentation or a technical fault.",
+  },
+  {
+    heading: "4. Pricing and currency",
+    body: "All prices are quoted in US dollars and settled in USDC. Prices may change without notice; the price displayed at the time you place your order is the price that will be charged.",
+  },
+  {
+    heading: "5. Shipping and delivery",
+    body: "Delivery times are estimates. Mova Store is not responsible for delays caused by carriers, customs or circumstances beyond our reasonable control.",
+  },
+  {
+    heading: "6. Returns",
+    body: "Returns and refunds are handled case by case in line with applicable consumer law. To request a return, contact customer service within 14 days of delivery with your order reference.",
+  },
+  {
+    heading: "7. User conduct",
+    body: "You agree not to misuse the Store, including by attempting to interfere with the checkout contract, scraping the catalog at scale, or submitting false or fraudulent orders.",
+  },
+  {
+    heading: "8. Limitation of liability",
+    body: "To the maximum extent permitted by law, Mova Store is not liable for indirect or consequential losses arising from your use of the Store. Blockchain-based settlement is final once the transaction is included in a ledger; see the checkout confirmation for the transaction hash.",
+  },
+  {
+    heading: "9. Changes to these terms",
+    body: "We may update these terms from time to time. The latest version will always be published on this page; continued use of the Store after changes constitutes acceptance of the new terms.",
+  },
+  {
+    heading: "10. Contact",
+    body: "Questions about these terms can be sent through the 24/7 customer service section on our home page.",
+  },
+];
+
+export default function TermsPage() {
+  return (
+    <main className="min-h-screen bg-mova-surface text-slate-900">
+      <div className="container mx-auto max-w-3xl px-6 py-16">
+        <h1 className="text-3xl font-bold text-purple-900 sm:text-4xl">
+          Terms of Use
+        </h1>
+        <p className="mt-2 text-sm text-slate-500">
+          Last updated: September 4, 2026
+        </p>
+        <div className="mt-10 space-y-8">
+          {sections.map((s) => (
+            <section key={s.heading}>
+              <h2 className="text-lg font-semibold text-purple-900">
+                {s.heading}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-700">{s.body}</p>
+            </section>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -8,25 +8,25 @@ export default function Footer() {
       <section className="container mx-auto flex h-28 flex-col items-center justify-between divide-black text-center font-normal sm:flex-row sm:divide-x-2 sm:divide-white/30">
         <span className="my-10 hidden gap-2 text-sm sm:my-0 sm:flex">
           <Link
-            href="/"
+            href="/terms"
             className="transition hover:underline hover:underline-offset-1"
           >
-            Term of use
+            Terms of Use
           </Link>
           <Link
-            href="/"
+            href="/privacy"
             className="transition hover:underline hover:underline-offset-1"
           >
             Privacy Policy
           </Link>
           <Link
-            href="/"
+            href="/#aboutus"
             className="transition hover:underline hover:underline-offset-1"
           >
             About us
           </Link>
           <Link
-            href="/"
+            href="/#contact"
             className="transition hover:underline hover:underline-offset-1"
           >
             24/7 Customer Service

--- a/tests/components/Footer.test.jsx
+++ b/tests/components/Footer.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Footer from "../../components/Footer";
+
+vi.mock("next/link", () => ({
+  default: ({ href, ...rest }) => (
+    <a href={href} data-testid="footer-link" {...rest} />
+  ),
+}));
+
+const linkText = (text) => screen.getByText(text).closest("a");
+
+describe("Footer", () => {
+  it("has no footer link that just bounces to the root path", () => {
+    render(<Footer />);
+    const hrefs = screen
+      .getAllByTestId("footer-link")
+      .map((a) => a.getAttribute("href"));
+    expect(hrefs).not.toContain("/");
+  });
+
+  it("points Terms of Use / Privacy Policy at their own routes", () => {
+    render(<Footer />);
+    expect(linkText("Terms of Use").getAttribute("href")).toBe("/terms");
+    expect(linkText("Privacy Policy").getAttribute("href")).toBe("/privacy");
+  });
+
+  it("points About us and 24/7 Customer Service at their home-page sections", () => {
+    render(<Footer />);
+    expect(linkText("About us").getAttribute("href")).toBe("/#aboutus");
+    expect(
+      linkText("24/7 Customer Service").getAttribute("href")
+    ).toBe("/#contact");
+  });
+
+  it("uses the corrected 'Terms of Use' wording", () => {
+    render(<Footer />);
+    expect(screen.queryByText("Term of use")).toBeNull();
+    expect(screen.getByText("Terms of Use")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #80

## Problem

All four footer links in `components/Footer.jsx` hard-coded `href="/"`, so every footer link bounced users back to the landing page, and the "Term of use" wording was ungrammatical.

## Change

- Added two real pages:
  - `app/terms/page.jsx` - Terms of Use (orders, Stellar/USDC settlement, returns, conduct, liability)
  - `app/privacy/page.jsx` - Privacy Policy (what we collect, wallet/on-chain data, cookies/localStorage, retention)
- `components/Footer.jsx` links now resolve to real destinations:
  - "Term of use" -> **"Terms of Use"** -> `/terms`
  - "Privacy Policy" -> `/privacy`
  - "About us" -> `/#aboutus` (existing about section on the home page)
  - "24/7 Customer Service" -> `/#contact` (existing contact section on the home page)
- `tests/components/Footer.test.jsx` (new): no link points at bare `/`; each link has its intended destination; the corrected wording is present.

## Verification

- `npm run test` - 40/40 pass (36 existing + 4 new)
- `npm run type-check` - passes
- `npm run lint` - passes (0 errors)

## Acceptance criteria (#80)

- [x] Each footer link resolves to an existing route rather than '/'
- [x] Clicking any footer link no longer reloads the home page