### PR TITLE
fix: render Slider images once with stable src-based keys

### DIFF
--- a/app/(landingpage)/Slider.jsx
+++ b/app/(landingpage)/Slider.jsx
@@ -12,9 +12,9 @@ const Slider = () => {
   return (
     <section className="py-14 overflow-hidden bg-mova-surface/60">
       <div className="flex gap-6 overflow-x-auto px-6 md:px-10 pb-2">
-        {[...images, ...images].map((src, index) => (
+        {images.map((src) => (
           <Image
-            key={index}
+            key={src}
             src={src}
             alt="Mova Store footwear"
             width={240}

--- a/tests/components/Slider.test.jsx
+++ b/tests/components/Slider.test.jsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Slider from "../../app/(landingpage)/Slider";
+
+vi.mock("next/image", () => ({
+  default: (props) => <img data-testid="slide" {...props} />,
+}));
+
+describe("Slider", () => {
+  it("renders exactly 5 images (no duplicated strip)", () => {
+    render(<Slider />);
+    expect(screen.getAllByTestId("slide")).toHaveLength(5);
+  });
+
+  it("renders each of the 5 image URLs exactly once (stable src-based keys)", () => {
+    const { container } = render(<Slider />);
+    const srcs = Array.from(container.querySelectorAll("img")).map((img) =>
+      img.getAttribute("src")
+    );
+    expect(srcs).toHaveLength(5);
+    expect(new Set(srcs).size).toBe(5);
+    const duplicates = srcs.filter((src, i) => srcs.indexOf(src) !== i);
+    expect(duplicates).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #75

## Problem

`app/(landingpage)/Slider.jsx` rendered `[...images, ...images]` so the same five Unsplash URLs appeared twice in one scroll strip, and every `<Image>` was keyed by its array index (`key={index}`), producing duplicate React keys and an inert second copy of the strip.

## Change

- Render the five-image array **once** with a stable unique key (`key={src}`).
- The existing `overflow-x-auto` scroll strip behaviour is unchanged (no duplicated DOM, no CSS-animation rewrite needed).
- `tests/components/Slider.test.jsx` (new):
  - `<Slider />` renders exactly 5 images
  - each of the 5 URLs appears exactly once (no duplicate keys/nodes)

## Verification

- `npm run test` - 38/38 pass (36 existing + 2 new)
- `npm run type-check` - passes
- `npm run lint` - passes (0 errors)

## Acceptance criteria (#75)

- [x] Rendering <Slider /> produces no duplicate-key console warning (stable src-based keys)
- [x] The container renders exactly 5 <img> elements, not 10
- [x] No looping effect is achieved with duplicated DOM (strip rendered once)