### PR TITLE
docs: fix dead 'Paying with USDC (testnet)' anchors (#46)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,7 +219,7 @@ npm run build        # Production build must succeed
 
 If your PR touches the Stellar payment flow, describe in the PR how you tested
 it against testnet (Freighter + USDC faucet account). Follow the flow in the
-root [README](README.md#paying-with-usdc-testnet).
+root [README](README.md#paying-with-stellar-testnet).
 
 ## Commit Message Style
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ buyer ──pay──▶ contract (escrow) ──dispatch──▶ merchant
   - [Step 5b — Whitelist the tokens you accept](#step-5b--whitelist-the-tokens-you-accept)
   - [Step 6 — Wire the deployed contract to the storefront](#step-6--wire-the-deployed-contract-to-the-storefront)
   - [Convenience script](#convenience-script)
-- [Paying with USDC (testnet)](#paying-with-usdc-testnet)
+- [Paying with Stellar (testnet)](#paying-with-stellar-testnet)
 - [Environment Variables Reference](#environment-variables-reference)
 - [Security Notes](#security-notes)
 - [Contributing](#contributing)


### PR DESCRIPTION
## Summary
Fixes #46 by resolving dead anchor links pointing to non-existent `#paying-with-usdc-testnet`.

## Changes
- Updated `README.md` Table of Contents entry from `[Paying with USDC (testnet)](#paying-with-usdc-testnet)` to `[Paying with Stellar (testnet)](#paying-with-stellar-testnet)`.
- Updated `CONTRIBUTING.md` reference link to `[README](README.md#paying-with-stellar-testnet)`.

## Acceptance Criteria Verification
- [x] `grep 'paying-with-usdc-testnet' README.md CONTRIBUTING.md` returns 0 matches.
- [x] `grep 'paying-with-stellar-testnet'` matches both updated references.
- [x] Automated heading slug check confirms every TOC deep link in `README.md` resolves to an existing heading slug.

## Payout Routing
- **EVM (Base/Arbitrum/Polygon/ETH):** `0xF46C9F6d70C50BF81ef3588AB523a90a594a2F89`
- **Stellar:** `GCL6OXAMLD75BMTINA6EMRUDWK5THQUSHMYNLSNBCJAPZJHNYJTUNIBC`