### PR TITLE
fix(errors): match exact AUTH_ERRORS phrases before broad Stellar heuristics

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -335,6 +335,17 @@ function parseErrorMessage(message: string): AppError {
     }
   }
 
+  // Check auth errors by exact message key or code.
+  // This must run BEFORE the broad keyword heuristics below: an auth message
+  // like "Email not confirmed: you cancelled the verification request"
+  // contains the word "cancelled" and would otherwise be misclassified as
+  // a Stellar USER_REJECTED error.
+  for (const [key, appError] of Object.entries(AUTH_ERRORS)) {
+    if (lowerMessage.includes(key.toLowerCase()) || lowerMessage.includes(appError.code.toLowerCase())) {
+      return appError;
+    }
+  }
+
   // Check for common error patterns
   if (lowerMessage.includes("insufficient") || lowerMessage.includes("balance")) {
     return STELLAR_ERRORS.INSUFFICIENT_BALANCE;
@@ -347,13 +358,6 @@ function parseErrorMessage(message: string): AppError {
   }
   if (lowerMessage.includes("freighter") && (lowerMessage.includes("install") || lowerMessage.includes("not installed"))) {
     return STELLAR_ERRORS.FREIGHTER_NOT_FOUND;
-  }
-
-  // Check auth errors by message
-  for (const [key, appError] of Object.entries(AUTH_ERRORS)) {
-    if (lowerMessage.includes(key.toLowerCase()) || lowerMessage.includes(appError.code.toLowerCase())) {
-      return appError;
-    }
   }
 
   // Return generic error with original message

--- a/tests/lib/errors.test.ts
+++ b/tests/lib/errors.test.ts
@@ -79,3 +79,37 @@ describe("Error Handling & Stellar Error Reconciliation Tests", () => {
     expect(isRecoverable(new WalletError("Wrong net", "WRONG_NETWORK"))).toBe(true);
   });
 });
+
+describe("parseErrorMessage precedence: exact AUTH_ERRORS before broad heuristics", () => {
+  it("classifies an auth message containing 'cancelled' as the auth error, not USER_REJECTED", () => {
+    const parsed = parseError(
+      "Email not confirmed: you cancelled the verification request"
+    );
+    expect(parsed.code).toBe("AUTH_EMAIL_NOT_CONFIRMED");
+    expect(parsed.userMessage).toBe("Please confirm your email before signing in.");
+  });
+
+  it("still maps a pure Stellar cancellation message to USER_REJECTED", () => {
+    const parsed = parseError("Transaction cancelled by user");
+    expect(parsed.code).toBe("WALLET_USER_REJECTED");
+  });
+
+  it("classifies an auth message containing 'timeout' as the auth error, not TX_TIMEOUT", () => {
+    const parsed = parseError(
+      "Invalid login credentials: the request timed out before the server responded"
+    );
+    expect(parsed.code).toBe("AUTH_INVALID_CREDENTIALS");
+  });
+
+  it("still maps a pure Stellar timeout message to TX_TIMEOUT", () => {
+    const parsed = parseError("Transaction submission timed out");
+    expect(parsed.code).toBe("TX_TIMEOUT");
+  });
+
+  it("classifies an auth weak-password message containing 'balance'-like words correctly", () => {
+    const parsed = parseError(
+      "Password should be at least 6 characters: insufficient strength"
+    );
+    expect(parsed.code).toBe("AUTH_WEAK_PASSWORD");
+  });
+});


### PR DESCRIPTION
## Summary
`parseErrorMessage` applied the broad single-word Stellar heuristics (`insufficient`/`balance`, `rejected`/`cancelled`, `timeout`, `freighter`) before iterating `AUTH_ERRORS`. Any auth message containing one of those words was misclassified as a Stellar error - e.g. "Email not confirmed: you cancelled the verification request" returned `USER_REJECTED` instead of `AUTH_EMAIL_NOT_CONFIRMED`.

This change reorders matching so exact `AUTH_ERRORS` phrase/code hits are checked before the broad heuristics, and adds precedence tests documenting the win conditions.

## Acceptance criteria
- [x] `parseError("Email not confirmed: you cancelled the verification request")` returns the auth email-not-confirmed entry, not UserRejected
- [x] A pure Stellar message like "Transaction cancelled by user" still maps to UserRejected
- [x] `npm run test`, `type-check` and `lint` pass (see Testing for the pre-existing-failure note)

## Testing
- New precedence tests in `tests/lib/errors.test.ts` (5 cases): the 3 auth-phrase cases **fail on the previous ordering** (verified by running against unmodified `lib/errors.ts`) and pass after the reorder; the 2 pure-Stellar cases confirm the heuristics still win when no auth phrase matches.
- Full suite: same result set as clean `main` (7 pre-existing failures in validation / checkout / ContactUs / events test files - unrelated to this change and present on `main` before it).

Fixes #35
