### PR TITLE
fix(collections): replace legacy layout/objectFit props and unused imports (closes #26)

### DIFF
--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -1,9 +1,9 @@
-import Image from 'next/image';
-import shoeImage1 from "/public/images/shoe4.png";
-import shoeImage2 from "/public/images/shoe3.png";
+import Image from "next/image";
+import shoeImage1 from "/public/images/shoe1.png";
+import shoeImage2 from "/public/images/shoe2.png";
 import shoeImage3 from "/public/images/shoe3.png";
 import shoeImage4 from "/public/images/shoe4.png";
-import shoeImage5 from "/public/images/shoe5.png";
+
 const shoes = [
   {
     id: 1,
@@ -15,19 +15,19 @@ const shoes = [
     id: 2,
     name: "Basketball Shoes",
     price: "$129.99",
-    imageUrl: shoeImage1,
+    imageUrl: shoeImage2,
   },
   {
     id: 3,
     name: "Casual Sneakers",
     price: "$79.99",
-    imageUrl: shoeImage1,
+    imageUrl: shoeImage3,
   },
   {
     id: 4,
     name: "Formal Shoes",
     price: "$149.99",
-    imageUrl: shoeImage1,
+    imageUrl: shoeImage4,
   },
 ];
 
@@ -37,13 +37,16 @@ export default function ShoesCollection() {
       <h1 className="text-3xl font-bold mb-6 text-center">Shoes Collection</h1>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
         {shoes.map((shoe) => (
-          <div key={shoe.id} className="bg-white shadow-lg rounded-lg overflow-hidden">
+          <div
+            key={shoe.id}
+            className="bg-white shadow-lg rounded-lg overflow-hidden"
+          >
             <div className="relative w-full h-48">
               <Image
                 src={shoe.imageUrl}
                 alt={shoe.name}
-                layout="fill"
-                objectFit="cover"
+                fill
+                style={{ objectFit: "cover" }}
                 className="rounded-t-lg"
               />
             </div>


### PR DESCRIPTION
Closes #26

### Changes
- Replaced legacy Next.js `layout="fill"` and `objectFit="cover"` props in `app/collections/page.tsx` with `fill` and `style={{ objectFit: "cover" }}`.
- Removed unused `shoeImage5` import and deduplicated shoes data mapping to assign unique shoe images (`shoeImage1`-`shoeImage4`) across catalog products.
- Validated clean type-checking (`npm run type-check`) and linting (`npm run lint`).