### PR TITLE
[Bounty: ] fix(tests): replace fake SHA-256 stub with real Node webcrypto

### DIFF
--- a/tests/lib/hash-order-id.test.ts
+++ b/tests/lib/hash-order-id.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { hashOrderId } from "../../lib/stellar/scval";
+
+describe("hashOrderId", () => {
+  it("produces a 32-byte digest", async () => {
+    const hash = await hashOrderId("test-order-123");
+    expect(hash).toBeInstanceOf(Uint8Array);
+    expect(hash.length).toBe(32);
+  });
+
+  it("is deterministic — same input yields same output", async () => {
+    const hash1 = await hashOrderId("order-abc");
+    const hash2 = await hashOrderId("order-abc");
+    expect(hash1).toEqual(hash2);
+  });
+
+  it("produces different hashes for different inputs (>32 chars)", async () => {
+    const longId = "a".repeat(40);
+    const longIdModified = "a".repeat(40) + "x";
+    const hash1 = await hashOrderId(longId);
+    const hash2 = await hashOrderId(longIdModified);
+    expect(hash1).not.toEqual(hash2);
+  });
+
+  it("is not a naive byte-copy stub — hash of 40 'a's differs from first-32-bytes-only", async () => {
+    // If the mock were the old fake (just copy first 32 bytes),
+    // these two would produce identical hashes. With real SHA-256 they differ.
+    const hash1 = await hashOrderId("a".repeat(40));
+    const hash2 = await hashOrderId("a".repeat(40) + "extra-chars-here");
+    expect(hash1).not.toEqual(hash2);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom";
 import { vi } from "vitest";
 import React from "react";
+import { webcrypto } from "node:crypto";
 
 // Mock Next.js router
 vi.mock("next/navigation", () => ({
@@ -31,26 +32,14 @@ vi.mock("next/image", () => ({
   }) => React.createElement("img", { src, alt, ...props }),
 }));
 
-// Mock window.crypto for tests
+// Replace fake crypto mock with REAL SHA-256 via Node webcrypto
 Object.defineProperty(globalThis, "crypto", {
   value: {
-    subtle: {
-      digest: async (_algorithm: string, data: ArrayBuffer) => {
-        const text = new TextDecoder().decode(data);
-        const hash = new Uint8Array(32);
-        for (let i = 0; i < text.length && i < 32; i++) {
-          hash[i] = text.charCodeAt(i);
-        }
-        return hash.buffer;
-      },
-    },
-    getRandomValues: (arr: Uint8Array) => {
-      for (let i = 0; i < arr.length; i++) {
-        arr[i] = Math.floor(Math.random() * 256);
-      }
-      return arr;
-    },
+    subtle: webcrypto.subtle,
+    getRandomValues: (arr: Uint8Array) => webcrypto.getRandomValues(arr),
   },
+  writable: false,
+  configurable: true,
 });
 
 // Mock environment variables


### PR DESCRIPTION
## Summary

Fixes #97

Replace the fake crypto.subtle.digest stub in tests/setup.ts with Node.js native webcrypto.subtle (real SHA-256).

## Problem
The old mock only preserved the first 32 input bytes — any two IDs sharing their first 32 characters would hash identically.

## Fix
Replace fake mock with Node real webcrypto.subtle.digest (SHA-256).

## Tests Added
tests/lib/hash-order-id.test.ts:
- digest length is 32 bytes
- determinism: same input → same hash
- input sensitivity: different suffix → different hash  
- proves not a naive byte-copy stub

**Bounty wallet:** 3rb3NNaU5foZFvVk4faVuMmqMvoxfADW3Xw5Wv5vfZr6