### PR TITLE
test: add Modal hidden/shown/close-button/remount tests

### DIFF
--- a/tests/components/Modal.test.jsx
+++ b/tests/components/Modal.test.jsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import Modal from "../../components/Modal";
+
+describe("Modal", () => {
+  it("renders nothing when show is false", () => {
+    const { container } = render(
+      <Modal show={false} onClose={vi.fn()}>
+        <p>Hidden body</p>
+      </Modal>
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders children and the close button when show is true", () => {
+    render(
+      <Modal show={true} onClose={vi.fn()}>
+        <p>Visible body</p>
+      </Modal>
+    );
+
+    expect(screen.getByText("Visible body")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("invokes onClose exactly once when the close button is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <Modal show={true} onClose={onClose}>
+        <p>Body</p>
+      </Modal>
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes the whole subtree when show flips back to false", () => {
+    const { rerender } = render(
+      <Modal show={true} onClose={vi.fn()}>
+        <p>Modal content</p>
+      </Modal>
+    );
+    expect(screen.getByText("Modal content")).toBeInTheDocument();
+
+    rerender(
+      <Modal show={false} onClose={vi.fn()}>
+        <p>Modal content</p>
+      </Modal>
+    );
+
+    expect(screen.queryByText("Modal content")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #98

## Change

Adds `tests/components/Modal.test.jsx` covering both states of the component:

- `show=false` renders nothing (empty DOM)
- `show=true` renders the children and the close button
- clicking the close button invokes `onClose` exactly once
- re-rendering with `show=false` removes the whole subtree

## Verification

- `npm run test` - 40/40 pass (36 existing + 4 new)
- `npm run type-check` - passes
- `npm run lint` - passes (0 errors)

## Acceptance criteria (#98)

- [x] show=false renders nothing; show=true renders children and the close button
- [x] Clicking the close button invokes onClose exactly once; npm run test passes