### PR TITLE
ci: add cargo fmt and clippy steps to contracts CI job (closes #52)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: wasm32v1-none
+          components: rustfmt, clippy
 
       - name: Cache Cargo
         uses: actions/cache@v4
@@ -79,6 +80,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-
             ${{ runner.os }}-cargo-
+
+      - name: Check Rust formatting
+        working-directory: contracts/checkout
+        run: cargo fmt -- --check
+
+      - name: Run Clippy lints
+        working-directory: contracts/checkout
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Build contracts
         working-directory: contracts/checkout


### PR DESCRIPTION
## Summary
Closes #52

Enforces Rust formatting (`cargo fmt -- --check`) and clippy lints (`cargo clippy --all-targets -- -D warnings`) in the contracts CI job.

## Context & Rationale
- `CONTRIBUTING.md:129-143` mandates contributors run `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings` before submitting contract pull requests.
- Previously, the `contracts` workflow job only executed `cargo build` and `cargo test`, allowing formatting drift and clippy warnings to pass undetected.
- Adding these automated checks ensures pull requests adhere strictly to the repository standards.

## Changes
- **`.github/workflows/ci.yml`**:
  - Added `rustfmt, clippy` to `components` in `dtolnay/rust-toolchain`.
  - Added `Check Rust formatting` step (`cargo fmt -- --check`).
  - Added `Run Clippy lints` step (`cargo clippy --all-targets -- -D warnings`).

## Verification & Acceptance Criteria
- [x] `.github/workflows/ci.yml` contracts job contains both formatting and clippy steps.
- [x] Toolchain includes `rustfmt` and `clippy` components.
- [x] Gating prevents unformatted or lint-failing Soroban contract code from merging.
