### PR TITLE
fix(ci): include rust-security in ci-success needs + explicit failure branches (#55)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
   # Summary job that requires all checks to pass
   ci-success:
     name: CI Success
-    needs: [frontend, contracts, security]
+    needs: [frontend, contracts, security, rust-security]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
@@ -159,6 +159,14 @@ jobs:
           fi
           if [[ "${{ needs.contracts.result }}" != "success" ]]; then
             echo "Contracts job failed"
+            exit 1
+          fi
+          if [[ "${{ needs.security.result }}" != "success" ]]; then
+            echo "Security job failed"
+            exit 1
+          fi
+          if [[ "${{ needs.rust-security.result }}" != "success" ]]; then
+            echo "Rust security job failed"
             exit 1
           fi
           echo "All required checks passed!"


### PR DESCRIPTION
## Summary
Fixes the gating gap in `.github/workflows/ci.yml`: the `ci-success` summary job declared `needs: [frontend, contracts, security]` but its script only inspected the `frontend` and `contracts` results and **completely ignored** both `security` and `rust-security`. As a result:

- A failure in the `security` job (npm audit / trufflehog) would not break `ci-success`.
- The `rust-security` job was missing from `needs` entirely, so cargo-audit failures were invisible to the gate.

## Changes
- `needs: [frontend, contracts, security]` → `needs: [frontend, contracts, security, rust-security]`.
- Added an explicit `if [[ "${{ needs.security.result }}" != "success" ]]; then exit 1; fi` branch to the summary script.
- Added an explicit `if [[ "${{ needs.rust-security.result }}" != "success" ]]; then exit 1; fi` branch.

Forcing any of the four needed jobs to fail now makes `ci-success` exit non-zero, restoring the gate's intent.

## Acceptance criteria (from #55)
- [x] `ci.yml:140` (now `:148`) `needs` lists all four jobs including `rust-security`.
- [x] The summary script has an explicit failure branch for each needed job.
- [x] Forcing a child job to fail makes `ci-success` exit non-zero (logic verified by inspection of the YAML — every branch exits 1 before reaching `All required checks passed!`).

Fixes #55
