### PR TITLE
fix(env): make validateEnv throw an error on missing required environment variables (closes #36)

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -217,6 +217,9 @@ export function validateEnv(): EnvConfig {
       `\n⚠️  Environment Configuration Errors:\n${errorList}\n\n` +
         `Please copy .env.local.example to .env.local and fill in the required values.\n`
     );
+    throw new Error(
+      `Environment configuration errors:\n${errorList}\n\nPlease copy .env.local.example to .env.local and fill in the required values.`
+    );
   }
 
   return { stellar, emailjs, supabase, admin };

--- a/tests/lib/env.test.ts
+++ b/tests/lib/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { isAdminEmail, isDevelopment, isProduction } from "../../lib/env";
+import { isAdminEmail, isDevelopment, isProduction, validateEnv } from "../../lib/env";
 
 describe("isAdminEmail", () => {
   beforeEach(() => {
@@ -58,5 +58,45 @@ describe("isProduction", () => {
   it("returns false in development", () => {
     vi.stubEnv("NODE_ENV", "development");
     expect(isProduction()).toBe(false);
+  });
+});
+
+describe("validateEnv", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("throws an error naming missing fields when required variables are unset", () => {
+    // Ensure required env vars are empty/unset
+    vi.stubEnv("NEXT_PUBLIC_CHECKOUT_CONTRACT_ID", "");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_SERVICE_ID", "");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_TEMPLATE_ID", "");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_PUBLIC_KEY", "");
+
+    expect(() => validateEnv()).toThrowError(/NEXT_PUBLIC_CHECKOUT_CONTRACT_ID/);
+    expect(() => validateEnv()).toThrowError(/NEXT_PUBLIC_SUPABASE_URL/);
+    expect(() => validateEnv()).toThrowError(/NEXT_PUBLIC_SUPABASE_ANON_KEY/);
+  });
+
+  it("returns populated configuration when all required environment variables are set", () => {
+    vi.stubEnv("NEXT_PUBLIC_CHECKOUT_CONTRACT_ID", "CA1234567890TESTCONTRACTID");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://project.supabase.co");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key-123");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_SERVICE_ID", "service_abc");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_TEMPLATE_ID", "template_xyz");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_PUBLIC_KEY", "pubkey_789");
+    vi.stubEnv("NEXT_PUBLIC_ADMIN_EMAILS", "admin@store.org");
+
+    const config = validateEnv();
+
+    expect(config.stellar.checkoutContractId).toBe("CA1234567890TESTCONTRACTID");
+    expect(config.supabase.url).toBe("https://project.supabase.co");
+    expect(config.supabase.anonKey).toBe("test-anon-key-123");
+    expect(config.emailjs.serviceId).toBe("service_abc");
+    expect(config.emailjs.templateId).toBe("template_xyz");
+    expect(config.emailjs.publicKey).toBe("pubkey_789");
+    expect(config.admin.adminEmails).toContain("admin@store.org");
   });
 });


### PR DESCRIPTION
## Summary
Closes #36

Updates `validateEnv` in `lib/env.ts` to throw an `Error` listing missing fields when required environment variables are absent, and adds unit tests covering error throwing and successful config population.

## Context & Rationale
- `validateEnv` JSDoc states it *"Throws an error with details about missing configuration"*.
- Previously, `validateEnv` only called `console.error` and returned an incomplete config object with empty strings for required parameters, masking misconfiguration during runtime.
- Throwing an explicit `Error` with the aggregated missing fields prevents silent failures and matches the documented API contract.

## Changes
- **`lib/env.ts`**: Added `throw new Error(...)` listing missing configuration fields when `errors.length > 0`.
- **`tests/lib/env.test.ts`**: Added a `describe("validateEnv")` test suite verifying that:
  1. `validateEnv()` throws and names missing fields when required variables are unset.
  2. `validateEnv()` returns the fully populated config when all required variables are set.

## Verification & Acceptance Criteria
- [x] With `NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY`/`NEXT_PUBLIC_CHECKOUT_CONTRACT_ID` unset, `validateEnv()` rejects and error message names the missing fields.
- [x] With all required vars stubbed, `validateEnv()` returns the populated config.
- [x] Unit tests pass cleanly.
