### PR TITLE
feat(db): add idempotent supabase/seed.sql with sample products (closes #44)

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -4,9 +4,10 @@
 2. Copy **Project URL** and **anon public** key into `.env.local`:
    - `NEXT_PUBLIC_SUPABASE_URL`
    - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
-3. In the SQL editor, run [`schema.sql`](./schema.sql).
-4. Auth → Providers: enable **Email** (and **Google** if you want OAuth).
-5. Auth → URL Configuration: add `http://localhost:3000/**` (and your production URL).
-6. Restart `npm run dev`.
+3. In the SQL editor, run [`schema.sql`](./schema.sql) to create the database tables, indices, and RLS policies.
+4. (Optional) In the SQL editor, run [`seed.sql`](./seed.sql) to populate sample sneaker products for local development and testing.
+5. Auth → Providers: enable **Email** (and **Google** if you want OAuth).
+6. Auth → URL Configuration: add `http://localhost:3000/**` (and your production URL).
+7. Restart `npm run dev`.
 
 Products live in the `products` table; images in the public `products` storage bucket.

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,45 @@
+-- Mova Store — Sample Products Seed Data
+-- Run this after schema.sql in Supabase SQL Editor (Dashboard → SQL → New query)
+-- Idempotent: safe to run multiple times without duplicate key errors
+
+insert into public.products (id, name, price, img, created_at)
+values
+  (
+    'a0000000-0000-0000-0000-000000000001',
+    'Velocity Runner Nitro',
+    129.99,
+    'https://images.unsplash.com/photo-1542291026-7eec264c27ff?auto=format&fit=crop&w=600&q=80',
+    now() - interval '5 days'
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000002',
+    'Cloud Stratus Pulse',
+    145.00,
+    'https://images.unsplash.com/photo-1551107696-a4b0c5a0d9a2?auto=format&fit=crop&w=600&q=80',
+    now() - interval '4 days'
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000003',
+    'Aero Trail Pro',
+    160.50,
+    'https://images.unsplash.com/photo-1608231387042-66d1773070a5?auto=format&fit=crop&w=600&q=80',
+    now() - interval '3 days'
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000004',
+    'Urban Glide Classic',
+    95.00,
+    'https://images.unsplash.com/photo-1525966222134-fcfa99b8ae77?auto=format&fit=crop&w=600&q=80',
+    now() - interval '2 days'
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000005',
+    'Stellar Echo High-Top',
+    179.99,
+    'https://images.unsplash.com/photo-1575537302964-96cd47c06b1b?auto=format&fit=crop&w=600&q=80',
+    now() - interval '1 day'
+  )
+on conflict (id) do update set
+  name = excluded.name,
+  price = excluded.price,
+  img = excluded.img;


### PR DESCRIPTION
## Summary
Closes #44

Adds a deterministic, re-runnable `supabase/seed.sql` populated with 5 sample sneaker products and documents the execution sequence in `supabase/README.md`.

## Context & Rationale
- Setting up a fresh development clone previously resulted in an empty catalog because the repository lacked seed data. Adding sample items manually required logging in and configuring `NEXT_PUBLIC_ADMIN_EMAILS`.
- Since `public.products.img` accepts standard image URLs and the catalog table has an open public-read RLS policy (`using (true)`), developers can seed sample products without needing storage bucket uploads.

## Changes
- **`supabase/seed.sql`**:
  - Inserted 5 sample sneaker products with deterministic UUIDs, names, valid numerical prices (`numeric(12,2)`), and high-resolution HTTPS image URLs.
  - Implemented `ON CONFLICT (id) DO UPDATE` to ensure safe, idempotent re-runs without duplicate-key collisions.
- **`supabase/README.md`**:
  - Documented running `schema.sql` first followed by `seed.sql` for sample data initialization.

## Verification & Acceptance Criteria
- [x] `supabase/seed.sql` re-runs safely without duplicate-key errors.
- [x] Sample rows are readable under the anon public-read RLS policy without authentication.
- [x] `supabase/README.md` documents the seed step alongside the schema setup.
