### PR TITLE
refactor(stellar): deduplicate hex encoding helpers and add orderIdHash tests (closes #17)

### DIFF
--- a/lib/stellar/checkout.ts
+++ b/lib/stellar/checkout.ts
@@ -13,6 +13,7 @@ import { decodePaymentEvent, PaymentReceipt, waitForTransaction } from "./events
 import {
   addressToScVal,
   bytes32ToScVal,
+  bytesToHex,
   hashOrderId,
   i128ToScVal,
 } from "./scval";
@@ -69,13 +70,7 @@ export function usdToRawUnits(amountUsd: number): bigint {
  * cross-check on-chain order ids with their own order numbers.
  */
 export async function orderIdHash(orderId: string): Promise<string> {
-  return hexOf(await hashOrderId(orderId));
-}
-
-function hexOf(bytes: Uint8Array): string {
-  return Array.from(bytes)
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+  return bytesToHex(await hashOrderId(orderId));
 }
 
 /**

--- a/lib/stellar/events.ts
+++ b/lib/stellar/events.ts
@@ -1,7 +1,7 @@
 import { rpc, StrKey, xdr } from "@stellar/stellar-sdk";
 
 import { RPC_URL, TX_TIMEOUT_SECONDS, TX_POLL_INTERVAL_MS } from "./config";
-import { bytesToHex, scValToString } from "./scval";
+import { scValToString } from "./scval";
 
 // ---------------------------------------------------------------------------
 // Payment event decoding.
@@ -128,5 +128,3 @@ export function decodePaymentEvent(
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
-
-export { bytesToHex };

--- a/tests/lib/stellar/checkout.test.ts
+++ b/tests/lib/stellar/checkout.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { orderIdHash } from "../../../lib/stellar/checkout";
+import { bytesToHex, hashOrderId } from "../../../lib/stellar/scval";
+
+describe("orderIdHash and hex encoding", () => {
+  it("computes 64-character lowercase hex order id matching bytesToHex(hashOrderId)", async () => {
+    const input = "abc";
+    const expectedBytes = await hashOrderId(input);
+    const expectedHex = bytesToHex(expectedBytes);
+
+    const result = await orderIdHash(input);
+
+    expect(result).toBe(expectedHex);
+    expect(result).toHaveLength(64);
+    expect(result).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("handles arbitrary order id strings deterministically", async () => {
+    const orderIds = [
+      "order-12345",
+      "test_order_999",
+      "",
+      "special-!@#$%^&*()_+",
+    ];
+
+    for (const id of orderIds) {
+      const hashed = await orderIdHash(id);
+      const manual = bytesToHex(await hashOrderId(id));
+      expect(hashed).toBe(manual);
+      expect(hashed).toHaveLength(64);
+      expect(hashed).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Addresses #17 by deduplicating hex encoding helpers in `lib/stellar`:
- Replaces private `hexOf` in `lib/stellar/checkout.ts` with exported `bytesToHex` from `lib/stellar/scval.ts`.
- Removes the redundant and unused re-export of `bytesToHex` in `lib/stellar/events.ts`.
- Adds unit tests in `tests/lib/stellar/checkout.test.ts` verifying that `orderIdHash(id)` equals `bytesToHex(await hashOrderId(id))` producing exact 64 lowercase hex characters across multiple input cases.

## Validation
- `npm test`: all 38 tests passing across 3 test files.
- `npm run type-check`: passed cleanly with zero type errors.
- `npm run lint`: passed with no errors.

Closes #17.