### PR TITLE
fix: check AUTH_ERRORS before broad Stellar heuristics in parseErrorMessage

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -325,6 +325,18 @@ export function parseError(error: unknown): AppError {
 function parseErrorMessage(message: string): AppError {
   const lowerMessage = message.toLowerCase();
 
+  // Check auth errors first so a phrase like
+  // "Email not confirmed: you cancelled the verification request" is not
+  // swallowed by the broad Stellar 'cancelled' heuristic below.
+  for (const [key, appError] of Object.entries(AUTH_ERRORS)) {
+    if (
+      lowerMessage.includes(key.toLowerCase()) ||
+      lowerMessage.includes(appError.code.toLowerCase())
+    ) {
+      return appError;
+    }
+  }
+
   // Check Stellar errors by key or code
   for (const [key, appError] of Object.entries(STELLAR_ERRORS)) {
     if (
@@ -347,13 +359,6 @@ function parseErrorMessage(message: string): AppError {
   }
   if (lowerMessage.includes("freighter") && (lowerMessage.includes("install") || lowerMessage.includes("not installed"))) {
     return STELLAR_ERRORS.FREIGHTER_NOT_FOUND;
-  }
-
-  // Check auth errors by message
-  for (const [key, appError] of Object.entries(AUTH_ERRORS)) {
-    if (lowerMessage.includes(key.toLowerCase()) || lowerMessage.includes(appError.code.toLowerCase())) {
-      return appError;
-    }
   }
 
   // Return generic error with original message

--- a/tests/lib/errors.test.ts
+++ b/tests/lib/errors.test.ts
@@ -79,3 +79,39 @@ describe("Error Handling & Stellar Error Reconciliation Tests", () => {
     expect(isRecoverable(new WalletError("Wrong net", "WRONG_NETWORK"))).toBe(true);
   });
 });
+
+describe("parseError - auth error precedence (#35)", () => {
+  it("classifies an auth message containing 'cancelled' as the auth error, not UserRejected", () => {
+    const result = parseError(
+      "Email not confirmed: you cancelled the verification request"
+    );
+    expect(result.code).toBe("AUTH_EMAIL_NOT_CONFIRMED");
+    expect(result.userMessage).toBe(
+      "Please confirm your email before signing in."
+    );
+  });
+
+  it("classifies a pure Stellar 'Transaction cancelled by user' as UserRejected", () => {
+    const result = parseError("Transaction cancelled by user");
+    expect(result.code).toBe("WALLET_USER_REJECTED");
+  });
+
+  it("still maps pure Stellar heuristics (balance) correctly", () => {
+    expect(parseError("Insufficient balance").code).toBe(
+      "ACCOUNT_INSUFFICIENT_BALANCE"
+    );
+  });
+
+  it("classifies the other auth phrases", () => {
+    expect(parseError("User already registered").code).toBe("AUTH_EMAIL_EXISTS");
+    expect(parseError("Invalid login credentials").code).toBe(
+      "AUTH_INVALID_CREDENTIALS"
+    );
+  });
+
+  it("falls back to the generic unknown error with the original message", () => {
+    const result = parseError("something completely unexpected");
+    expect(result.code).toBe("UNKNOWN_ERROR");
+    expect(result.message).toBe("something completely unexpected");
+  });
+});


### PR DESCRIPTION
Closes #35

## Problem

`parseErrorMessage` (lib/errors.ts) applied the broad single-word Stellar heuristics
('insufficient'/'balance', 'rejected'/'cancelled', 'timeout', ...) **before** iterating
`AUTH_ERRORS`. An auth message that happens to contain one of those words - e.g.
'Email not confirmed: you cancelled the verification request' - was misclassified as
the Stellar `UserRejected` error instead of `AUTH_EMAIL_NOT_CONFIRMED`.

## Change

Reordered matching in `parseErrorMessage`: the exact `AUTH_ERRORS` phrase/code check
now runs before the Stellar table and the broad heuristics. Pure Stellar messages are
unaffected - none of the `AUTH_ERRORS` phrases/codes is a substring of them.

## Verification

- `tests/lib/errors.test.ts` (new) documents the win conditions:
  - `parseError('Email not confirmed: you cancelled the verification request')`
    returns `AUTH_EMAIL_NOT_CONFIRMED` (fails on main: returns `WALLET_USER_REJECTED`)
  - `parseError('Transaction cancelled by user')` still maps to `UserRejected`
  - `parseError('Insufficient balance')` still maps to `InsufficientBalance`
  - other auth phrases + the generic fallback
- `npm run test` - 41/41 pass (36 existing + 5 new)
- `npm run type-check` - passes
- `npm run lint` - passes (0 errors)

## Acceptance criteria (#35)

- [x] parseError('Email not confirmed: you cancelled the verification request') returns the auth email-not-confirmed entry, not UserRejected
- [x] A pure Stellar message like 'Transaction cancelled by user' still maps to UserRejected
- [x] npm run test, type-check and lint pass