### PR TITLE
test: add unit tests for Modal show/hide rendering and onClose behaviour (#98)

### DIFF
--- a/tests/components/Modal.test.jsx
+++ b/tests/components/Modal.test.jsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import Modal from "../../components/Modal";
+
+describe("Modal component", () => {
+  it("renders nothing when show is false", () => {
+    const { container } = render(
+      <Modal show={false} onClose={vi.fn()}>
+        <div>Modal Content</div>
+      </Modal>
+    );
+
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText("Modal Content")).not.toBeInTheDocument();
+  });
+
+  it("renders children and close button when show is true", () => {
+    render(
+      <Modal show={true} onClose={vi.fn()}>
+        <div>Modal Content</div>
+      </Modal>
+    );
+
+    expect(screen.getByText("Modal Content")).toBeInTheDocument();
+    const closeButton = screen.getByRole("button");
+    expect(closeButton).toBeInTheDocument();
+  });
+
+  it("calls onClose exactly once when the close button is clicked", () => {
+    const handleClose = vi.fn();
+    render(
+      <Modal show={true} onClose={handleClose}>
+        <div>Modal Content</div>
+      </Modal>
+    );
+
+    const closeButton = screen.getByRole("button");
+    fireEvent.click(closeButton);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes subtree when re-rendered with show=false", () => {
+    const { rerender, container } = render(
+      <Modal show={true} onClose={vi.fn()}>
+        <div>Modal Content</div>
+      </Modal>
+    );
+
+    expect(screen.getByText("Modal Content")).toBeInTheDocument();
+
+    rerender(
+      <Modal show={false} onClose={vi.fn()}>
+        <div>Modal Content</div>
+      </Modal>
+    );
+
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText("Modal Content")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #98

### Changes
- Added `tests/components/Modal.test.jsx` covering the `Modal` component:
  - Asserts that `show=false` returns `null` and renders nothing to the DOM.
  - Asserts that `show=true` renders child content and the close button.
  - Asserts that clicking the close button triggers the `onClose` callback exactly once.
  - Asserts that re-rendering with `show=false` cleanly unmounts and removes the subtree from the DOM.

### Verification
- `npm run test` passes (40 tests passing).
- `npm run type-check` passes.
- `npm run lint` passes.