### PR TITLE
fix(checkout): remove unused useCart import

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useState, useEffect } from "react";
-import { useCart } from "../../context/CartContext";
 
 import Toast from "../../components/Toast";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";


### PR DESCRIPTION
### Summary
Remove unused `useCart` import from `app/checkout/page.tsx`.

### Changes
- Removed the unused `import { useCart } from "../../context/CartContext";` in `app/checkout/page.tsx` since `/checkout` manages order totals from local storage without depending on `CartContext`.

Closes #110