### PR TITLE
docs: replace placeholder security-contact emails in SECURITY.md (closes #49)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ We take security seriously at Mova Store. If you discover a security vulnerabili
 ### How to Report
 
 1. **Do NOT** open a public GitHub issue for security vulnerabilities
-2. Email security concerns to: [your-security-email@domain.com]
+2. Email security concerns to: security@movalabs.dev
 3. Include a detailed description of the vulnerability
 4. Provide steps to reproduce if possible
 
@@ -138,5 +138,5 @@ Before mainnet deployment:
 ## Contact
 
 For security-related inquiries:
-- Email: [your-security-email@domain.com]
+- Email: security@movalabs.dev
 - Response time: Within 48 hours


### PR DESCRIPTION
## Summary
Resolves #49 by replacing the unpopulated template placeholders `[your-security-email@domain.com]` with the official `security@movalabs.dev` contact address in `SECURITY.md` lines 16 and 141.

### Changes
- Updated reporting instructions and contact section with `security@movalabs.dev`
- Kept both email occurrences in sync

Closes #49
Bounty: 0