### PR TITLE
fix(orders): preserve buyer/token metadata when merging dispatch and refund events (closes #73)

### DIFF
--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -8,6 +8,7 @@ import {
   refundOrder,
   OrderEvent,
   eventToOrder,
+  mergeOrderEvent,
   OrderStatus,
 } from "../../../lib/stellar/orders";
 import { NETWORK, CHECKOUT_CONTRACT_ID } from "../../../lib/stellar/config";
@@ -199,10 +200,7 @@ const OrdersManagementContent = () => {
             // Update existing order or add new one
             const existing = newMap.get(order.orderId);
             if (existing) {
-              // Update status if the new event is more recent
-              if (event.ledger > (existing.ledger || 0)) {
-                newMap.set(order.orderId, { ...existing, ...order });
-              }
+              newMap.set(order.orderId, mergeOrderEvent(existing, order));
             } else {
               newMap.set(order.orderId, order);
             }

--- a/lib/stellar/orders.ts
+++ b/lib/stellar/orders.ts
@@ -500,3 +500,40 @@ export function eventToOrder(
     txHash,
   };
 }
+
+/**
+ * Merges a newer order event over an existing order row.
+ * Preserves core order metadata (buyer, token, tokenSymbol, amount) when lifecycle
+ * events (such as dispatch or refund) arrive with different/empty topic payloads,
+ * carrying forward status, ledger, txHash, and timestamp.
+ */
+export function mergeOrderEvent(
+  existing: OrderEvent,
+  incoming: OrderEvent
+): OrderEvent {
+  // Only update if incoming event is newer or has same/higher ledger
+  if (incoming.ledger < (existing.ledger || 0)) {
+    return existing;
+  }
+
+  // If incoming event is a lifecycle transition (Shipped/Refunded) or lacks full buyer/token metadata,
+  // preserve existing buyer, token, tokenSymbol, amount, and amountRaw.
+  const isLifecycleEvent = incoming.status === "Shipped" || incoming.status === "Refunded";
+  const preserveBuyer = isLifecycleEvent || (!incoming.buyer && Boolean(existing.buyer));
+  const preserveToken = isLifecycleEvent || (!incoming.token && Boolean(existing.token));
+  const preserveAmount = isLifecycleEvent || (incoming.amountRaw === BigInt(0) && existing.amountRaw > BigInt(0));
+
+  return {
+    ...existing,
+    ...incoming,
+    buyer: preserveBuyer ? existing.buyer : (incoming.buyer || existing.buyer),
+    token: preserveToken ? existing.token : (incoming.token || existing.token),
+    tokenSymbol: preserveToken ? existing.tokenSymbol : (incoming.tokenSymbol || existing.tokenSymbol),
+    amount: preserveAmount ? existing.amount : incoming.amount,
+    amountRaw: preserveAmount ? existing.amountRaw : incoming.amountRaw,
+    status: incoming.status !== "Unknown" ? incoming.status : existing.status,
+    ledger: incoming.ledger || existing.ledger,
+    txHash: incoming.txHash || existing.txHash,
+    timestamp: incoming.timestamp || existing.timestamp,
+  };
+}

--- a/tests/lib/stellar/orders.test.ts
+++ b/tests/lib/stellar/orders.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { mergeOrderEvent, OrderEvent } from "../../../lib/stellar/orders";
+
+describe("mergeOrderEvent", () => {
+  const existingPaidOrder: OrderEvent = {
+    orderId: "order_1234567890abcdef",
+    buyer: "GBUYER_ORIGINAL_STELLAR_KEY_123",
+    amount: "100.00",
+    amountRaw: BigInt(1000000000),
+    token: "C_USDC_CONTRACT_ADDRESS",
+    tokenSymbol: "USDC",
+    status: "Paid",
+    timestamp: 1690000000000,
+    ledger: 1000,
+    txHash: "tx_pay_hash_123",
+  };
+
+  it("merges a dispatch event over an existing Paid row, keeping buyer, token, and amount while updating status, ledger, and txHash", () => {
+    const incomingDispatchEvent: OrderEvent = {
+      orderId: "order_1234567890abcdef",
+      buyer: "GMERCHANT_KEY_TOPIC2", // dispatch topic2 is merchant address
+      amount: "0.00",
+      amountRaw: BigInt(0),
+      token: "",
+      tokenSymbol: "TOKEN",
+      status: "Shipped",
+      timestamp: 1690000050000,
+      ledger: 1050,
+      txHash: "tx_dispatch_hash_456",
+    };
+
+    const merged = mergeOrderEvent(existingPaidOrder, incomingDispatchEvent);
+
+    expect(merged.orderId).toBe("order_1234567890abcdef");
+    expect(merged.status).toBe("Shipped");
+    expect(merged.ledger).toBe(1050);
+    expect(merged.txHash).toBe("tx_dispatch_hash_456");
+
+    // Preserved fields from existing order
+    expect(merged.buyer).toBe("GBUYER_ORIGINAL_STELLAR_KEY_123");
+    expect(merged.token).toBe("C_USDC_CONTRACT_ADDRESS");
+    expect(merged.tokenSymbol).toBe("USDC");
+    expect(merged.amount).toBe("100.00");
+    expect(merged.amountRaw).toBe(BigInt(1000000000));
+  });
+
+  it("merges a refund event over an existing Paid row, keeping buyer, token, and amount while updating status to Refunded", () => {
+    const incomingRefundEvent: OrderEvent = {
+      orderId: "order_1234567890abcdef",
+      buyer: "GMERCHANT_KEY_TOPIC2",
+      amount: "0.00",
+      amountRaw: BigInt(0),
+      token: "",
+      tokenSymbol: "TOKEN",
+      status: "Refunded",
+      timestamp: 1690000060000,
+      ledger: 1060,
+      txHash: "tx_refund_hash_789",
+    };
+
+    const merged = mergeOrderEvent(existingPaidOrder, incomingRefundEvent);
+
+    expect(merged.orderId).toBe("order_1234567890abcdef");
+    expect(merged.status).toBe("Refunded");
+    expect(merged.ledger).toBe(1060);
+    expect(merged.txHash).toBe("tx_refund_hash_789");
+    expect(merged.buyer).toBe("GBUYER_ORIGINAL_STELLAR_KEY_123");
+    expect(merged.token).toBe("C_USDC_CONTRACT_ADDRESS");
+    expect(merged.tokenSymbol).toBe("USDC");
+    expect(merged.amount).toBe("100.00");
+  });
+
+  it("does not overwrite with older ledgers if incoming event is older than existing", () => {
+    const olderEvent: OrderEvent = {
+      orderId: "order_1234567890abcdef",
+      buyer: "GOTHER",
+      amount: "50.00",
+      amountRaw: BigInt(500000000),
+      token: "C_XLM",
+      tokenSymbol: "XLM",
+      status: "Pending",
+      timestamp: 1680000000000,
+      ledger: 900,
+      txHash: "tx_old_hash",
+    };
+
+    const merged = mergeOrderEvent(existingPaidOrder, olderEvent);
+    expect(merged).toEqual(existingPaidOrder);
+  });
+});


### PR DESCRIPTION
### Summary
Closes #73

When a newer `dispatch` or `refund` lifecycle event arrives for an existing order row in the Admin Orders dashboard, the previous inline reducer replaced all fields of the existing order with the event-derived order object (`{ ...existing, ...order }`). Because `eventToOrder` derives buyer from `fields.buyer || fields.topic2`, and dispatch topics are `[order_id, merchant]`, the merchant address in `topic2` overwrote the original buyer's address, and empty/unspecified token fields caused `tokenSymbol` to fall back to generic values.

### Changes
1. **Extracted Pure Helper (`mergeOrderEvent`)**:
   - Added and exported `mergeOrderEvent(existing: OrderEvent, incoming: OrderEvent): OrderEvent` in `lib/stellar/orders.ts`.
   - Carries forward updated lifecycle fields (`status`, `ledger`, `txHash`, `timestamp`) while cleanly preserving `buyer`, `token`, `tokenSymbol`, `amount`, and `amountRaw` across lifecycle transitions (`Shipped`, `Refunded`).
2. **Updated Admin Orders Dashboard (`app/admin/orders/page.tsx`)**:
   - Replaced inline merge with `mergeOrderEvent(existing, order)`.
3. **Unit Tests (`tests/lib/stellar/orders.test.ts`)**:
   - Added unit tests covering dispatch merges over paid rows, refund merges, and ledger ordering checks.

### Verification
- `npm run type-check`: Passed with 0 errors.
- `vitest run tests/lib/stellar/orders.test.ts`: Passed (3/3 tests).
