### PR TITLE
docs: remove stale PUBLIC_MERCHANT_ADDRESS references from README (closes #47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,6 @@ NEXT_PUBLIC_CHECKOUT_CONTRACT_ID=
 
 # USDC token contract (testnet default; set for mainnet)
 # NEXT_PUBLIC_USDC_CONTRACT_ID=CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA
-
-# Display-only: the merchant wallet that receives USDC payments.
-# The authoritative value lives on-chain, set during contract initialize.
-# PUBLIC_MERCHANT_ADDRESS=
 ```
 
 ### 4. Run the local dev server
@@ -469,7 +465,6 @@ It prints the `NEXT_PUBLIC_CHECKOUT_CONTRACT_ID` to paste into `.env.local`.
 | `NEXT_PUBLIC_CHECKOUT_CONTRACT_ID`    | yes*     | Deployed checkout contract (C…)           |
 | `NEXT_PUBLIC_USDC_CONTRACT_ID`        | no       | USDC token contract (testnet default)     |
 | `NEXT_PUBLIC_NATIVE_ASSET_CONTRACT_ID`| no       | Native XLM SAC (verified testnet default) |
-| `PUBLIC_MERCHANT_ADDRESS`             | no       | Display-only merchant wallet (on-chain value is authoritative) |
 | `NEXT_PUBLIC_SUPABASE_URL`            | yes      | Supabase project URL                      |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY`       | yes      | Supabase anon/public key                  |
 | `NEXT_PUBLIC_ADMIN_EMAILS`            | no       | Comma-separated admin emails              |


### PR DESCRIPTION
## Summary
Closes #47

Removes stale, unused `PUBLIC_MERCHANT_ADDRESS` references from `README.md`.

## Context & Rationale
- `PUBLIC_MERCHANT_ADDRESS` was referenced in the quick-start env block (as a commented line) and in the Environment Variables reference table.
- However, no application code reads this environment variable, and it is untemplated in `.env.local.example`.
- In the Mova Store architecture, the merchant recipient address is set authoritatively on-chain during Soroban contract `initialize` (`--merchant <ADDRESS>`), making client-side environment variable configuration unnecessary.

## Changes
1. **`README.md` (Quick-start env block)**: Removed the commented `# PUBLIC_MERCHANT_ADDRESS=` and its description.
2. **`README.md` (Environment Variables table)**: Removed the `PUBLIC_MERCHANT_ADDRESS` table row so all documented variables align with `.env.local.example`.

## Verification & Acceptance Criteria
- [x] `grep -rn 'MERCHANT_ADDRESS' README.md .env.local.example lib` returns only the intended on-chain reference in the deployment walkthrough (`--merchant G...YOUR_MERCHANT_ADDRESS...`).
- [x] Every environment variable listed in the README table exists in `.env.local.example`.
- [x] Clean documentation diff with zero side effects.
