### PR TITLE
test: add FAQ/Newsletter/ContactUs component tests; validate newsletter email + clear state

### DIFF
--- a/app/(landingpage)/newsletter.jsx
+++ b/app/(landingpage)/newsletter.jsx
@@ -1,6 +1,8 @@
 import Toast from "../../components/Toast";
 import { useState } from "react";
 
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export default function Newsletter() {
   const [toast, setToast] = useState({ show: false, message: "" });
   const [email, setEmail] = useState("");
@@ -11,12 +13,16 @@ export default function Newsletter() {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (email.length !== 0) {
+    const value = email;
+    // Clear state *and* the form so a stale email can never be
+    // reused by the next submission.
+    setEmail("");
+    e.target.reset();
+    if (value && EMAIL_RE.test(value)) {
       showToast("Thank you for subscribing!");
     } else {
-      showToast("Please enter your email!");
+      showToast("Please enter a valid email!");
     }
-    e.target.reset();
   };
 
   return (
@@ -40,6 +46,7 @@ export default function Newsletter() {
             className="appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none"
             placeholder="Enter your email"
             aria-label="Email"
+            value={email}
             onChange={(e) => {
               setEmail(e.target.value);
             }}

--- a/tests/(landingpage)/ContactUs.test.jsx
+++ b/tests/(landingpage)/ContactUs.test.jsx
@@ -1,0 +1,91 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ContactUs from "../../app/(landingpage)/ContactUs";
+
+vi.mock("../../lib/sendmail", () => ({
+  default: vi.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import sendMail from "../../lib/sendmail";
+
+function fillForm() {
+  fireEvent.change(screen.getByPlaceholderText("Your Name"), {
+    target: { value: "Ada" },
+  });
+  fireEvent.change(screen.getByPlaceholderText("Your Email"), {
+    target: { value: "ada@example.com" },
+  });
+  fireEvent.change(screen.getByPlaceholderText("Your Message"), {
+    target: { value: "Hello Mova!" },
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(sendMail).mockReset();
+});
+
+describe("ContactUs", () => {
+  it("renders an error message when sendMail rejects", async () => {
+    vi.mocked(sendMail).mockRejectedValue(new Error("mail down"));
+    render(<ContactUs />);
+    fillForm();
+
+    fireEvent.click(screen.getByRole("button", { name: /send message/i }));
+
+    expect(
+      await screen.findByText("Unable to send message, please try again later")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Message sent successfully!")).not.toBeInTheDocument();
+  });
+
+  it("shows the success toast and resets the form when sendMail resolves", async () => {
+    vi.mocked(sendMail).mockResolvedValue({ ok: true });
+    render(<ContactUs />);
+    fillForm();
+
+    fireEvent.click(screen.getByRole("button", { name: /send message/i }));
+
+    expect(await screen.findByText("Message sent successfully!")).toBeInTheDocument();
+    expect(sendMail).toHaveBeenCalledWith({
+      name: "Ada",
+      email: "ada@example.com",
+      message: "Hello Mova!",
+    });
+
+    // controlled inputs are reset after a successful send
+    const form = screen.getByRole("button", { name: /send message/i }).closest("form");
+    const inputs = within(form).getAllByRole("textbox").slice(0, 2);
+    for (const input of inputs) {
+      expect(input).toHaveValue("");
+    }
+    expect(within(form).getByPlaceholderText("Your Message")).toHaveValue("");
+  });
+
+  it("disables the submit button while the request is in flight", async () => {
+    let resolveSend;
+    vi.mocked(sendMail).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSend = resolve;
+        })
+    );
+    render(<ContactUs />);
+    fillForm();
+    const button = screen.getByRole("button", { name: /send message/i });
+
+    fireEvent.click(button);
+    expect(button).toBeDisabled();
+    expect(screen.getByText("Sending...")).toBeInTheDocument();
+
+    await waitFor(() => resolveSend?.({ ok: true }));
+    await screen.findByText("Message sent successfully!");
+  });
+});

--- a/tests/(landingpage)/FAQ.test.jsx
+++ b/tests/(landingpage)/FAQ.test.jsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import FAQ from "../../app/(landingpage)/FAQ";
+
+function openButtons() {
+  return screen
+    .getAllByRole("button")
+    .filter((b) => b.getAttribute("aria-expanded") === "true");
+}
+
+describe("FAQ", () => {
+  it("starts with no panel open", () => {
+    render(<FAQ />);
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(8);
+    for (const button of buttons) {
+      expect(button).toHaveAttribute("aria-expanded", "false");
+    }
+    expect(openButtons()).toHaveLength(0);
+  });
+
+  it("opens exactly one panel and toggles aria-expanded", () => {
+    render(<FAQ />);
+    const [first, second] = screen.getAllByRole("button");
+
+    fireEvent.click(first);
+    expect(first).toHaveAttribute("aria-expanded", "true");
+    expect(openButtons()).toHaveLength(1);
+
+    // opening a second question closes the first (single-open accordion)
+    fireEvent.click(second);
+    expect(second).toHaveAttribute("aria-expanded", "true");
+    expect(first).toHaveAttribute("aria-expanded", "false");
+    expect(openButtons()).toHaveLength(1);
+
+    // clicking the open question again closes it
+    fireEvent.click(second);
+    expect(second).toHaveAttribute("aria-expanded", "false");
+    expect(openButtons()).toHaveLength(0);
+  });
+
+  it("expands the answer panel of the open question", () => {
+    render(<FAQ />);
+    const [first] = screen.getAllByRole("button");
+    // the answer panel is the sibling right after the question button
+    const panel = first.nextElementSibling;
+    expect(panel.className).toContain("max-h-0");
+
+    fireEvent.click(first);
+    expect(panel.className).toContain("max-h-96");
+    expect(panel.textContent).toContain(
+      "Stellar is a fast, low-cost blockchain network"
+    );
+  });
+});

--- a/tests/(landingpage)/newsletter.test.jsx
+++ b/tests/(landingpage)/newsletter.test.jsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import Newsletter from "../../app/(landingpage)/newsletter";
+
+const SUCCESS = "Thank you for subscribing!";
+const ERROR = "Please enter a valid email!";
+
+function submit(email) {
+  const input = screen.getByPlaceholderText("Enter your email");
+  if (email !== null) {
+    fireEvent.change(input, { target: { value: email } });
+  }
+  fireEvent.click(screen.getByRole("button", { name: /subscribe/i }));
+}
+
+describe("Newsletter", () => {
+  it("never shows the success toast for an invalid email", () => {
+    render(<Newsletter />);
+    submit("not-an-email");
+
+    expect(screen.queryByText(SUCCESS)).not.toBeInTheDocument();
+    expect(screen.getByText(ERROR)).toBeInTheDocument();
+  });
+
+  it("never shows the success toast for an empty submission", () => {
+    render(<Newsletter />);
+    submit(null);
+
+    expect(screen.queryByText(SUCCESS)).not.toBeInTheDocument();
+    expect(screen.getByText(ERROR)).toBeInTheDocument();
+  });
+
+  it("shows the success toast for a valid email and clears the state", () => {
+    render(<Newsletter />);
+    submit("shopper@example.com");
+    expect(screen.getByText(SUCCESS)).toBeInTheDocument();
+
+    // form and state are reset after submit
+    const input = screen.getByPlaceholderText("Enter your email");
+    expect(input).toHaveValue("");
+
+    // submitting again with an empty field must not reuse the stale email
+    submit(null);
+    expect(screen.queryByText(SUCCESS)).not.toBeInTheDocument();
+    expect(screen.getByText(ERROR)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #96

## Change

First component tests for the landing page (`tests/(landingpage)/`):

- **FAQ.test.jsx** — starts with no panel open; clicking a question opens exactly
  one panel and toggles `aria-expanded`; opening a second question closes the first
  (single-open accordion); the open panel's `max-h` class expands.
- **newsletter.test.jsx** — an invalid email (or an empty submission) never shows
  the success toast (error toast instead); a valid email shows the success toast,
  the input and the email state are cleared, and a follow-up empty submit does not
  reuse the stale email.
- **ContactUs.test.jsx** — with `lib/sendmail` mocked: a rejection renders the error
  message ("Unable to send message, please try again later"); a resolution shows the
  success toast, passes the form data to `sendMail` and resets the inputs; the submit
  button is disabled while the request is in flight.

### Bug found while writing the Newsletter tests

`handleSubmit` treated any non-empty string as a valid email (any garbage got
"Thank you for subscribing!") and never cleared the `email` state after `e.target.reset()`,
so a stale email could be reused by the next submission. Minimal fix:
validate with a basic email pattern, show the error toast otherwise, and clear the
state after every submit.

## Verification

- `npm run test` - 45/45 pass (36 existing + 9 new)
- `npm run type-check` - passes
- `npm run lint` - passes (0 errors)

## Acceptance criteria (#96)

- [x] FAQ test asserts exactly one panel is open and aria-expanded toggles
- [x] Newsletter test asserts an invalid email never shows the success toast
- [x] ContactUs test asserts a mock sendMail rejection renders the error message
- [x] npm run test passes