### PR TITLE
fix: validate checkout OTP with exact 6-digit compare and numeric input rules

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -21,6 +21,7 @@ import {
 import { BsBank, BsCalendarDate } from "react-icons/bs";
 import { SiKlarna } from "react-icons/si";
 import sendMail from "../../lib/sendmail";
+import { validateOTP } from "../../lib/validation";
 import StellarCheckoutButton from "../../components/StellarCheckoutButton";
 import StellarWalletButton from "../../components/StellarWalletButton";
 import StellarOrderWatch from "../../components/StellarOrderWatch";
@@ -28,7 +29,9 @@ import { SiStellar } from "react-icons/si";
 
 const Checkout = () => {
 
-  const [otp, setOtp] = useState(Math.floor(Math.random() * 1000000) + 1);
+  const [otp, setOtp] = useState(
+    () => String(Math.floor(Math.random() * 1e6)).padStart(6, "0")
+  );
   const [totalPrice, setTotalPrice] = useState(0);
   const [toast, setToast] = useState({ show: false, message: "" });
   const [stage, setStage] = useState(1);
@@ -96,15 +99,15 @@ const Checkout = () => {
 
   const handleEmailConfirmationSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setIsOtpSending(true);
-    if (parseInt(enteredOtp) === otp) {
-      setStage(3);
-      localStorage.clear();
-      showToast("OTP confirmed successfully.");
-    } else {
-      setIsOtpSending(false);
+    const entered = enteredOtp.trim();
+    if (!validateOTP(entered).isValid || entered !== otp) {
       showToast("Incorrect OTP. Please try again.");
+      return;
     }
+    setIsOtpSending(true);
+    setStage(3);
+    localStorage.clear();
+    showToast("OTP confirmed successfully.");
   };
 
   const handleGoBack = () => {
@@ -365,6 +368,8 @@ const Checkout = () => {
                     value={enteredOtp}
                     onChange={handleOtpChange}
                     required
+                    maxLength={6}
+                    inputMode="numeric"
                     placeholder="OTP"
                     className="w-64 px-3 py-2 border rounded"
                   />

--- a/tests/app/checkout/page.otp.test.tsx
+++ b/tests/app/checkout/page.otp.test.tsx
@@ -1,0 +1,116 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { sendMail } = vi.hoisted(() => ({ sendMail: vi.fn() }));
+
+vi.mock("../../../lib/sendmail", () => ({ default: sendMail }));
+vi.mock("../../../components/StellarCheckoutButton", () => ({
+  default: () => null,
+}));
+vi.mock("../../../components/StellarWalletButton", () => ({
+  default: () => null,
+}));
+vi.mock("../../../components/StellarOrderWatch", () => ({
+  default: () => null,
+}));
+vi.mock("../../../context/CartContext", () => ({ useCart: () => ({}) }));
+
+import Checkout from "../../../app/checkout/page";
+
+/** Render the checkout page and submit stage 1, returning the OTP from the (mocked) email. */
+const reachOtpStage = async () => {
+  render(<Checkout />);
+  const form = screen
+    .getByRole("button", { name: /^submit$/i })
+    .closest("form") as HTMLFormElement;
+  fireEvent.submit(form);
+  await act(async () => {});
+  const payload = sendMail.mock.calls[0][0] as { message: string };
+  const match = payload.message.match(/Your OTP is: (\d{6})/);
+  if (!match) throw new Error(`OTP not found in mail message: ${payload.message}`);
+  return match[1];
+};
+
+const submitOtpForm = () => {
+  const form = screen
+    .getByPlaceholderText("OTP")
+    .closest("form") as HTMLFormElement;
+  fireEvent.submit(form);
+  return form;
+};
+
+describe("Checkout OTP validation (#76)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it("sends a zero-padded six-digit OTP and accepts it back", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.000042); // otp = "000042"
+    sendMail.mockResolvedValue(undefined);
+
+    const otp = await reachOtpStage();
+    expect(otp).toBe("000042");
+
+    fireEvent.change(screen.getByPlaceholderText("OTP"), {
+      target: { value: "000042" },
+    });
+    submitOtpForm();
+    expect(await screen.findByText("Order Completed.")).toBeTruthy();
+  });
+
+  it("rejects a wrong numeric OTP", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.000042); // otp = "000042"
+    sendMail.mockResolvedValue(undefined);
+
+    const otp = await reachOtpStage();
+    const wrong = String((Number(otp) + 1) % 1_000_000).padStart(6, "0");
+
+    fireEvent.change(screen.getByPlaceholderText("OTP"), {
+      target: { value: wrong },
+    });
+    submitOtpForm();
+    await act(async () => {});
+
+    expect(screen.queryByText("Order Completed.")).toBeNull();
+    expect(screen.getByText("Incorrect OTP. Please try again.")).toBeTruthy();
+  });
+
+  it("rejects digits followed by junk characters", async () => {
+    sendMail.mockResolvedValue(undefined);
+    const otp = await reachOtpStage();
+    const junk = otp.slice(0, 3) + "x";
+
+    fireEvent.change(screen.getByPlaceholderText("OTP"), {
+      target: { value: junk },
+    });
+    submitOtpForm();
+    await act(async () => {});
+
+    expect(screen.queryByText("Order Completed.")).toBeNull();
+    expect(screen.getByText("Incorrect OTP. Please try again.")).toBeTruthy();
+  });
+
+  it("rejects letters-only input", async () => {
+    sendMail.mockResolvedValue(undefined);
+    await reachOtpStage();
+
+    fireEvent.change(screen.getByPlaceholderText("OTP"), {
+      target: { value: "abc" },
+    });
+    submitOtpForm();
+    await act(async () => {});
+
+    expect(screen.queryByText("Order Completed.")).toBeNull();
+    expect(screen.getByText("Incorrect OTP. Please try again.")).toBeTruthy();
+  });
+
+  it("enforces maxLength=6 and a numeric input on the OTP field", async () => {
+    sendMail.mockResolvedValue(undefined);
+    await reachOtpStage();
+
+    const input = screen.getByPlaceholderText("OTP");
+    expect(input).toHaveAttribute("maxlength", "6");
+    expect(input).toHaveAttribute("inputmode", "numeric");
+  });
+});


