### PR TITLE
fix(stellar): replace Node Buffer globals with Uint8Array conversions (closes #18)

### DIFF
--- a/lib/stellar/events.ts
+++ b/lib/stellar/events.ts
@@ -82,9 +82,10 @@ export function decodePaymentEvent(
 
     let eventContractId: string | undefined;
     try {
-      if (event.contractId()) {
+      const contractId = event.contractId();
+      if (contractId) {
         eventContractId = StrKey.encodeContract(
-          Buffer.from(event.contractId() as unknown as Uint8Array)
+          contractId as unknown as Parameters<typeof StrKey.encodeContract>[0]
         );
       }
     } catch {

--- a/lib/stellar/orders.ts
+++ b/lib/stellar/orders.ts
@@ -107,7 +107,9 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
       .addOperation(
         contract.call(
           "order",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHash, "hex"))
+          xdr.ScVal.scvBytes(
+            orderIdHashBytes as unknown as Parameters<typeof xdr.ScVal.scvBytes>[0]
+          )
         )
       )
       .setTimeout(30)
@@ -171,7 +173,7 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
           case "token":
             if (val.switch() === xdr.ScValType.scvAddress()) {
               order.token = StrKey.encodeContract(
-                Buffer.from(val.address().contractId() as unknown as Uint8Array)
+                val.address().contractId() as unknown as Parameters<typeof StrKey.encodeContract>[0]
               );
             }
             break;
@@ -230,7 +232,9 @@ export async function dispatchOrder(
       .addOperation(
         contract.call(
           "dispatch",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHashBytes))
+          xdr.ScVal.scvBytes(
+            orderIdHashBytes as unknown as Parameters<typeof xdr.ScVal.scvBytes>[0]
+          )
         )
       )
       .setTimeout(TX_TIMEOUT_SECONDS)
@@ -311,7 +315,9 @@ export async function refundOrder(orderId: string): Promise<OrderActionResult> {
       .addOperation(
         contract.call(
           "refund",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHashBytes))
+          xdr.ScVal.scvBytes(
+            orderIdHashBytes as unknown as Parameters<typeof xdr.ScVal.scvBytes>[0]
+          )
         )
       )
       .setTimeout(TX_TIMEOUT_SECONDS)

--- a/lib/stellar/scval.ts
+++ b/lib/stellar/scval.ts
@@ -22,12 +22,11 @@ export function i128ToScVal(value: bigint | number | string): xdr.ScVal {
  * Build a BytesN<32> ScVal from a Uint8Array (or hex string).
  */
 export function bytes32ToScVal(bytes: Uint8Array | string): xdr.ScVal {
-  const buf =
-    typeof bytes === "string" ? Buffer.from(hexToBytes(bytes)) : Buffer.from(bytes);
-  if (buf.length !== 32) {
-    throw new Error(`order_id must be exactly 32 bytes (got ${buf.length})`);
+  const u8 = typeof bytes === "string" ? hexToBytes(bytes) : bytes;
+  if (u8.length !== 32) {
+    throw new Error(`order_id must be exactly 32 bytes (got ${u8.length})`);
   }
-  return xdr.ScVal.scvBytes(buf);
+  return xdr.ScVal.scvBytes(u8 as unknown as Parameters<typeof xdr.ScVal.scvBytes>[0]);
 }
 
 /**

--- a/tests/lib/stellar/scval.test.ts
+++ b/tests/lib/stellar/scval.test.ts
@@ -67,6 +67,14 @@ describe("ScVal helpers", () => {
       );
       expect(() => bytes32ToScVal("aabbcc")).toThrow("order_id must be exactly 32 bytes");
     });
+
+    it("produces byte-identical XDR for hex string and Uint8Array inputs", () => {
+      const hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+      const u8 = hexToBytes(hex);
+      const scValFromHex = bytes32ToScVal(hex);
+      const scValFromBytes = bytes32ToScVal(u8);
+      expect(scValFromHex.toXDR("base64")).toBe(scValFromBytes.toXDR("base64"));
+    });
   });
 
   describe("hexToBytes and bytesToHex", () => {


### PR DESCRIPTION
## Summary
Replaces Node Buffer globals with standard Uint8Array conversions across client-side `lib/stellar` modules to prevent runtime failures in browser environments where Buffer is not polyfilled.

## Changes
- `lib/stellar/scval.ts`: `bytes32ToScVal` passes `Uint8Array` directly to `xdr.ScVal.scvBytes` after 32-byte validation, using `hexToBytes` for string inputs.
- `lib/stellar/events.ts`: `decodePaymentEvent` passes `event.contractId()` directly to `StrKey.encodeContract` without Node Buffer wrapping.
- `lib/stellar/orders.ts`: passes `orderIdHashBytes` directly to `xdr.ScVal.scvBytes` in `readOrder`, `dispatchOrder`, and `refundOrder`; passes `val.address().contractId()` directly to `StrKey.encodeContract` without Node Buffer wrapping.
- `tests/lib/stellar/scval.test.ts`: adds unit test verifying `bytes32ToScVal(hexString)` and `bytes32ToScVal(uint8ArrayOfSameBytes)` produce byte-identical XDR.

## Verification
- `grep -rn "Buffer" lib/stellar` returns no matches.
- `npm run type-check` passes without errors.
- `npx vitest run tests/lib/stellar/` passes (32 tests in 4 test files).
- `npm run build` succeeds.

Closes #18

## Payout Routing
- **EVM (Base/Arbitrum/Polygon/ETH):** `0xF46C9F6d70C50BF81ef3588AB523a90a594a2F89`
- **Stellar:** `GCL6OXAMLD75BMTINA6EMRUDWK5THQUSHMYNLSNBCJAPZJHNYJTUNIBC`