### PR TITLE
fix(ci): gate ci-success on every required check including rust-security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
   # Summary job that requires all checks to pass
   ci-success:
     name: CI Success
-    needs: [frontend, contracts, security]
+    needs: [frontend, contracts, security, rust-security]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
@@ -159,6 +159,14 @@ jobs:
           fi
           if [[ "${{ needs.contracts.result }}" != "success" ]]; then
             echo "Contracts job failed"
+            exit 1
+          fi
+          if [[ "${{ needs.security.result }}" != "success" ]]; then
+            echo "Security job failed"
+            exit 1
+          fi
+          if [[ "${{ needs.rust-security.result }}" != "success" ]]; then
+            echo "Rust security job failed"
             exit 1
           fi
           echo "All required checks passed!"


### PR DESCRIPTION
## Summary
The `ci-success` summary job did not actually gate every required check:

- `needs: [frontend, contracts, security]` omitted the `rust-security` job entirely, so its result was invisible to the gate.
- The script only inspected `needs.frontend.result` and `needs.contracts.result` and printed "All required checks passed!" even when `security` (or any later job) failed.

This change adds `rust-security` to `needs` and gives the summary script an explicit failure branch for each of the four needed jobs.

## Acceptance criteria
- [x] `needs` lists all four jobs including `rust-security`
- [x] The summary script has an explicit failure branch for each needed job
- [x] Forcing a child job to fail makes `ci-success` exit non-zero - the gate logic was exercised locally against every branch (frontend / contracts / security / rust-security failure -> exit 1; all success -> exit 0). Note: the actual GitHub Actions run requires push access to this repo's CI, so the branch-level logic was verified by executing the identical bash script with mocked job results.

## Testing
- YAML parses cleanly (`js-yaml` load of the workflow).
- Gate script logic tested with all four failure permutations and the success path.

Fixes #55
