### PR TITLE
[Bounty: $70] Add unit tests for usdToRawUnits in lib/stellar/checkout.ts

### DIFF
--- a/tests/lib/stellar/checkout.test.ts
+++ b/tests/lib/stellar/checkout.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { usdToRawUnits } from "../../../lib/stellar/checkout";
+import { WalletError } from "../../../lib/stellar/freighter";
+
+function expectInvalidAmount(amountUsd: number): void {
+  try {
+    usdToRawUnits(amountUsd);
+    expect.fail(`expected usdToRawUnits(${String(amountUsd)}) to throw`);
+  } catch (err) {
+    expect(err).toBeInstanceOf(WalletError);
+    expect((err as WalletError).code).toBe("INVALID_AMOUNT");
+  }
+}
+
+describe("usdToRawUnits", () => {
+  it("converts 12.34 USD to 123400000n (floating-point safe)", () => {
+    expect(usdToRawUnits(12.34)).toBe(123400000n);
+  });
+
+  it("converts 0.29 USD to 2900000n (floating-point safe)", () => {
+    expect(usdToRawUnits(0.29)).toBe(2900000n);
+  });
+
+  it("converts 0.0000001 USD to 1n", () => {
+    expect(usdToRawUnits(0.0000001)).toBe(1n);
+  });
+
+  it("converts 1 USD to 10000000n", () => {
+    expect(usdToRawUnits(1)).toBe(10000000n);
+  });
+
+  it("throws WalletError with code INVALID_AMOUNT for zero", () => {
+    expectInvalidAmount(0);
+  });
+
+  it("throws WalletError with code INVALID_AMOUNT for a negative amount", () => {
+    expectInvalidAmount(-5);
+  });
+
+  it("throws WalletError with code INVALID_AMOUNT for NaN", () => {
+    expectInvalidAmount(Number.NaN);
+  });
+
+  it("throws WalletError with code INVALID_AMOUNT for Infinity", () => {
+    expectInvalidAmount(Number.POSITIVE_INFINITY);
+  });
+});


### PR DESCRIPTION
Closes #13.

Adds Vitest coverage at `tests/lib/stellar/checkout.test.ts` for `usdToRawUnits`:
- pins `12.34` → `123400000n`, `0.29` → `2900000n`, `0.0000001` → `1n`, `1` → `10000000n` with strict bigint `toBe` (`===`)
- asserts `WalletError` with `code === 'INVALID_AMOUNT'` for `0`, `-5`, `NaN`, and `Infinity`

No production behavior change.
patch_sha256=d581c0e321acf65f0167537626667851c18a429a3a4b2d2a7b722207b7e507d5