### PR TITLE
fix(navbar): navigate home when hash links are clicked from non-landing pages

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -26,14 +26,20 @@ function BrandMark() {
 }
 
 function Navbar() {
+  const router = useRouter();
+
   useEffect(() => {
     const handleLinkClick = (event) => {
-      event.preventDefault();
       const href = event.currentTarget.getAttribute("href");
+      if (!href || !href.startsWith("#")) return;
       const targetId = href.substring(1);
       const targetElement = document.getElementById(targetId);
       if (targetElement) {
+        event.preventDefault();
         targetElement.scrollIntoView({ behavior: "smooth" });
+      } else {
+        event.preventDefault();
+        router.push(`/${href}`);
       }
     };
 
@@ -45,9 +51,7 @@ function Navbar() {
         link.removeEventListener("click", handleLinkClick)
       );
     };
-  }, []);
-
-  const router = useRouter();
+  }, [router]);
   const [toast, setToast] = useState({ show: false, message: "" });
   const showToast = (message) => {
     setToast({ show: true, message });


### PR DESCRIPTION
### Summary
Ensure hash links (`#aboutus`, `#contact`) in `Navbar` navigate to `/#<targetId>` when clicked from non-landing pages (e.g. `/shop`, `/blog`, `/checkout`).

### Changes
- Updated `handleLinkClick` in `components/Navbar.jsx` to check if `document.getElementById(targetId)` exists on the current page.
- If the target is present, it prevents default and smoothly scrolls into view.
- If the target element is absent (on non-landing pages), it routes to `/${href}` via Next.js router instead of swallowing the click.

Closes #83