### PR TITLE
feat(accessibility): implement real WCAG AA relative luminance contrast check (closes #39)

### DIFF
--- a/lib/accessibility.ts
+++ b/lib/accessibility.ts
@@ -250,19 +250,58 @@ export function getAnimationDuration(normalDuration: number): number {
 // Color Contrast
 // =============================================================================
 
+function parseHexColor(hex: string): [number, number, number] | null {
+  let cleaned = hex.replace(/^#/, "").trim();
+  if (cleaned.length === 3) {
+    cleaned = cleaned
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+  if (cleaned.length !== 6) return null;
+  const num = parseInt(cleaned, 16);
+  if (isNaN(num)) return null;
+  return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
+}
+
+function getChannelLuminance(val: number): number {
+  const sRGB = val / 255;
+  return sRGB <= 0.04045
+    ? sRGB / 12.92
+    : Math.pow((sRGB + 0.055) / 1.055, 2.4);
+}
+
+/**
+ * Calculates the relative luminance of an sRGB color.
+ */
+export function getRelativeLuminance(hex: string): number {
+  const rgb = parseHexColor(hex);
+  if (!rgb) return 0;
+  const [r, g, b] = rgb.map(getChannelLuminance);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * Calculates the contrast ratio between two colors.
+ */
+export function getContrastRatio(foreground: string, background: string): number {
+  const l1 = getRelativeLuminance(foreground);
+  const l2 = getRelativeLuminance(background);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
 /**
  * Checks if a color combination meets WCAG AA contrast requirements.
- * Note: This is a simplified check. For production, use a proper contrast library.
+ * WCAG AA requires 4.5:1 for normal text, 3:1 for large text.
  */
 export function meetsContrastRequirement(
   foreground: string,
   background: string,
   largeText = false
 ): boolean {
-  // This is a placeholder. In production, implement proper contrast calculation.
-  // WCAG AA requires 4.5:1 for normal text, 3:1 for large text.
-  console.warn(
-    "meetsContrastRequirement is a placeholder. Implement proper contrast checking."
-  );
-  return true;
+  const ratio = getContrastRatio(foreground, background);
+  const threshold = largeText ? 3.0 : 4.5;
+  return ratio >= threshold;
 }

--- a/tests/lib/accessibility.test.ts
+++ b/tests/lib/accessibility.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  isFocusable,
+  getFocusableElements,
+  isVisible,
+  trapFocus,
+  generateAriaId,
+  ariaExpanded,
+  ariaLive,
+  ariaInvalid,
+  announceToScreenReader,
+  saveFocus,
+  focusFirstError,
+  prefersReducedMotion,
+  getAnimationDuration,
+  getRelativeLuminance,
+  getContrastRatio,
+  meetsContrastRequirement,
+} from "../../lib/accessibility";
+
+describe("Accessibility - Color Contrast & Luminance (#39)", () => {
+  it("calculates relative luminance correctly", () => {
+    expect(getRelativeLuminance("#000000")).toBe(0);
+    expect(getRelativeLuminance("#ffffff")).toBeCloseTo(1, 5);
+  });
+
+  it("calculates contrast ratio correctly", () => {
+    expect(getContrastRatio("#000000", "#ffffff")).toBeCloseTo(21, 1);
+    expect(getContrastRatio("#ffffff", "#ffffff")).toBeCloseTo(1, 1);
+  });
+
+  it("meetsContrastRequirement returns true for black on white", () => {
+    expect(meetsContrastRequirement("#000000", "#ffffff")).toBe(true);
+    expect(meetsContrastRequirement("#ffffff", "#000000")).toBe(true);
+  });
+
+  it("meetsContrastRequirement returns false for identical colors", () => {
+    expect(meetsContrastRequirement("#ffffff", "#ffffff")).toBe(false);
+    expect(meetsContrastRequirement("#000000", "#000000")).toBe(false);
+  });
+
+  it("meetsContrastRequirement handles ~3.8:1 pair like #828282 on #ffffff correctly with largeText flag", () => {
+    // #828282 on #ffffff has a contrast ratio around ~3.84:1 (< 4.5:1, but >= 3.0:1)
+    expect(meetsContrastRequirement("#828282", "#ffffff", false)).toBe(false);
+    expect(meetsContrastRequirement("#828282", "#ffffff", true)).toBe(true);
+  });
+
+  it("does not call console.warn when meetsContrastRequirement is executed", () => {
+    const warnSpy = vi.spyOn(console, "warn");
+    meetsContrastRequirement("#000000", "#ffffff");
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+describe("Accessibility - DOM and ARIA Helpers", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("isFocusable identifies focusable vs disabled/tabindex=-1 elements", () => {
+    const btn = document.createElement("button");
+    const disabledBtn = document.createElement("button");
+    disabledBtn.disabled = true;
+    const div = document.createElement("div");
+    const divTabindex = document.createElement("div");
+    divTabindex.setAttribute("tabindex", "0");
+    const divNegativeTabindex = document.createElement("div");
+    divNegativeTabindex.setAttribute("tabindex", "-1");
+
+    expect(isFocusable(btn)).toBe(true);
+    expect(isFocusable(disabledBtn)).toBe(false);
+    expect(isFocusable(div)).toBe(false);
+    expect(isFocusable(divTabindex)).toBe(true);
+    expect(isFocusable(divNegativeTabindex)).toBe(false);
+  });
+
+  it("generateAriaId produces unique prefix IDs", () => {
+    const id1 = generateAriaId("modal");
+    const id2 = generateAriaId("modal");
+    expect(id1.startsWith("modal-")).toBe(true);
+    expect(id1).not.toBe(id2);
+  });
+
+  it("aria props generators work as expected", () => {
+    expect(ariaExpanded(true, "panel-1")).toEqual({
+      "aria-expanded": true,
+      "aria-controls": "panel-1",
+    });
+    expect(ariaLive("assertive")).toEqual({
+      "aria-live": "assertive",
+      "aria-atomic": true,
+    });
+    expect(ariaInvalid(true, "err-1")).toEqual({
+      "aria-invalid": true,
+      "aria-describedby": "err-1",
+    });
+    expect(ariaInvalid(false)).toEqual({
+      "aria-invalid": false,
+    });
+  });
+
+  it("reduced motion helpers work with window.matchMedia", () => {
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: query === "(prefers-reduced-motion: reduce)",
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    expect(prefersReducedMotion()).toBe(true);
+    expect(getAnimationDuration(300)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description
Closes #39.

Implements standard WCAG 2.1 relative luminance calculation (L = 0.2126R + 0.7152G + 0.0722B with sRGB gamma expansion) and contrast ratio calculation ((L1 + 0.05) / (L2 + 0.05)) in `meetsContrastRequirement`.

### Key Changes
- Replaced placeholder in `lib/accessibility.ts` with standard sRGB linearization and relative luminance formulas (`getRelativeLuminance`, `getContrastRatio`, `meetsContrastRequirement`).
- Supported hex color string formats (e.g. `#fff`, `#000000`, `828282`).
- Evaluates compliance against 4.5:1 for normal text and 3:1 for large text (`largeText = true`).
- Removed `console.warn` placeholder output.
- Added unit tests in `tests/lib/accessibility.test.ts` testing luminance, contrast ratio thresholds, normal/large text differences, and accessibility helper utilities.

### Validation
- `npm run test` passes all 46 unit tests.
- `npm run lint` and `npx tsc --noEmit --skipLibCheck` pass with 0 errors.
