### PR TITLE
fix: clear stale success/error banners in EditProductForm and style errors red

### DIFF
--- a/app/admin/EditProductForm.jsx
+++ b/app/admin/EditProductForm.jsx
@@ -16,6 +16,9 @@ const EditProductForm = ({ productId, onProductUpdated }) => {
   const [errorMessage, setErrorMessage] = useState("");
 
   useEffect(() => {
+    // Clear stale messages from a previously selected product.
+    setSuccessMessage("");
+    setErrorMessage("");
     const fetchProduct = async () => {
       setLoading(true);
       try {
@@ -41,6 +44,8 @@ const EditProductForm = ({ productId, onProductUpdated }) => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setSuccessMessage("");
+    setErrorMessage("");
     setLoading(true);
 
     try {
@@ -77,7 +82,7 @@ const EditProductForm = ({ productId, onProductUpdated }) => {
           </div>
         )}
         {errorMessage && (
-          <div className="mb-4 p-4 text-white bg-purple-500 rounded-md">
+          <div className="mb-4 p-4 text-white bg-red-500 rounded-md">
             {errorMessage}
           </div>
         )}

--- a/tests/app/admin/EditProductForm.test.jsx
+++ b/tests/app/admin/EditProductForm.test.jsx
@@ -1,0 +1,83 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { getProductById, updateProduct, uploadProductImage } = vi.hoisted(() => ({
+  getProductById: vi.fn(),
+  updateProduct: vi.fn(),
+  uploadProductImage: vi.fn(),
+}));
+
+vi.mock("../../../lib/products", () => ({
+  getProductById,
+  updateProduct,
+  uploadProductImage,
+}));
+
+import EditProductForm from "../../../app/admin/EditProductForm";
+
+const product = (id, price) => ({
+  name: `Name ${id}`,
+  price,
+  img: `${id}.png`,
+});
+
+describe("EditProductForm stale banner (#27)", () => {
+  it("loads the selected product into the form", async () => {
+    getProductById.mockResolvedValue(product("A", 11));
+    render(<EditProductForm productId="A" onProductUpdated={() => {}} />);
+    expect(await screen.findByDisplayValue("Name A")).toBeTruthy();
+    expect(screen.getByDisplayValue("11")).toBeTruthy();
+  });
+
+  it("does not show a stale success banner after switching products", async () => {
+    getProductById.mockImplementation(async (id) => product(id, 12));
+    updateProduct.mockResolvedValue({ ok: true });
+
+    const { rerender } = render(
+      <EditProductForm productId="A" onProductUpdated={() => {}} />
+    );
+    await screen.findByDisplayValue("Name A");
+
+    fireEvent.click(screen.getByRole("button", { name: /update product/i }));
+    expect(
+      await screen.findByText("Product updated successfully!")
+    ).toBeTruthy();
+
+    // Selecting another product must immediately clear the green banner.
+    rerender(<EditProductForm productId="B" onProductUpdated={() => {}} />);
+    expect(
+      screen.queryByText("Product updated successfully!")
+    ).toBeNull();
+
+    expect(await screen.findByDisplayValue("Name B")).toBeTruthy();
+  });
+
+  it("shows a fetch failure in a red error box", async () => {
+    getProductById.mockRejectedValue(new Error("boom"));
+    render(<EditProductForm productId="A" onProductUpdated={() => {}} />);
+
+    const message = await screen.findByText(
+      "Error fetching product: boom"
+    );
+    expect(message.className).toContain("bg-red-500");
+  });
+
+  it("shows an update failure in a red error box and clears it on reload", async () => {
+    getProductById.mockImplementation(async (id) => product(id, 12));
+    updateProduct.mockRejectedValue(new Error("oops"));
+
+    const { rerender } = render(
+      <EditProductForm productId="A" onProductUpdated={() => {}} />
+    );
+    await screen.findByDisplayValue("Name A");
+
+    fireEvent.click(screen.getByRole("button", { name: /update product/i }));
+    const error = await screen.findByText("Error updating product: oops");
+    expect(error.className).toContain("bg-red-500");
+
+    // Loading another product clears the prior error immediately.
+    rerender(<EditProductForm productId="B" onProductUpdated={() => {}} />);
+    expect(screen.queryByText("Error updating product: oops")).toBeNull();
+    expect(await screen.findByDisplayValue("Name B")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #27

## Problem

`EditProductForm` stays mounted while `productId` changes, but its fetch effect never
cleared `successMessage`/`errorMessage` first - after updating product A the green
'Product updated successfully!' banner still showed above product B. Error messages
were also rendered in the success-style purple box.

## Change

- Reset `successMessage` and `errorMessage` at the start of the fetch effect (so
  loading any product clears prior messages immediately) and before each submit.
- Give error messages a distinct red style (`bg-red-500` instead of `bg-purple-500`).

## Verification

`tests/app/admin/EditProductForm.test.jsx` (new, lib/products mocked):

- loads the selected product into the form
- update product A then select product B: no stale success banner; the banner shows
  after a successful update and is gone immediately on re-render with the new id
- simulated fetch failure shows the message in a **red** error box
- simulated update failure shows the red error box, and it is cleared when another
  product is loaded

## Acceptance criteria (#27)

- [x] Update product A then select product B: no stale success banner is visible
- [x] Simulated fetch/update failure shows the message in a red error box
- [x] Loading a product clears prior messages immediately
- [x] next lint passes (plus npm run test 40/40 and type-check)