### PR TITLE
fix(contact): render persistent error message and remove unused form ref

### DIFF
--- a/app/(landingpage)/ContactUs.jsx
+++ b/app/(landingpage)/ContactUs.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useRef } from "react";
+import { useState } from "react";
 import { FaGithub, FaTwitter, FaDiscord } from "react-icons/fa";
 import sendMail from "../../lib/sendmail";
 
@@ -33,21 +33,23 @@ const ContactUs = () => {
   const [toast, setToast] = useState({ show: false, message: "" });
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
-  const form = useRef();
 
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData({ ...formData, [name]: value });
+    if (error) setError(null);
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setIsLoading(true);
+    setError(null);
     try {
       await sendMail(formData);
       showToast("Message sent successfully!");
       setFormData({ name: "", email: "", message: "" });
-    } catch (error) {
+      setError(null);
+    } catch (err) {
       setError("Failed to send message.");
       showToast("Unable to send message, please try again later");
     }
@@ -178,6 +180,15 @@ const ContactUs = () => {
               "Send Message"
             )}
           </button>
+          {error && (
+            <p
+              role="alert"
+              aria-live="polite"
+              className="mt-4 text-center text-sm font-medium text-red-600"
+            >
+              {error}
+            </p>
+          )}
         </form>
           </div>
         </div>

--- a/tests/components/contactus.test.tsx
+++ b/tests/components/contactus.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import ContactUs from "@/app/(landingpage)/ContactUs";
+import * as sendMailModule from "@/lib/sendmail";
+
+vi.mock("@/lib/sendmail", () => ({
+  default: vi.fn(),
+}));
+
+describe("ContactUs component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders error persistently when sendMail rejects", async () => {
+    vi.mocked(sendMailModule.default).mockRejectedValueOnce(new Error("Network Error"));
+
+    render(<ContactUs />);
+
+    fireEvent.change(screen.getByPlaceholderText("Your Name"), {
+      target: { value: "Alice" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Your Email"), {
+      target: { value: "alice@example.com" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Your Message"), {
+      target: { value: "Hello world" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Send Message" }));
+
+    await waitFor(() => {
+      const errorMsg = screen.getByRole("alert");
+      expect(errorMsg).toBeInTheDocument();
+      expect(errorMsg).toHaveTextContent("Failed to send message.");
+    });
+  });
+
+  it("clears error on subsequent input change or retry", async () => {
+    vi.mocked(sendMailModule.default)
+      .mockRejectedValueOnce(new Error("Network Error"))
+      .mockResolvedValueOnce({ status: 200, text: "OK" });
+
+    render(<ContactUs />);
+
+    const nameInput = screen.getByPlaceholderText("Your Name");
+    fireEvent.change(nameInput, { target: { value: "Bob" } });
+    fireEvent.change(screen.getByPlaceholderText("Your Email"), { target: { value: "bob@example.com" } });
+    fireEvent.change(screen.getByPlaceholderText("Your Message"), { target: { value: "Test" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Send Message" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    // Typing in name input clears error
+    fireEvent.change(nameInput, { target: { value: "Bobby" } });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Summary
Render error message persistently in the ContactUs form on failure and clean up unused `useRef`.

### Changes
- Added aria-live error alert below the form submit button in `app/(landingpage)/ContactUs.jsx`.
- Cleared error state on retry, input change, and successful submit.
- Removed unused `useRef` import and `const form = useRef()` declaration.
- Added unit tests in `tests/components/contactus.test.tsx` verifying error appearance on sendMail rejection and cleanup on subsequent input changes.

Closes #81