### PR TITLE
fix(deps): remove unused placeholder fs dependency from package.json (closes #16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@stellar/stellar-sdk": "^16.2.0",
         "@supabase/supabase-js": "^2.112.3",
         "@vercel/og": "^0.6.2",
-        "fs": "^0.0.1-security",
         "next": "14.2.5",
         "next-auth": "^4.24.7",
         "nextjs-toploader": "^1.6.12",
@@ -5178,11 +5177,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@stellar/stellar-sdk": "^16.2.0",
     "@supabase/supabase-js": "^2.112.3",
     "@vercel/og": "^0.6.2",
-    "fs": "^0.0.1-security",
     "next": "14.2.5",
     "next-auth": "^4.24.7",
     "nextjs-toploader": "^1.6.12",


### PR DESCRIPTION
## Summary
Resolves #16 by removing the unneeded placeholder `fs: ^0.0.1-security` dependency from `package.json` and pruning it from `package-lock.json`.

### Changes
- Removed placeholder `"fs": "^0.0.1-security"` from `package.json` dependencies.
- Pruned `node_modules/fs` from `package-lock.json`.

Closes #16
Bounty: 5