### PR DESCRIPTION
Closes #76

## Problem

Checkout OTP verification compared `parseInt(enteredOtp) === otp` where `otp` was a
number (`Math.floor(Math.random()*1000000)+1`), so:

- the emailed code was often shorter than six digits (no zero padding),
- `parseInt` accepted trailing junk ("123x" or "123.4" matched OTP 123),
- the unused `validateOTP` helper in lib/validation.ts was never enforced,
- the input had no `maxLength`/`inputMode`.

## Change

- Store the OTP as a zero-padded 6-digit string.
- Compare the trimmed input with exact string equality, gated by `validateOTP`
  (six digits only - junk characters and letters-only input are rejected).
- Enforce `maxLength={6}` and `inputMode="numeric"` on the OTP field.

## Verification

`tests/app/checkout/page.otp.test.tsx` (new; sendMail and the Stellar components
mocked - the actual OTP is read from the mocked email body):

- a zero-padded OTP such as `000042` (deterministic via a `Math.random` spy) is
  accepted and completes the order
- a wrong numeric OTP is rejected
- digits followed by junk characters are rejected
- letters-only input is rejected
- the field enforces `maxLength=6` and `inputMode=numeric`

- `npm run test` - 41/41 pass (36 existing + 5 new)
- `npm run type-check` - passes
- `npm run lint` - passes (0 errors)

## Acceptance criteria (#76)

- [x] A wrong numeric OTP is rejected and digits followed by junk characters are rejected
- [x] A correct zero-padded OTP such as 000042 is accepted
- [x] Letters-only input is rejected