### PR TITLE
fix(checkout): compare OTP against zero-padded 6-digit value

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -21,6 +21,7 @@ import {
 import { BsBank, BsCalendarDate } from "react-icons/bs";
 import { SiKlarna } from "react-icons/si";
 import sendMail from "../../lib/sendmail";
+import { validateOTP } from "../../lib/validation";
 import StellarCheckoutButton from "../../components/StellarCheckoutButton";
 import StellarWalletButton from "../../components/StellarWalletButton";
 import StellarOrderWatch from "../../components/StellarOrderWatch";
@@ -28,7 +29,12 @@ import { SiStellar } from "react-icons/si";
 
 const Checkout = () => {
 
-  const [otp, setOtp] = useState(Math.floor(Math.random() * 1000000) + 1);
+  // OTP is stored as a zero-padded 6-digit string so it always matches the format
+  // shown in the email (e.g. "000042") and can be compared with exact string
+  // equality instead of a loose numeric parse.
+  const [otp, setOtp] = useState<string>(() =>
+    String(Math.floor(Math.random() * 1000000)).padStart(6, "0")
+  );
   const [totalPrice, setTotalPrice] = useState(0);
   const [toast, setToast] = useState({ show: false, message: "" });
   const [stage, setStage] = useState(1);
@@ -97,7 +103,14 @@ const Checkout = () => {
   const handleEmailConfirmationSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsOtpSending(true);
-    if (parseInt(enteredOtp) === otp) {
+    // Validate the raw trimmed input as a 6-digit code, then compare it against the
+    // zero-padded OTP with exact string equality. We deliberately compare the raw
+    // input rather than validateOTP's sanitized value, because the validator strips
+    // non-digits ("000042abc" -> "000042") and would otherwise let digits-followed-
+    // by-junk through.
+    const entered = enteredOtp.trim();
+    const { isValid } = validateOTP(entered);
+    if (isValid && entered === otp) {
       setStage(3);
       localStorage.clear();
       showToast("OTP confirmed successfully.");
@@ -365,6 +378,9 @@ const Checkout = () => {
                     value={enteredOtp}
                     onChange={handleOtpChange}
                     required
+                    maxLength={6}
+                    inputMode="numeric"
+                    pattern="[0-9]{6}"
                     placeholder="OTP"
                     className="w-64 px-3 py-2 border rounded"
                   />


### PR DESCRIPTION
## Summary

Fixes the checkout OTP validation flaw described in #76.

The checkout OTP flow had two problems in `app/checkout/page.tsx`:

1. **Non-padded OTP** — the code generated the OTP as a raw number
   (`Math.floor(Math.random() * 1000000) + 1`), so it was never
   zero-padded and could even be 7 digits. A legitimate code like
   `000042` could never be entered/matched.
2. **Loose comparison** — validation used `parseInt(enteredOtp) === otp`,
   which silently accepts trailing junk (`"123x"`, `"123.4"` → `123`).

## Changes

- Store the OTP as a **zero-padded 6-digit string**
  (`String(Math.floor(Math.random() * 1000000)).padStart(6, "0")`,
  range `0..999999`, always exactly 6 digits including `000042`).
- Validate the **raw trimmed input** with the existing (already exported
  and unit-tested) `validateOTP()` from `lib/validation.ts`, then compare
  it against the padded OTP with **exact string equality**.
  - Subtle point: `validateOTP` *strips* non-digits, so its sanitized
    output would turn `"000042abc"` into `"000042"`. This fix compares the
    **raw** trimmed value (`entered === otp`), not the sanitized one, so
    digits-followed-by-junk is correctly rejected.
- Add `maxLength={6}`, `inputMode="numeric"`, `pattern="[0-9]{6}"` to the
  OTP input for better UX and client-side guarding.

Single file changed, no schema / API / contract changes.

## Acceptance criteria coverage

| Case | Result |
| --- | --- |
| Wrong numeric OTP | rejected (`entered !== otp`) |
| Digits followed by junk (`"123456x"`) | rejected (raw value `!==` padded string) |
| Correct zero-padded OTP (`000042`) | accepted (string equality) |
| Letters-only / empty / wrong length | rejected (`validateOTP` fails) |

## Verification

Run in the repo:

- `npx tsc --noEmit --skipLibCheck` — no errors in checkout.
- `npm run test` — **36/36 vitest tests pass** (includes the existing
  `validateOTP` suite in `tests/lib/validation.test.ts`, which already
  covers 6-digit acceptance, `000000`, and rejection of empty / short /
  long / non-digit input).
- `npx next lint --file app/checkout/page.tsx` — no ESLint warnings or
  errors.

The diff is intentionally minimal (only OTP-related lines) to keep review
clean.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
