### PR TITLE
refactor: reuse LoadingSpinner in root and shop route loading

### DIFF
--- a/app/loading.jsx
+++ b/app/loading.jsx
@@ -1,12 +1,8 @@
 import React from "react";
+import LoadingSpinner from "@/components/LoadingSpinner";
+
 const loading = () => {
-  return (
-    <div className="flex items-center justify-center min-h-screen bg-white">
-      <div className="text-center">
-        <div className="loader border-t-4 border-purple-700 rounded-full w-16 h-16 mx-auto animate-spin"></div>
-      </div>
-    </div>
-  );
+  return <LoadingSpinner />;
 };
 
 export default loading;

--- a/app/shop/loading.jsx
+++ b/app/shop/loading.jsx
@@ -1,13 +1,8 @@
 import React from "react";
-// import LoadingSpinner from "../../components/LoadingSpinner";
+import LoadingSpinner from "@/components/LoadingSpinner";
+
 const loading = () => {
-  return (
-    <div className="flex items-center justify-center min-h-screen bg-white">
-      <div className="text-center">
-        <div className="loader border-t-4 border-purple-700 rounded-full w-16 h-16 mx-auto animate-spin"></div>
-      </div>
-    </div>
-  );
+  return <LoadingSpinner />;
 };
 
 export default loading;

--- a/tests/components/loading.test.tsx
+++ b/tests/components/loading.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import RootLoading from "@/app/loading";
+import ShopLoading from "@/app/shop/loading";
+
+describe("Loading components", () => {
+  it("renders LoadingSpinner with expected loader classes", () => {
+    const { container } = render(<LoadingSpinner />);
+    const loader = container.querySelector(".loader");
+    expect(loader).toBeInTheDocument();
+    expect(loader).toHaveClass("border-t-4", "border-purple-700", "rounded-full", "animate-spin");
+  });
+
+  it("renders LoadingSpinner in root app/loading", () => {
+    const { container } = render(<RootLoading />);
+    const loader = container.querySelector(".loader");
+    expect(loader).toBeInTheDocument();
+    expect(loader).toHaveClass("animate-spin");
+  });
+
+  it("renders LoadingSpinner in app/shop/loading", () => {
+    const { container } = render(<ShopLoading />);
+    const loader = container.querySelector(".loader");
+    expect(loader).toBeInTheDocument();
+    expect(loader).toHaveClass("animate-spin");
+  });
+});


### PR DESCRIPTION
### Summary
Reuse the shared `components/LoadingSpinner.jsx` component in `app/loading.jsx` and `app/shop/loading.jsx`, removing duplicated markup.

### Changes
- Updated `app/loading.jsx` and `app/shop/loading.jsx` to import and render `<LoadingSpinner />`.
- Added unit tests in `tests/components/loading.test.tsx` verifying the shared spinner markup and route loading exports.

Closes #111