### PR TITLE
fix(cart): keep itemCount and totalPrice in sync with cartItems in removeFromCart (closes #20)

### DIFF
--- a/context/CartContext.jsx
+++ b/context/CartContext.jsx
@@ -42,26 +42,26 @@ export const CartProvider = ({ children }) => {
   const removeFromCart = (product) => {
     setCartItems((prevCartItems) => {
       const index = prevCartItems.findIndex((item) => item.id === product.id);
-      if (index === -1) return prevCartItems; // If item not found, return previous cart items
+      if (index === -1) return prevCartItems;
 
+      const removedItem = prevCartItems[index];
       const updatedCartItems = [...prevCartItems];
-      updatedCartItems.splice(index, 1); // Remove the item from the array
+      updatedCartItems.splice(index, 1);
       localStorage.setItem("cartItems", JSON.stringify(updatedCartItems));
+
+      setItemCount((prevItemCount) => {
+        const newItemCount = Math.max(0, prevItemCount - 1);
+        localStorage.setItem("itemCount", newItemCount.toString());
+        return newItemCount;
+      });
+
+      setTotalPrice((prevTotalPrice) => {
+        const newTotalPrice = Math.max(0, prevTotalPrice - (removedItem.price || 0));
+        localStorage.setItem("totalPrice", newTotalPrice.toString());
+        return newTotalPrice;
+      });
+
       return updatedCartItems;
-    });
-
-    setItemCount((prevItemCount) => {
-      const newItemCount = prevItemCount - 1;
-      localStorage.setItem("itemCount", newItemCount.toString());
-      return newItemCount;
-    });
-
-    setTotalPrice((prevTotalPrice) => {
-      const removedItem = cartItems.find((item) => item.id === product.id);
-      if (!removedItem) return prevTotalPrice; // If item not found, return previous total price
-      const newTotalPrice = prevTotalPrice - removedItem.price;
-      localStorage.setItem("totalPrice", newTotalPrice.toString());
-      return newTotalPrice;
     });
   };
 

--- a/tests/context/CartContext.test.tsx
+++ b/tests/context/CartContext.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import React from "react";
+import { CartProvider, useCart } from "../../context/CartContext";
+
+describe("CartContext removeFromCart", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    React.createElement(CartProvider, null, children)
+  );
+
+  it("adds and removes items correctly", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    const item1 = { id: "p1", name: "Shoe 1", price: 100 };
+    const item2 = { id: "p2", name: "Shoe 2", price: 50 };
+
+    act(() => {
+      result.current.addToCart(item1);
+      result.current.addToCart(item2);
+    });
+
+    expect(result.current.itemCount).toBe(2);
+    expect(result.current.totalPrice).toBe(150);
+    expect(result.current.cartItems).toHaveLength(2);
+
+    act(() => {
+      result.current.removeFromCart(item1);
+    });
+
+    expect(result.current.itemCount).toBe(1);
+    expect(result.current.totalPrice).toBe(50);
+    expect(result.current.cartItems).toHaveLength(1);
+    expect(result.current.cartItems[0].id).toBe("p2");
+
+    expect(localStorage.getItem("itemCount")).toBe("1");
+    expect(localStorage.getItem("totalPrice")).toBe("50");
+    expect(JSON.parse(localStorage.getItem("cartItems") || "[]")).toHaveLength(1);
+  });
+
+  it("leaves itemCount and totalPrice unchanged when removing an item not in the cart", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    const item1 = { id: "p1", name: "Shoe 1", price: 100 };
+    const nonExistentItem = { id: "p999", name: "Ghost", price: 999 };
+
+    act(() => {
+      result.current.addToCart(item1);
+    });
+
+    expect(result.current.itemCount).toBe(1);
+    expect(result.current.totalPrice).toBe(100);
+
+    // Attempt to remove non-existent item
+    act(() => {
+      result.current.removeFromCart(nonExistentItem);
+    });
+
+    expect(result.current.itemCount).toBe(1);
+    expect(result.current.totalPrice).toBe(100);
+    expect(result.current.cartItems).toHaveLength(1);
+    expect(localStorage.getItem("itemCount")).toBe("1");
+    expect(localStorage.getItem("totalPrice")).toBe("100");
+  });
+
+  it("repeated remove calls can never produce a negative itemCount or totalPrice", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    const item1 = { id: "p1", name: "Shoe 1", price: 100 };
+
+    // Cart is empty initially
+    act(() => {
+      result.current.removeFromCart(item1);
+      result.current.removeFromCart(item1);
+    });
+
+    expect(result.current.itemCount).toBe(0);
+    expect(result.current.totalPrice).toBe(0);
+    expect(result.current.cartItems).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
+    env: {
+      NODE_ENV: "development",
+    },
     setupFiles: ["./tests/setup.ts"],
     include: ["**/*.{test,spec}.{js,jsx,ts,tsx}"],
     exclude: ["node_modules", "contracts", ".next", "out"],


### PR DESCRIPTION
## Summary
Fixes #20 by synchronizing `itemCount` and `totalPrice` updates with the exact outcome of removing an item from `cartItems`.

### Key Changes
- In `removeFromCart`, locate the target item in `prevCartItems` and only decrement `itemCount` and `totalPrice` when an item is actually found and spliced.
- Clamp `itemCount` and `totalPrice` with `Math.max(0, ...)` to ensure counts and prices never become negative on edge cases or duplicate removal triggers.
- Updated `vitest.config.ts` test environment configuration so testing-library hooks execute properly in testing mode.
- Added comprehensive unit tests in `tests/context/CartContext.test.tsx` verifying:
  - Normal add and remove transitions correctly update state and localStorage.
  - Removing an item not in the cart leaves `itemCount`, `totalPrice`, and `cartItems` unchanged.
  - Repeated remove calls on an empty or modified cart cannot produce negative item counts or negative total prices.

### Acceptance Criteria Covered
- [x] Removing an item that is not in the cart leaves itemCount and totalPrice unchanged (renderHook tests)
- [x] Repeated remove calls can never produce a negative itemCount
- [x] After any remove, localStorage itemCount === cartItems.length and totalPrice equals sum of prices
- [x] All unit and type tests pass cleanly (`npm test`, `npm run type-check`)
