### PR TITLE
fix(products): remove orphaned product images from Supabase storage on delete (closes #43)

### DIFF
--- a/lib/products.js
+++ b/lib/products.js
@@ -40,13 +40,11 @@ export async function uploadProductImage(file) {
   const ext = file.name.split(".").pop() || "jpg";
   const path = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
 
-  const { error: uploadError } = await supabase.storage
-    .from(PRODUCTS_BUCKET)
-    .upload(path, file, {
-      cacheControl: "3600",
-      upsert: false,
-      contentType: file.type || "image/jpeg",
-    });
+  const { error: uploadError } = await supabase.storage.from(PRODUCTS_BUCKET).upload(path, file, {
+    cacheControl: "3600",
+    upsert: false,
+    contentType: file.type || "image/jpeg",
+  });
 
   if (uploadError) throw new Error(uploadError.message);
 
@@ -77,7 +75,47 @@ export async function updateProduct(id, { name, price, img }) {
   return mapProduct(data);
 }
 
+/**
+ * Extract storage object path from a Supabase public storage URL.
+ */
+export function getStoragePathFromUrl(url, bucket = PRODUCTS_BUCKET) {
+  if (!url || typeof url !== "string") return null;
+  try {
+    const parsed = new URL(url);
+    const prefix = `/storage/v1/object/public/${bucket}/`;
+    const idx = parsed.pathname.indexOf(prefix);
+    if (idx !== -1) {
+      return decodeURIComponent(parsed.pathname.slice(idx + prefix.length));
+    }
+  } catch {
+    // If not a full URL, fallback to segment check
+    const marker = `/${bucket}/`;
+    const idx = url.indexOf(marker);
+    if (idx !== -1) {
+      return decodeURIComponent(url.slice(idx + marker.length));
+    }
+  }
+  return null;
+}
+
 export async function deleteProduct(id) {
+  // Fetch product to find its image URL before deleting
+  try {
+    const product = await getProductById(id);
+    if (product?.img) {
+      const storagePath = getStoragePathFromUrl(product.img, PRODUCTS_BUCKET);
+      if (storagePath) {
+        try {
+          await supabase.storage.from(PRODUCTS_BUCKET).remove([storagePath]);
+        } catch {
+          // Tolerate storage removal failure so row deletion still proceeds
+        }
+      }
+    }
+  } catch {
+    // Tolerate fetch failure so delete still attempts
+  }
+
   const { error } = await supabase.from(PRODUCTS_TABLE).delete().eq("id", id);
   if (error) throw new Error(error.message);
 }

--- a/tests/lib/products.test.ts
+++ b/tests/lib/products.test.ts
@@ -26,6 +26,7 @@ import {
   createProduct,
   updateProduct,
   deleteProduct,
+  getStoragePathFromUrl,
 } from "../../lib/products";
 
 describe("lib/products data layer", () => {
@@ -68,6 +69,24 @@ describe("lib/products data layer", () => {
       };
       const mapped = mapProduct(raw);
       expect(mapped?.price).toBe(25);
+    });
+  });
+
+  describe("getStoragePathFromUrl", () => {
+    it("extracts object path from full Supabase public URL", () => {
+      const url = "https://xyz.supabase.co/storage/v1/object/public/products/12345-shoe.png";
+      expect(getStoragePathFromUrl(url)).toBe("12345-shoe.png");
+    });
+
+    it("extracts nested path correctly", () => {
+      const url = "https://xyz.supabase.co/storage/v1/object/public/products/folder/item.jpg";
+      expect(getStoragePathFromUrl(url)).toBe("folder/item.jpg");
+    });
+
+    it("returns null for non-matching URLs or empty input", () => {
+      expect(getStoragePathFromUrl(null)).toBeNull();
+      expect(getStoragePathFromUrl("")).toBeNull();
+      expect(getStoragePathFromUrl("https://other-domain.com/shoe.png")).toBeNull();
     });
   });
 
@@ -160,7 +179,9 @@ describe("lib/products data layer", () => {
         error: null,
       });
       mockStorageFrom.getPublicUrl.mockReturnValue({
-        data: { publicUrl: "https://dummy.supabase.co/storage/v1/object/public/products/12345.png" },
+        data: {
+          publicUrl: "https://dummy.supabase.co/storage/v1/object/public/products/12345.png",
+        },
       });
 
       const url = await uploadProductImage(mockFile);
@@ -265,29 +286,83 @@ describe("lib/products data layer", () => {
   });
 
   describe("deleteProduct", () => {
-    it("deletes a product by id", async () => {
-      const mockEq = vi.fn().mockResolvedValue({ data: null, error: null });
-      const mockDelete = vi.fn().mockReturnValue({ eq: mockEq });
-      mockFrom.mockReturnValue({ delete: mockDelete });
+    it("deletes product and removes image from storage if present", async () => {
+      const productRow = {
+        id: "p-del",
+        name: "Old Shoe",
+        price: "50",
+        img: "https://xyz.supabase.co/storage/v1/object/public/products/1234-oldshoe.png",
+      };
+
+      // Mock getProductById
+      const mockMaybeSingle = vi.fn().mockResolvedValue({ data: productRow, error: null });
+      const mockSelectEq = vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+      const mockSelect = vi.fn().mockReturnValue({ eq: mockSelectEq });
+
+      // Mock delete
+      const mockDeleteEq = vi.fn().mockResolvedValue({ data: null, error: null });
+      const mockDelete = vi.fn().mockReturnValue({ eq: mockDeleteEq });
+
+      mockFrom.mockReturnValue({
+        select: mockSelect,
+        delete: mockDelete,
+      });
+
+      mockStorageFrom.remove.mockResolvedValue({ data: [], error: null });
 
       await deleteProduct("p-del");
 
-      expect(mockFrom).toHaveBeenCalledWith("products");
+      expect(mockStorageFrom.remove).toHaveBeenCalledWith(["1234-oldshoe.png"]);
       expect(mockDelete).toHaveBeenCalledTimes(1);
-      expect(mockEq).toHaveBeenCalledWith("id", "p-del");
+      expect(mockDeleteEq).toHaveBeenCalledWith("id", "p-del");
     });
 
-    it("throws error when delete fails", async () => {
-      const mockEq = vi.fn().mockResolvedValue({
+    it("still deletes row if storage remove fails or throws", async () => {
+      const productRow = {
+        id: "p-del2",
+        name: "Old Shoe",
+        price: "50",
+        img: "https://xyz.supabase.co/storage/v1/object/public/products/1234-oldshoe.png",
+      };
+
+      const mockMaybeSingle = vi.fn().mockResolvedValue({ data: productRow, error: null });
+      const mockSelectEq = vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+      const mockSelect = vi.fn().mockReturnValue({ eq: mockSelectEq });
+
+      const mockDeleteEq = vi.fn().mockResolvedValue({ data: null, error: null });
+      const mockDelete = vi.fn().mockReturnValue({ eq: mockDeleteEq });
+
+      mockFrom.mockReturnValue({
+        select: mockSelect,
+        delete: mockDelete,
+      });
+
+      mockStorageFrom.remove.mockRejectedValue(new Error("Storage unavailable"));
+
+      await deleteProduct("p-del2");
+
+      expect(mockStorageFrom.remove).toHaveBeenCalledWith(["1234-oldshoe.png"]);
+      expect(mockDelete).toHaveBeenCalledTimes(1);
+      expect(mockDeleteEq).toHaveBeenCalledWith("id", "p-del2");
+    });
+
+    it("throws error when db delete fails", async () => {
+      const mockMaybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+      const mockSelectEq = vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+      const mockSelect = vi.fn().mockReturnValue({ eq: mockSelectEq });
+
+      const mockDeleteEq = vi.fn().mockResolvedValue({
         data: null,
         error: new Error("Foreign key constraint violation"),
       });
-      const mockDelete = vi.fn().mockReturnValue({ eq: mockEq });
-      mockFrom.mockReturnValue({ delete: mockDelete });
+      const mockDelete = vi.fn().mockReturnValue({ eq: mockDeleteEq });
 
-      await expect(deleteProduct("p-del")).rejects.toThrow(
-        "Foreign key constraint violation"
-      );
+      mockFrom.mockReturnValue({
+        select: mockSelect,
+        delete: mockDelete,
+      });
+
+      await expect(deleteProduct("p-del")).rejects.toThrow("Foreign key constraint violation");
     });
   });
 });


### PR DESCRIPTION
### Overview
Closes #43.

When deleting a product row in `deleteProduct` (`lib/products.js`), the associated image stored in Supabase storage (`products` bucket) remained orphaned as `deleteProduct` only dropped the database record.

### Changes
1. Added helper `getStoragePathFromUrl(url, bucket)` in `lib/products.js` to reliably parse and extract the storage object path from public storage URLs.
2. Updated `deleteProduct(id)` to fetch the product record and remove the associated image from `supabase.storage.from(PRODUCTS_BUCKET).remove([path])` before deleting the database row.
3. Added try/catch around storage removal to gracefully tolerate missing storage objects or transient storage removal errors without preventing database row deletion.
4. Added comprehensive unit tests in `tests/lib/products.test.ts` covering:
   - `getStoragePathFromUrl` parsing valid, nested, and invalid storage URLs.
   - `deleteProduct` removing the storage object and deleting the database row.
   - `deleteProduct` continuing row deletion if storage removal throws/fails.
   - `deleteProduct` throwing when database delete fails.

### Validation
- `npx vitest run tests/lib/products.test.ts` -> 20/20 tests passed
- `npm run type-check` -> Clean
- `npm run lint` -> Clean
- `npx prettier --check` -> Clean
