### PR TITLE
fix: render a persistent error under the ContactUs form and drop the unused ref

### DIFF
--- a/app/(landingpage)/ContactUs.jsx
+++ b/app/(landingpage)/ContactUs.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useRef } from "react";
+import { useState } from "react";
 import { FaGithub, FaTwitter, FaDiscord } from "react-icons/fa";
 import sendMail from "../../lib/sendmail";
 
@@ -33,7 +33,6 @@ const ContactUs = () => {
   const [toast, setToast] = useState({ show: false, message: "" });
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
-  const form = useRef();
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -42,12 +41,14 @@ const ContactUs = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setError(null);
     setIsLoading(true);
     try {
       await sendMail(formData);
+      setError(null);
       showToast("Message sent successfully!");
       setFormData({ name: "", email: "", message: "" });
-    } catch (error) {
+    } catch {
       setError("Failed to send message.");
       showToast("Unable to send message, please try again later");
     }
@@ -179,6 +180,15 @@ const ContactUs = () => {
             )}
           </button>
         </form>
+          {error && (
+            <div
+              className="mt-3 text-sm text-red-600"
+              role="alert"
+              aria-live="polite"
+            >
+              {error}
+            </div>
+          )}
           </div>
         </div>
       </div>

--- a/tests/(landingpage)/ContactUs.error.test.jsx
+++ b/tests/(landingpage)/ContactUs.error.test.jsx
@@ -1,0 +1,61 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { sendMail } = vi.hoisted(() => ({ sendMail: vi.fn() }));
+vi.mock("../../lib/sendmail", () => ({ default: sendMail }));
+
+import ContactUs from "../../app/(landingpage)/ContactUs";
+
+const fillForm = () => {
+  fireEvent.change(screen.getByPlaceholderText("Your Name"), {
+    target: { value: "Tester" },
+  });
+  fireEvent.change(screen.getByPlaceholderText("Your Email"), {
+    target: { value: "tester@example.com" },
+  });
+  fireEvent.change(screen.getByPlaceholderText("Your Message"), {
+    target: { value: "Hello there" },
+  });
+};
+
+const submit = () => {
+  fireEvent.click(screen.getByRole("button", { name: /send message/i }));
+};
+
+describe("ContactUs persistent error rendering (#81)", () => {
+  it("starts with no error region", () => {
+    sendMail.mockResolvedValue(undefined);
+    render(<ContactUs />);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("shows a persistent error when sendMail rejects (not only the toast)", async () => {
+    sendMail.mockRejectedValue(new Error("mail server down"));
+    render(<ContactUs />);
+    fillForm();
+    submit();
+    await act(async () => {});
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Failed to send message.");
+  });
+
+  it("clears the error once a subsequent submit succeeds", async () => {
+    sendMail.mockRejectedValueOnce(new Error("mail server down"));
+    sendMail.mockResolvedValueOnce(undefined);
+    render(<ContactUs />);
+
+    fillForm();
+    submit();
+    await act(async () => {});
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    // fill again (inputs were NOT reset after a failure) and retry
+    fillForm();
+    submit();
+    await act(async () => {});
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByPlaceholderText("Your Name")).toHaveValue("");
+  });
+});


### PR DESCRIPTION
Closes #81

## Problem

`ContactUs`'s catch block called `setError('Failed to send message.')` but nothing in
the render read the error state, so a failed submit was only visible as the transient
toast. The `form` useRef was also declared but never attached to the form.

## Change

- Render the error persistently under the form in an `aria-live` region (`role=alert`).
- Clear it at the start of each submit (retry) and after a success.
- Remove the unused `form` ref (and the now-unneeded `useRef` import).

## Verification

`tests/(landingpage)/ContactUs.error.test.jsx` (new; lib/sendmail mocked):

- no error region on initial render
- a rejected sendMail shows a visible persistent error (role=alert), not only the toast
- the error disappears once a subsequent submit succeeds (and the form resets)

- `npm run test` - 39/39 pass (36 existing + 3 new)
- `npm run type-check` - passes
- `npm run lint` - passes (0 errors)

## Acceptance criteria (#81)

- [x] Mocking sendMail rejection shows a visible persistent error, not only a toast
- [x] The error disappears once a subsequent submit succeeds
- [x] The unused form ref is removed