### PR TITLE
fix(contact): render persistent error message on failure and clear on success (closes #81)

### DIFF
--- a/app/(landingpage)/ContactUs.jsx
+++ b/app/(landingpage)/ContactUs.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useRef } from "react";
+import { useState } from "react";
 import { FaGithub, FaTwitter, FaDiscord } from "react-icons/fa";
 import sendMail from "../../lib/sendmail";
 
@@ -33,7 +33,6 @@ const ContactUs = () => {
   const [toast, setToast] = useState({ show: false, message: "" });
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
-  const form = useRef();
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -43,11 +42,13 @@ const ContactUs = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setIsLoading(true);
+    setError(null);
     try {
       await sendMail(formData);
       showToast("Message sent successfully!");
       setFormData({ name: "", email: "", message: "" });
-    } catch (error) {
+      setError(null);
+    } catch (err) {
       setError("Failed to send message.");
       showToast("Unable to send message, please try again later");
     }
@@ -145,6 +146,15 @@ const ContactUs = () => {
               required
             />
           </div>
+          {error && (
+            <div
+              role="alert"
+              aria-live="polite"
+              className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg"
+            >
+              {error}
+            </div>
+          )}
           <button
             type="submit"
             className="w-full bg-purple-700 hover:bg-purple-600 text-white font-bold py-3 px-4 rounded-lg transition duration-300 ease-in-out flex items-center justify-center"

--- a/tests/components/ContactUs.test.tsx
+++ b/tests/components/ContactUs.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ContactUs from "../../app/(landingpage)/ContactUs";
+import sendMail from "../../lib/sendmail";
+
+vi.mock("../../lib/sendmail", () => ({
+  default: vi.fn(),
+}));
+
+describe("ContactUs component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the contact form properly", () => {
+    render(<ContactUs />);
+    expect(screen.getByPlaceholderText("Your Name")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Your Email")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Your Message")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /send message/i })).toBeInTheDocument();
+  });
+
+  it("shows persistent error message when sendMail fails", async () => {
+    vi.mocked(sendMail).mockRejectedValueOnce(new Error("Network error"));
+
+    render(<ContactUs />);
+
+    fireEvent.change(screen.getByPlaceholderText("Your Name"), {
+      target: { value: "John Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Your Email"), {
+      target: { value: "john@example.com" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Your Message"), {
+      target: { value: "Hello world" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /send message/i }));
+
+    await waitFor(() => {
+      const errorAlert = screen.getByRole("alert");
+      expect(errorAlert).toBeInTheDocument();
+      expect(errorAlert).toHaveTextContent("Failed to send message.");
+    });
+  });
+
+  it("clears the error message when a subsequent submission succeeds", async () => {
+    vi.mocked(sendMail).mockRejectedValueOnce(new Error("Network error"));
+
+    render(<ContactUs />);
+
+    fireEvent.change(screen.getByPlaceholderText("Your Name"), {
+      target: { value: "John Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Your Email"), {
+      target: { value: "john@example.com" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Your Message"), {
+      target: { value: "Hello world" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /send message/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Failed to send message.");
+    });
+
+    // Now second submit succeeds
+    vi.mocked(sendMail).mockResolvedValueOnce({ status: 200, text: "OK" });
+
+    fireEvent.change(screen.getByPlaceholderText("Your Name"), {
+      target: { value: "John Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Your Email"), {
+      target: { value: "john@example.com" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Your Message"), {
+      target: { value: "Hello again" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /send message/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes #81.

In `app/(landingpage)/ContactUs.jsx`:
- Renders the `error` state visibly in an accessible alert region (`role="alert"`, `aria-live="polite"`) beneath the form inputs when `sendMail` fails.
- Clears the error state on retry and upon successful message submission.
- Removes the unused `form` `useRef()` declaration that was never attached to the DOM element.
- Adds comprehensive unit/component tests in `tests/components/ContactUs.test.tsx` verifying initial rendering, error rendering on failure, and automatic error clearing on successful retry.

## Validation
- `npm test` passed (39 tests passed across 3 test suites).
- `npm run type-check` passed cleanly.
