### PR TITLE
test: add unit tests for ScVal conversion helpers in lib/stellar/scval.ts (closes #11)

### DIFF
--- a/lib/stellar/scval.ts
+++ b/lib/stellar/scval.ts
@@ -14,7 +14,7 @@ export function i128ToScVal(value: bigint | number | string): xdr.ScVal {
   const v = BigInt(value);
   const mask = BigInt("0xffffffffffffffff");
   const lo = new xdr.Uint64(BigInt.asUintN(64, v & mask));
-  const hi = new xdr.Int64(BigInt.asUintN(64, v >> BigInt(64)));
+  const hi = new xdr.Int64(BigInt.asIntN(64, v >> BigInt(64)));
   return xdr.ScVal.scvI128(new xdr.Int128Parts({ lo, hi }));
 }
 

--- a/tests/lib/stellar/scval.test.ts
+++ b/tests/lib/stellar/scval.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { nativeToScVal, xdr } from "@stellar/stellar-sdk";
+import {
+  i128ToScVal,
+  bytes32ToScVal,
+  addressToScVal,
+  symbolToScVal,
+  scValToString,
+  scValToNativeSafe,
+  hexToBytes,
+  bytesToHex,
+  hashOrderId,
+} from "../../../lib/stellar/scval";
+
+describe("ScVal helpers", () => {
+  describe("i128ToScVal", () => {
+    it("matches nativeToScVal XDR base64 for key boundary values", () => {
+      const cases = [
+        0n,
+        1n,
+        -1n,
+        (1n << 64n) - 1n,
+        1n << 64n,
+        -(1n << 63n),
+        (1n << 127n) - 1n,
+        -(1n << 127n),
+      ];
+
+      for (const val of cases) {
+        const customScVal = i128ToScVal(val);
+        const nativeScVal = nativeToScVal(val, { type: "i128" });
+        expect(customScVal.toXDR("base64")).toBe(nativeScVal.toXDR("base64"));
+      }
+    });
+
+    it("accepts number and string inputs", () => {
+      expect(i128ToScVal(100).toXDR("base64")).toBe(
+        nativeToScVal(100n, { type: "i128" }).toXDR("base64")
+      );
+      expect(i128ToScVal("5000000").toXDR("base64")).toBe(
+        nativeToScVal(5000000n, { type: "i128" }).toXDR("base64")
+      );
+    });
+  });
+
+  describe("bytes32ToScVal", () => {
+    it("accepts exactly 32-byte Uint8Array", () => {
+      const bytes = new Uint8Array(32).fill(7);
+      const scVal = bytes32ToScVal(bytes);
+      expect(scVal.switch()).toBe(xdr.ScValType.scvBytes());
+      expect(scVal.bytes().length).toBe(32);
+    });
+
+    it("accepts 64-character hex string", () => {
+      const hex = "ab".repeat(32);
+      const scVal = bytes32ToScVal(hex);
+      expect(scVal.switch()).toBe(xdr.ScValType.scvBytes());
+      expect(scVal.bytes().length).toBe(32);
+    });
+
+    it("throws on inputs not equal to 32 bytes", () => {
+      expect(() => bytes32ToScVal(new Uint8Array(31))).toThrow(
+        "order_id must be exactly 32 bytes (got 31)"
+      );
+      expect(() => bytes32ToScVal(new Uint8Array(33))).toThrow(
+        "order_id must be exactly 32 bytes (got 33)"
+      );
+      expect(() => bytes32ToScVal("aabbcc")).toThrow("order_id must be exactly 32 bytes");
+    });
+  });
+
+  describe("hexToBytes and bytesToHex", () => {
+    it("round-trips hex and bytes with normalized lowercase output", () => {
+      const hex = "a1B2c3";
+      const bytes = hexToBytes(hex);
+      expect(bytesToHex(bytes)).toBe("a1b2c3");
+    });
+
+    it("throws on odd-length hex strings", () => {
+      expect(() => hexToBytes("123")).toThrow("invalid hex string (odd length)");
+    });
+  });
+
+  describe("scValToString and scValToNativeSafe", () => {
+    it("decodes symbols, strings, and booleans", () => {
+      expect(scValToString(symbolToScVal("TEST"))).toBe("TEST");
+      expect(scValToString(xdr.ScVal.scvString("hello"))).toBe("hello");
+      expect(scValToString(xdr.ScVal.scvBool(true))).toBe("true");
+    });
+
+    it("decodes negative i128 correctly", () => {
+      const scVal = i128ToScVal(-123n);
+      expect(scValToString(scVal)).toBe("-123");
+      expect(scValToNativeSafe(scVal)).toBe(-123n);
+    });
+
+    it("decodes bytes to hex string", () => {
+      const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+      const scVal = xdr.ScVal.scvBytes(Buffer.from(bytes));
+      expect(scValToString(scVal)).toBe("deadbeef");
+    });
+  });
+
+  describe("hashOrderId", () => {
+    it("deterministically returns a 32-byte Uint8Array", async () => {
+      const hash1 = await hashOrderId("order_12345");
+      const hash2 = await hashOrderId("order_12345");
+      expect(hash1).toBeInstanceOf(Uint8Array);
+      expect(hash1.length).toBe(32);
+      expect(hash1).toEqual(hash2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Resolves #11 by adding comprehensive unit tests for the ScVal construction and decoding helpers in `lib/stellar/scval.ts` and fixing negative i128 hi-part sign handling.

### Changes
- Fixed `i128ToScVal` high 64-bit part using `BigInt.asIntN(64, ...)` so negative i128 values encode cleanly into `xdr.Int64` without RangeErrors.
- Added `tests/lib/stellar/scval.test.ts` verifying:
  - Base64 parity of `i128ToScVal` against `nativeToScVal(v, { type: 'i128' })` across all boundary values (`0`, `1`, `-1`, `2^64-1`, `2^64`, `-2^63`, `2^127-1`, `-2^127`).
  - `bytes32ToScVal` exact 32-byte Uint8Array / 64-char hex support and length error guards.
  - `hexToBytes` / `bytesToHex` roundtrip and lowercase normalization.
  - `scValToString` and `scValToNativeSafe` decoding for negative i128, symbols, and bytes.
  - `hashOrderId` deterministic 32-byte digest generation.

All 11 tests passing.

Closes #11
Bounty: 5