### PR TITLE
fix(newsletter): validate email input and reset state on submit

### DIFF
--- a/app/(landingpage)/newsletter.jsx
+++ b/app/(landingpage)/newsletter.jsx
@@ -1,5 +1,6 @@
 import Toast from "../../components/Toast";
 import { useState } from "react";
+import { validateEmail } from "../../lib/validation";
 
 export default function Newsletter() {
   const [toast, setToast] = useState({ show: false, message: "" });
@@ -11,11 +12,19 @@ export default function Newsletter() {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (email.length !== 0) {
-      showToast("Thank you for subscribing!");
-    } else {
+    if (!email || email.trim().length === 0) {
       showToast("Please enter your email!");
+      return;
     }
+
+    const validation = validateEmail(email);
+    if (!validation.isValid) {
+      showToast(validation.error || "Please enter a valid email address");
+      return;
+    }
+
+    showToast("Thank you for subscribing!");
+    setEmail("");
     e.target.reset();
   };
 
@@ -37,6 +46,7 @@ export default function Newsletter() {
           <input
             type="email"
             name="email"
+            value={email}
             className="appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none"
             placeholder="Enter your email"
             aria-label="Email"

--- a/tests/components/newsletter.test.tsx
+++ b/tests/components/newsletter.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import Newsletter from "@/app/(landingpage)/newsletter";
+
+describe("Newsletter component", () => {
+  it("shows error toast when email is empty", () => {
+    render(<Newsletter />);
+    const submitBtn = screen.getByRole("button", { name: "Subscribe" });
+
+    fireEvent.click(submitBtn);
+
+    expect(screen.getByText("Please enter your email!")).toBeInTheDocument();
+  });
+
+  it("shows error toast when invalid email is entered", () => {
+    render(<Newsletter />);
+    const input = screen.getByPlaceholderText("Enter your email");
+    const submitBtn = screen.getByRole("button", { name: "Subscribe" });
+
+    fireEvent.change(input, { target: { value: "invalid-email" } });
+    fireEvent.click(submitBtn);
+
+    expect(
+      screen.getByText("Please enter a valid email address")
+    ).toBeInTheDocument();
+  });
+
+  it("shows success toast and resets email state on valid submission", () => {
+    render(<Newsletter />);
+    const input = screen.getByPlaceholderText("Enter your email") as HTMLInputElement;
+    const submitBtn = screen.getByRole("button", { name: "Subscribe" });
+
+    fireEvent.change(input, { target: { value: "user@example.com" } });
+    fireEvent.click(submitBtn);
+
+    expect(screen.getByText("Thank you for subscribing!")).toBeInTheDocument();
+    expect(input.value).toBe("");
+
+    // Submitting again on cleared input should now ask for email
+    fireEvent.click(submitBtn);
+    expect(screen.getByText("Please enter your email!")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Summary
Validate newsletter email with `validateEmail` from `lib/validation.ts` and clear the React email state upon successful submission.

### Changes
- Checked for empty or invalid email formatting before accepting subscription submissions in `app/(landingpage)/newsletter.jsx`.
- Cleared the React `email` state and controlled input after successful subscription so empty resubmission triggers validation.
- Added unit tests in `tests/components/newsletter.test.tsx` verifying empty email, invalid email, and valid subscription state transitions.

Closes #74