### PR TITLE
docs: add Step 5b whitelist tokens to deployment TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ buyer ──pay──▶ contract (escrow) ──dispatch──▶ merchant
   - [Step 3 — Set up a testnet identity](#step-3--set-up-a-testnet-identity)
   - [Step 4 — Deploy to testnet](#step-4--deploy-to-testnet)
   - [Step 5 — Initialize with your merchant wallet](#step-5--initialize-with-your-merchant-wallet)
+  - [Step 5b — Whitelist the tokens you accept](#step-5b--whitelist-the-tokens-you-accept)
   - [Step 6 — Wire the deployed contract to the storefront](#step-6--wire-the-deployed-contract-to-the-storefront)
   - [Convenience script](#convenience-script)
 - [Paying with USDC (testnet)](#paying-with-usdc-testnet)


### PR DESCRIPTION
### Summary
Add missing **Step 5b — Whitelist the tokens you accept** entry into the Smart Contract Deployment Table of Contents in `README.md`.

### Changes
- Inserted `- [Step 5b — Whitelist the tokens you accept](#step-5b--whitelist-the-tokens-you-accept)` between Step 5 and Step 6 in the Table of Contents.
- The new anchor link resolves directly to the existing `### Step 5b — Whitelist the tokens you accept` section.

Closes #116