### PR TITLE
ci: make dedicated TypeScript type-check step fail CI on errors (closes #51)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
         run: npm run lint
 
       - name: Type check
-        run: npx tsc --noEmit --skipLibCheck
-        continue-on-error: true # Allow to pass while fixing type errors
+        run: npm run type-check
 
       - name: Run tests
         run: npm run test


### PR DESCRIPTION
## Summary
Closes #51

Makes the dedicated TypeScript type check step strictly gating in CI rather than ignoring errors via `continue-on-error: true`.

## Context & Rationale
- The frontend CI job previously executed `npx tsc --noEmit --skipLibCheck` with `continue-on-error: true`.
- Consequently, type errors did not fail this step; they were only caught downstream during `next build`, defeating the purpose of an isolated fast type verification step.
- Calling the defined package script (`npm run type-check`) ensures standard script invocation matching local developer workflows.

## Changes
- **`.github/workflows/ci.yml`**:
  - Removed `continue-on-error: true`.
  - Replaced inline `npx tsc --noEmit --skipLibCheck` with `npm run type-check`.

## Verification & Acceptance Criteria
- [x] `.github/workflows/ci.yml:35-37` shows a required type-check step with no `continue-on-error`.
- [x] Uses the canonical `npm run type-check` script from `package.json`.
- [x] Clean workflow diff with zero side effects.
