### PR TITLE
[Bounty: $75] Align the CONTRIBUTING testing-guidelines section with the real tests/ tree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,9 +179,10 @@ npm run test:ui
 ```
 
 **Test file locations:**
-- Unit tests: `tests/lib/` for library functions
-- Component tests: `tests/components/` for React components
+- Unit tests: `tests/lib/` for library functions (for example `tests/lib/env.test.ts` and `tests/lib/validation.test.ts`)
+- Shared Vitest setup: `tests/setup.ts`
 - Tests should be named `*.test.ts` or `*.test.tsx`
+- Put new component tests under `tests/` only when you add them; do not assume a `tests/components/` directory exists yet
 
 **What to test:**
 - Utility functions (validation, formatting, etc.)


### PR DESCRIPTION
## Summary
CONTRIBUTING.md told contributors that unit tests live in `tests/lib/` and component tests live in `tests/components/`. A fresh clone only has `tests/setup.ts` and `tests/lib/*.test.ts` — git cannot track an empty `tests/components/` directory, so the documented component-test home did not exist.

This change updates the testing-guidelines section so documented locations match the tracked tree: `tests/lib/` for unit tests and `tests/setup.ts` for Vitest setup. It no longer presents `tests/components/` as an existing directory.

Fixes https://github.com/Movalabs-crew/mova-store/issues/113

## Acceptance
- The guidelines no longer treat `tests/components/` as a present location
- Documented test locations match the tracked `tests/` tree (`tests/lib/`, `tests/setup.ts`)

## Testing
- `npm run test` (existing Vitest suite in `tests/lib/`)
patch_sha256=9acf863b769604713a371f65a169c9bcd1e42eb843fafe36d6e3f08f3512cb92