### PR TITLE
ci: enforce npm audit failure on high-severity vulnerabilities (closes #50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,6 @@ jobs:
 
       - name: Audit dependencies
         run: npm audit --audit-level=high
-        continue-on-error: true # Report but don't fail yet
 
       - name: Check for secrets
         uses: trufflesecurity/trufflehog@main


### PR DESCRIPTION
## Summary
Closes #50

Ensures `npm audit` failures strictly gate the CI pipeline on high-severity vulnerabilities, honoring the documented policy in `SECURITY.md`.

## Context & Rationale
- `SECURITY.md:77` explicitly states: `CI pipeline fails on high-severity vulnerabilities`.
- However, `.github/workflows/ci.yml:107-108` previously specified `continue-on-error: true # Report but don't fail yet`, allowing jobs with high-severity vulnerabilities to report success.
- Removing `continue-on-error: true` restores alignment between the published security policy and automated CI checks.

## Changes
- **`.github/workflows/ci.yml`**: Removed `continue-on-error: true` from the `Audit dependencies` step under the `security` job.

## Verification & Acceptance Criteria
- [x] `ci.yml` security job's `npm audit` step has no `continue-on-error`.
- [x] High-severity vulnerability alerts now accurately gate CI completion.
- [x] Matches `SECURITY.md:77` security specification.
