### PR TITLE
fix(order-watch): clear error banner on indexer recovery and successful event match (closes #70)

### DIFF
--- a/components/StellarOrderWatch.jsx
+++ b/components/StellarOrderWatch.jsx
@@ -34,16 +34,22 @@ const StellarOrderWatch = ({ orderId, enabled = true, onEvent = null }) => {
       indexer.start({
         onStatus: (s) => {
           setConnected(s.running);
-          if (s.lastError) setError(s.lastError);
+          if (s.lastError) {
+            setError(s.lastError);
+          } else if (s.running) {
+            setError("");
+          }
         },
         onError: (err) => setError(err.message),
         onEvent: (event) => {
           if (event.symbol !== "pay") return;
           const orderHex = (event.fields.topic4 || "").toLowerCase();
           if (orderHex !== expected) return;
+          setError("");
           setMatched(event);
           if (onEvent) onEvent(event);
-          indexer.stop();        },
+          indexer.stop();
+        },
       });
     };
 

--- a/tests/components/StellarOrderWatch.test.tsx
+++ b/tests/components/StellarOrderWatch.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import React from "react";
+import StellarOrderWatch from "../../components/StellarOrderWatch";
+
+// Mock the scval helpers
+vi.mock("../../lib/stellar/scval", () => ({
+  hashOrderId: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3, 4])),
+  bytesToHex: vi.fn().mockReturnValue("01020304"),
+}));
+
+let mockIndexerInstance: any = null;
+
+// Mock the indexer
+vi.mock("../../lib/stellar/indexer", () => {
+  return {
+    PaymentEventIndexer: vi.fn().mockImplementation(() => {
+      mockIndexerInstance = {
+        start: vi.fn(),
+        stop: vi.fn(),
+      };
+      return mockIndexerInstance;
+    }),
+  };
+});
+
+describe("StellarOrderWatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIndexerInstance = null;
+  });
+
+  it("clears the error banner when onStatus receives lastError=undefined while running", async () => {
+    let capturedCallbacks: any = null;
+
+    const { unmount } = render(
+      <StellarOrderWatch orderId="test-order-123" enabled={true} />
+    );
+
+    // Wait for async hashOrderId to resolve and indexer.start to be called
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockIndexerInstance).not.toBeNull();
+    expect(mockIndexerInstance.start).toHaveBeenCalled();
+    capturedCallbacks = mockIndexerInstance.start.mock.calls[0][0];
+
+    // Trigger transient failure via onStatus
+    act(() => {
+      capturedCallbacks.onStatus({
+        running: true,
+        lastError: "Transient network timeout",
+      });
+    });
+
+    expect(screen.getByText("Transient network timeout")).toBeInTheDocument();
+
+    // Indexer recovers: onStatus called with running: true and no lastError
+    act(() => {
+      capturedCallbacks.onStatus({
+        running: true,
+        lastError: undefined,
+      });
+    });
+
+    // Error banner should be gone
+    expect(screen.queryByText("Transient network timeout")).not.toBeInTheDocument();
+
+    unmount();
+  });
+
+  it("clears error banner when a matching payment event is received", async () => {
+    let capturedCallbacks: any = null;
+
+    render(<StellarOrderWatch orderId="test-order-123" enabled={true} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    capturedCallbacks = mockIndexerInstance.start.mock.calls[0][0];
+
+    // Set error
+    act(() => {
+      capturedCallbacks.onError(new Error("RPC hiccup"));
+    });
+
+    expect(screen.getByText("RPC hiccup")).toBeInTheDocument();
+
+    // Match payment event
+    act(() => {
+      capturedCallbacks.onEvent({
+        symbol: "pay",
+        ledger: 100,
+        txHash: "tx123",
+        fields: {
+          topic4: "01020304",
+          amount: "10.0",
+          topic1: "USDC",
+        },
+      });
+    });
+
+    // Error should be resolved and match banner shown
+    expect(screen.queryByText("RPC hiccup")).not.toBeInTheDocument();
+    expect(screen.getByText("Payment detected on-chain ✓")).toBeInTheDocument();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
+    env: {
+      NODE_ENV: "development",
+    },
     setupFiles: ["./tests/setup.ts"],
     include: ["**/*.{test,spec}.{js,jsx,ts,tsx}"],
     exclude: ["node_modules", "contracts", ".next", "out"],


### PR DESCRIPTION
## Summary
Fixes #70 by ensuring that `StellarOrderWatch` clears its error state when the indexer recovers from a transient failure or when a matching on-chain payment event is successfully detected.

### Key Changes
- In `components/StellarOrderWatch.jsx`:
  - When `onStatus` receives an update where `s.lastError` is falsy while `s.running` is true, clear the error banner (`setError("")`).
  - When `onEvent` receives a matching payment event, also clear any previous error banner before displaying the green confirmation banner.
- Added comprehensive unit tests in `tests/components/StellarOrderWatch.test.tsx` verifying:
  - Driving the mocked indexer's `onStatus` with `{ running: true, lastError: '...' }` shows the banner, and subsequent `{ running: true, lastError: undefined }` clears it.
  - Receiving a valid payment event clears any prior error message.

### Acceptance Criteria Covered
- [x] Component test driving mocked indexer `onStatus` with `{ running: true, lastError: 'x' }` then `{ running: true, lastError: undefined }` asserts banner disappears
- [x] `npm run test` and `npm run type-check` pass cleanly
