### PR TITLE
test: add unit tests for accessibility helpers (focusable order, focus trap, announcer, reduced motion)

### DIFF
--- a/tests/lib/accessibility.test.ts
+++ b/tests/lib/accessibility.test.ts
@@ -116,3 +116,179 @@ describe("Accessibility - DOM and ARIA Helpers", () => {
     expect(getAnimationDuration(300)).toBe(0);
   });
 });
+
+/**
+ * jsdom does no layout: every element reports offsetWidth/Height = 0 and
+ * empty getClientRects(), which would make isVisible() false for everything.
+ * Give fixture elements a size, but zero size when display:none.
+ */
+function makeVisible(root: HTMLElement): void {
+  root.querySelectorAll<HTMLElement>("*").forEach((el) => {
+    const size = () =>
+      getComputedStyle(el).display === "none" ? 0 : 100;
+    Object.defineProperty(el, "offsetWidth", {
+      configurable: true,
+      get: size,
+    });
+    Object.defineProperty(el, "offsetHeight", {
+      configurable: true,
+      get: size,
+    });
+  });
+}
+
+function fixture(html: string): HTMLElement {
+  const el = document.createElement("div");
+  el.innerHTML = html;
+  document.body.appendChild(el);
+  return el;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("isFocusable", () => {
+  it("accepts interactive elements and excludes disabled or negative-tabindex ones", () => {
+    const root = fixture(
+      '<button id="b">b</button>' +
+        '<button id="bd" disabled>bd</button>' +
+        '<a id="a" href="#x">a</a>' +
+        '<span id="t0" tabindex="0">t0</span>' +
+        '<span id="tn1" tabindex="-1">tn1</span>' +
+        '<div id="d">d</div>'
+    );
+    makeVisible(root);
+    const byId = (id: string) =>
+      root.querySelector<HTMLElement>(`#${id}`)!;
+
+    expect(isFocusable(byId("b"))).toBe(true);
+    expect(isFocusable(byId("bd"))).toBe(false);
+    expect(isFocusable(byId("a"))).toBe(true);
+    expect(isFocusable(byId("t0"))).toBe(true);
+    expect(isFocusable(byId("tn1"))).toBe(false);
+    expect(isFocusable(byId("d"))).toBe(false);
+  });
+});
+
+describe("getFocusableElements", () => {
+  it("returns focusable elements in document order, excluding disabled/hidden", () => {
+    const root = fixture(
+      '<button id="b1">B1</button>' +
+        '<input id="i1" />' +
+        '<a id="a1" href="#x">A1</a>' +
+        '<span id="s1" tabindex="0">S1</span>' +
+        '<button id="b2" disabled>B2</button>' +
+        '<a id="a2" href="#y" style="display:none">A2</a>' +
+        '<span id="s2" tabindex="-1">S2</span>' +
+        '<div id="d1">D1</div>'
+    );
+    makeVisible(root);
+
+    const ids = getFocusableElements(root).map((el) => el.id);
+    expect(ids).toEqual(["b1", "i1", "a1", "s1"]);
+  });
+});
+
+describe("trapFocus", () => {
+  it("focuses the first element and wraps Tab / Shift+Tab at the edges", () => {
+    const root = fixture(
+      '<button id="f1">F1</button>' +
+        '<button id="f2">F2</button>' +
+        '<button id="f3">F3</button>'
+    );
+    makeVisible(root);
+    const first = root.querySelector<HTMLElement>("#f1")!;
+    const last = root.querySelector<HTMLElement>("#f3")!;
+
+    const cleanup = trapFocus(root);
+    expect(document.activeElement).toBe(first);
+
+    // Tab on the last element wraps to the first
+    last.focus();
+    const tab = new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true });
+    root.dispatchEvent(tab);
+    expect(tab.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(first);
+
+    // Shift+Tab on the first element wraps to the last
+    const shiftTab = new KeyboardEvent("keydown", {
+      key: "Tab",
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    root.dispatchEvent(shiftTab);
+    expect(shiftTab.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(last);
+
+    // cleanup removes the keydown listener
+    cleanup();
+    const after = new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true });
+    root.dispatchEvent(after);
+    expect(after.defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(last);
+  });
+});
+
+describe("announceToScreenReader", () => {
+  it("adds a role=status node, then removes it after the timeout", () => {
+    vi.useFakeTimers();
+    announceToScreenReader("cart updated", "assertive");
+
+    const node = document.querySelector<HTMLElement>('[role="status"]');
+    expect(node).not.toBeNull();
+    expect(node!.textContent).toBe("cart updated");
+    expect(node!.getAttribute("aria-live")).toBe("assertive");
+    expect(node!.getAttribute("aria-atomic")).toBe("true");
+
+    vi.advanceTimersByTime(1000);
+    expect(document.querySelector('[role="status"]')).toBeNull();
+  });
+});
+
+describe("saveFocus", () => {
+  it("restores the previously focused element", () => {
+    const first = fixture("<button id='sb1'>one</button>").querySelector<
+      HTMLButtonElement
+    >("#sb1")!;
+    first.focus();
+    const restore = saveFocus();
+
+    const second = fixture("<button id='sb2'>two</button>").querySelector<
+      HTMLButtonElement
+    >("#sb2")!;
+    second.focus();
+
+    restore();
+    expect(document.activeElement).toBe(first);
+  });
+});
+
+describe("prefersReducedMotion", () => {
+  function mockMatchMedia(matches: boolean) {
+    const mql = {
+      matches,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as MediaQueryList;
+    vi.spyOn(window, "matchMedia").mockReturnValue(mql);
+  }
+
+  it("honours a mocked matchMedia result and feeds getAnimationDuration", () => {
+    mockMatchMedia(true);
+    expect(prefersReducedMotion()).toBe(true);
+    expect(getAnimationDuration(300)).toBe(0);
+
+    mockMatchMedia(false);
+    expect(prefersReducedMotion()).toBe(false);
+    expect(getAnimationDuration(300)).toBe(300);
+  });
+});


### PR DESCRIPTION
Closes #38

## Change

Adds `tests/lib/accessibility.test.ts` (jsdom, fixtures mounted into `document.body`):

- `isFocusable` / `getFocusableElements`: a fixture with button/input/a[href]/
  [tabindex] plus a disabled button, a display:none link, a tabindex=-1 span and a
  plain div — asserts document-order results with disabled/hidden elements excluded.
  (jsdom does no layout, so fixture elements get an `offsetWidth`/`offsetHeight`
  getter that reports 0 for display:none and a size otherwise.)
- `trapFocus`: focuses the first element; Tab on the last wraps to the first;
  Shift+Tab on the first wraps to the last (both `preventDefault`ed); the returned
  cleanup removes the keydown listener.
- `announceToScreenReader`: appends a `role=status` node with the message,
  `aria-live` and `aria-atomic`, and removes it after the 1s timeout (fake timers).
- `saveFocus`: restores the previously focused element.
- `prefersReducedMotion` / `getAnimationDuration`: honour a mocked `matchMedia`
  (reduced -> 0 duration, normal -> unchanged).

## Verification

- `npm run test` - 42/42 pass (36 existing + 6 new)
- `npm run type-check` - passes
- `npm run lint` - passes (0 errors)

## Acceptance criteria (#38)

- [x] getFocusableElements orders and excludes disabled/hidden elements correctly on a fixture with button/input/a[href]/[tabindex]
- [x] trapFocus wraps Tab/Shift+Tab and its returned cleanup removes the keydown listener
- [x] announceToScreenReader adds then removes the [role=status] node
- [x] prefersReducedMotion honours a mocked matchMedia
- [x] npm run test passes (jsdom, no browser needed)