### PR TITLE
fix(errors): map Supabase structured auth error codes in parseError (closes #34)

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -184,6 +184,15 @@ const STELLAR_ERRORS: Record<string, AppError> = {
 // Auth Error Messages (Supabase)
 // =============================================================================
 
+const SUPABASE_AUTH_CODE_MAP: Record<string, string> = {
+  user_already_exists: "User already registered",
+  email_exists: "User already registered",
+  invalid_credentials: "Invalid login credentials",
+  email_not_confirmed: "Email not confirmed",
+  weak_password: "Password should be at least 6 characters",
+  validation_failed: "Unable to validate email address: invalid format",
+};
+
 const AUTH_ERRORS: Record<string, AppError> = {
   "User already registered": {
     code: "AUTH_EMAIL_EXISTS",
@@ -297,8 +306,14 @@ export function parseError(error: unknown): AppError {
   if (error instanceof Error) {
     // Check for auth errors
     const authCode = (error as { code?: string }).code;
-    if (authCode && AUTH_ERRORS[authCode]) {
-      return AUTH_ERRORS[authCode];
+    if (authCode) {
+      if (AUTH_ERRORS[authCode]) {
+        return AUTH_ERRORS[authCode];
+      }
+      const mapped = SUPABASE_AUTH_CODE_MAP[authCode];
+      if (mapped && AUTH_ERRORS[mapped]) {
+        return AUTH_ERRORS[mapped];
+      }
     }
 
     return parseErrorMessage(error.message);

--- a/tests/lib/errors.test.ts
+++ b/tests/lib/errors.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { parseError } from "../../lib/errors";
+
+class MockAuthError extends Error {
+  code?: string;
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = "AuthError";
+    this.code = code;
+  }
+}
+
+describe("parseError Supabase structured auth error mapping", () => {
+  it("maps email_not_confirmed code even with generic error message", () => {
+    const error = new MockAuthError("An unexpected error occurred", "email_not_confirmed");
+    const parsed = parseError(error);
+    expect(parsed.code).toBe("AUTH_EMAIL_NOT_CONFIRMED");
+    expect(parsed.userMessage).toBe("Please confirm your email before signing in.");
+  });
+
+  it("maps user_already_exists code to AUTH_EMAIL_EXISTS", () => {
+    const error = new MockAuthError("Error", "user_already_exists");
+    const parsed = parseError(error);
+    expect(parsed.code).toBe("AUTH_EMAIL_EXISTS");
+    expect(parsed.action).toBe("Login");
+  });
+
+  it("maps invalid_credentials code to AUTH_INVALID_CREDENTIALS", () => {
+    const error = new MockAuthError("Auth failed", "invalid_credentials");
+    const parsed = parseError(error);
+    expect(parsed.code).toBe("AUTH_INVALID_CREDENTIALS");
+  });
+
+  it("maps weak_password code to AUTH_WEAK_PASSWORD", () => {
+    const error = new MockAuthError("Password rejected", "weak_password");
+    const parsed = parseError(error);
+    expect(parsed.code).toBe("AUTH_WEAK_PASSWORD");
+  });
+
+  it("still supports direct phrase matching fallback when code is missing", () => {
+    const error = new Error("User already registered");
+    const parsed = parseError(error);
+    expect(parsed.code).toBe("AUTH_EMAIL_EXISTS");
+  });
+});


### PR DESCRIPTION
## Summary
Resolves #34 by adding a Supabase Auth error code mapping layer to `lib/errors.ts` checked in `parseError` before fallback free-text matching.

### Changes
- Added `SUPABASE_AUTH_CODE_MAP` mapping snake_case Supabase auth codes (`user_already_exists`, `email_exists`, `invalid_credentials`, `email_not_confirmed`, `weak_password`, `validation_failed`) to their corresponding `AUTH_ERRORS` entries.
- Added `tests/lib/errors.test.ts` asserting that Errors carrying `code: 'email_not_confirmed'`, `'user_already_exists'`, `'invalid_credentials'`, and `'weak_password'` resolve directly to typed `AppError` records.

Closes #34
Bounty: 0