### PR TITLE
docs: replace placeholder issues URL in troubleshooting guide

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -279,7 +279,7 @@ Common issues and solutions for Mova Store development and production.
 
 If you can't resolve an issue:
 
-1. **Search existing issues:** [GitHub Issues](https://github.com/yourusername/mova-store/issues)
+1. **Search existing issues:** [GitHub Issues](https://github.com/Movalabs-crew/mova-store/issues)
 2. **Check Stellar docs:** [developers.stellar.org](https://developers.stellar.org)
 3. **Ask in Discord:** [Stellar Discord](https://discord.gg/stellar)
 4. **Open a new issue** with:


### PR DESCRIPTION
### Summary
Replace placeholder URL with real repository issues URL in docs/TROUBLESHOOTING.md.

### Changes
- Updated the issues link in docs/TROUBLESHOOTING.md to point to https://github.com/Movalabs-crew/mova-store/issues.

Closes #114