### PR TITLE
fix(checkout): disable stage-1 submit and stage-2 OTP buttons in flight

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -310,7 +310,8 @@ const Checkout = () => {
                 </div>
                 <button
                   type="submit"
-                  className="w-full flex justify-center items-center bg-purple-500 text-white py-2 rounded hover:bg-purple-700 transition-colors"
+                  disabled={isSubmitting}
+                  className="w-full flex justify-center items-center bg-purple-500 text-white py-2 rounded hover:bg-purple-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isSubmitting ? (
                     <>
@@ -371,7 +372,8 @@ const Checkout = () => {
                 </div>
                 <button
                   type="submit"
-                  className="w-full bg-purple-500 text-white flex justify-center items-center py-2 rounded hover:bg-purple-700 transition-colors"
+                  disabled={isOtpSending}
+                  className="w-full bg-purple-500 text-white flex justify-center items-center py-2 rounded hover:bg-purple-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isOtpSending ? (
                     <>


### PR DESCRIPTION
### Summary
Disable the checkout stage-1 submit button while \`isSubmitting\` is true and the stage-2 OTP confirm button while \`isOtpSending\` is true to prevent duplicate form submissions and redundant OTP emails.

### Changes
- Added \`disabled={isSubmitting}\` and disabled styling to stage-1 submit button in \`app/checkout/page.tsx\`.
- Added \`disabled={isOtpSending}\` and disabled styling to stage-2 OTP confirm button in \`app/checkout/page.tsx\`.

Closes #78