### PR TITLE
fix(cart): handle corrupt localStorage payloads during CartProvider hydration (closes #21)

### DIFF
--- a/context/CartContext.jsx
+++ b/context/CartContext.jsx
@@ -11,10 +11,45 @@ export const CartProvider = ({ children }) => {
   const [totalPrice, setTotalPrice] = useState(0);
 
   useEffect(() => {
-    const storedCartItems = JSON.parse(localStorage.getItem("cartItems")) || [];
-    const storedItemCount = parseInt(localStorage.getItem("itemCount")) || 0;
-    const storedTotalPrice =
-      parseFloat(localStorage.getItem("totalPrice")) || 0;
+    let storedCartItems = [];
+    let storedItemCount = 0;
+    let storedTotalPrice = 0;
+
+    try {
+      const rawItems = localStorage.getItem("cartItems");
+      if (rawItems) {
+        const parsed = JSON.parse(rawItems);
+        if (Array.isArray(parsed)) {
+          storedCartItems = parsed;
+        }
+      }
+    } catch {
+      storedCartItems = [];
+    }
+
+    try {
+      const rawCount = localStorage.getItem("itemCount");
+      if (rawCount) {
+        const parsedCount = parseInt(rawCount, 10);
+        if (Number.isFinite(parsedCount) && parsedCount >= 0) {
+          storedItemCount = parsedCount;
+        }
+      }
+    } catch {
+      storedItemCount = 0;
+    }
+
+    try {
+      const rawPrice = localStorage.getItem("totalPrice");
+      if (rawPrice) {
+        const parsedPrice = parseFloat(rawPrice);
+        if (Number.isFinite(parsedPrice) && parsedPrice >= 0) {
+          storedTotalPrice = parsedPrice;
+        }
+      }
+    } catch {
+      storedTotalPrice = 0;
+    }
 
     setCartItems(storedCartItems);
     setItemCount(storedItemCount);

--- a/tests/context/CartContext.test.jsx
+++ b/tests/context/CartContext.test.jsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { CartProvider, useCart } from "../../context/CartContext";
+
+function TestConsumer() {
+  const { cartItems, itemCount, totalPrice } = useCart();
+  return (
+    <div>
+      <span data-testid="count">{itemCount}</span>
+      <span data-testid="total">{totalPrice}</span>
+      <span data-testid="items-length">{cartItems.length}</span>
+    </div>
+  );
+}
+
+describe("CartProvider hydration error handling", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("mounts without throwing and falls back to empty cart when cartItems is corrupt JSON", async () => {
+    localStorage.setItem("cartItems", "{broken");
+    localStorage.setItem("itemCount", "invalid");
+    localStorage.setItem("totalPrice", "NaN");
+
+    render(
+      <CartProvider>
+        <TestConsumer />
+      </CartProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("count").textContent).toBe("0");
+      expect(screen.getByTestId("total").textContent).toBe("0");
+      expect(screen.getByTestId("items-length").textContent).toBe("0");
+    });
+  });
+
+  it("safely ignores non-array JSON stored in cartItems", async () => {
+    localStorage.setItem("cartItems", JSON.stringify({ not: "an array" }));
+
+    render(
+      <CartProvider>
+        <TestConsumer />
+      </CartProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("items-length").textContent).toBe("0");
+    });
+  });
+
+  it("hydrates valid cart items and totals cleanly", async () => {
+    const sampleItems = [{ id: "prod_1", name: "Shirt", price: 25.5 }];
+    localStorage.setItem("cartItems", JSON.stringify(sampleItems));
+    localStorage.setItem("itemCount", "1");
+    localStorage.setItem("totalPrice", "25.5");
+
+    render(
+      <CartProvider>
+        <TestConsumer />
+      </CartProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("count").textContent).toBe("1");
+      expect(screen.getByTestId("total").textContent).toBe("25.5");
+      expect(screen.getByTestId("items-length").textContent).toBe("1");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Resolves #21 by wrapping `localStorage` reads during `CartProvider` mount in individual `try/catch` blocks, validating that `cartItems` parses to a valid array and that `itemCount` / `totalPrice` parse to finite non-negative numbers, with graceful fallback to empty cart state on corrupt data.

### Changes
- Wrapped `cartItems`, `itemCount`, and `totalPrice` hydration in `try/catch` blocks.
- Added array check on parsed `cartItems` and `Number.isFinite` checks on numeric counters.
- Added unit tests in `tests/context/CartContext.test.jsx` verifying graceful fallback on corrupt JSON, non-array payloads, and successful hydration on valid entries.

Closes #21
Bounty: 0