### PR TITLE
docs: fix dead 'Paying with Stellar' anchors in README and CONTRIBUTING (closes #46)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,7 +219,7 @@ npm run build        # Production build must succeed
 
 If your PR touches the Stellar payment flow, describe in the PR how you tested
 it against testnet (Freighter + USDC faucet account). Follow the flow in the
-root [README](README.md#paying-with-usdc-testnet).
+root [README](README.md#paying-with-stellar-testnet).
 
 ## Commit Message Style
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ buyer ──pay──▶ contract (escrow) ──dispatch──▶ merchant
   - [Step 5b — Whitelist the tokens you accept](#step-5b--whitelist-the-tokens-you-accept)
   - [Step 6 — Wire the deployed contract to the storefront](#step-6--wire-the-deployed-contract-to-the-storefront)
   - [Convenience script](#convenience-script)
-- [Paying with USDC (testnet)](#paying-with-usdc-testnet)
+- [Paying with Stellar (testnet)](#paying-with-stellar-testnet)
 - [Environment Variables Reference](#environment-variables-reference)
 - [Security Notes](#security-notes)
 - [Contributing](#contributing)


### PR DESCRIPTION
## Summary
Closes #46

Fixes the dead table of contents anchor in `README.md` and the stale deep-link in `CONTRIBUTING.md`.

### Changes Made
1. In `README.md`, updated TOC entry line 85 from `[Paying with USDC (testnet)](#paying-with-usdc-testnet)` to `[Paying with Stellar (testnet)](#paying-with-stellar-testnet)` so it accurately matches the actual heading `## Paying with Stellar (testnet)` at line 442.
2. In `CONTRIBUTING.md`, updated line 222 from `root [README](README.md#paying-with-usdc-testnet)` to `root [README](README.md#paying-with-stellar-testnet)`.

### Verification
- `grep 'paying-with-usdc-testnet' README.md CONTRIBUTING.md` returns 0 matches.
- `grep 'paying-with-stellar-testnet' README.md CONTRIBUTING.md` returns matches in both files.
- Verified TOC deep links in `README.md` resolve to valid headings.
