### PR TITLE
ci: add per-job timeout-minutes bounds to every CI job (closes #101)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
   frontend:
     name: Frontend (Lint, Type Check, Test, Build)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -55,6 +56,7 @@ jobs:
   contracts:
     name: Soroban Contracts (Build, Test)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -92,6 +94,7 @@ jobs:
   security:
     name: Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -116,6 +119,7 @@ jobs:
   rust-security:
     name: Rust Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -139,6 +143,7 @@ jobs:
     name: CI Success
     needs: [frontend, contracts, security]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always()
 
     steps:


### PR DESCRIPTION
## Summary
Resolves #101 by configuring explicit `timeout-minutes` on every job in `.github/workflows/ci.yml` to prevent hung builds, dependency installs, or network calls from consuming runner minutes.

### Changes
- `frontend`: `timeout-minutes: 20`
- `contracts`: `timeout-minutes: 30`
- `security`: `timeout-minutes: 15`
- `rust-security`: `timeout-minutes: 30`
- `ci-success`: `timeout-minutes: 5`

Closes #101
Bounty: 0