### PR TITLE
test: add unit tests for the floating Cart badge button (#99)

### DIFF
--- a/tests/components/Cart.test.jsx
+++ b/tests/components/Cart.test.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Cart from "../../components/Cart";
+
+describe("Cart component", () => {
+  it("does not render the badge when itemCount is 0", () => {
+    const handleClick = vi.fn();
+    render(<Cart itemCount={0} onClick={handleClick} />);
+
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+    expect(screen.queryByText("3")).not.toBeInTheDocument();
+  });
+
+  it("renders the badge with correct count when itemCount > 0", () => {
+    const handleClick = vi.fn();
+    render(<Cart itemCount={3} onClick={handleClick} />);
+
+    const badge = screen.getByText("3");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass("bg-purple-600");
+  });
+
+  it("calls onClick exactly once when clicked", () => {
+    const handleClick = vi.fn();
+    render(<Cart itemCount={3} onClick={handleClick} />);
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
Adds comprehensive unit tests for `components/Cart.jsx` as requested in #99.

## Changes
- Created `tests/components/Cart.test.jsx` verifying:
  - Badge is not rendered when `itemCount=0`
  - Badge renders with correct count and styling when `itemCount > 0` (e.g. 3)
  - Clicking the cart button invokes `onClick` handler exactly once

## Validation
- `npm run test` passes with 100% success on all component test suites.

Closes #99
/claim #99
