### PR TITLE
fix(stellar): distinguish RPC failures from missing accounts in loadAccount and getNativeBalance

### DIFF
--- a/lib/stellar/account.ts
+++ b/lib/stellar/account.ts
@@ -51,11 +51,23 @@ export function isAccountMissingError(err: unknown): boolean {
   if (err instanceof WalletError && err.code === "ACCOUNT_NOT_FOUND") {
     return true;
   }
+  // Numeric HTTP status: soroban-rpc reports a missing account as a 404.
+  // Check the structured fields first so a bare status code is enough even
+  // when the SDK strips the original message.
+  const status =
+    (err as { status?: unknown } | null)?.status ??
+    (err as { response?: { status?: unknown } } | null)?.response?.status;
+  if (status === 404) {
+    return true;
+  }
   const parts: string[] = [];
   if (err instanceof Error) {
     parts.push(err.message);
   }
   const code = (err as { code?: unknown } | null)?.code;
+  if (code === 404) {
+    return true;
+  }
   if (typeof code === "string") {
     parts.push(code);
   }

--- a/lib/stellar/account.ts
+++ b/lib/stellar/account.ts
@@ -43,8 +43,45 @@ export interface PaymentReadiness {
 }
 
 /**
+ * Decides whether a rejection from the RPC layer means "this account does not
+ * exist" (safe to fund / report as unfunded) versus an infrastructure failure
+ * (dead RPC, timeout, auth) that must NOT be mistaken for an empty account.
+ */
+export function isAccountMissingError(err: unknown): boolean {
+  if (err instanceof WalletError && err.code === "ACCOUNT_NOT_FOUND") {
+    return true;
+  }
+  const parts: string[] = [];
+  if (err instanceof Error) {
+    parts.push(err.message);
+  }
+  const code = (err as { code?: unknown } | null)?.code;
+  if (typeof code === "string") {
+    parts.push(code);
+  }
+  const text = parts.join(" ").toLowerCase();
+  return (
+    /account\s+(is\s+)?(not\s+found|missing|does\s+not\s+exist)/.test(text) ||
+    /(not\s+found|missing)\s+account/.test(text) ||
+    text.includes("account_not_found")
+  );
+}
+
+/** Wrap any non-account-missing RPC failure in a distinct RPC_ERROR. */
+function toRpcError(err: unknown): WalletError {
+  const detail = err instanceof Error ? err.message : String(err);
+  return new WalletError(
+    `Stellar RPC request failed: ${detail}. The network may be down - ` +
+      "check your connection or RPC endpoint and retry.",
+    "RPC_ERROR"
+  );
+}
+
+/**
  * Load a buyer account, funding it on testnet when it does not exist yet.
  * On mainnet a missing account is a hard error.
+ * RPC/network failures are rethrown as RPC_ERROR and never trigger friendbot
+ * funding, so a dead RPC is distinguishable from a truly unfunded account.
  */
 export async function loadAccount(
   server: rpc.Server,
@@ -52,14 +89,29 @@ export async function loadAccount(
   opts: { fund?: boolean } = {}
 ): Promise<LoadedAccount> {
   const fund = opts.fund ?? true;
+  let account: Account;
   try {
-    const account = await server.getAccount(publicKey);
+    account = await server.getAccount(publicKey);
     return { account, funded: false };
-  } catch {
+  } catch (err) {
+    if (!isAccountMissingError(err)) {
+      throw toRpcError(err);
+    }
     if (!IS_MAINNET && fund) {
       await fundTestnetAccount(publicKey);
-      const account = await server.getAccount(publicKey);
-      return { account, funded: true };
+      try {
+        account = await server.getAccount(publicKey);
+        return { account, funded: true };
+      } catch (retryErr) {
+        if (!isAccountMissingError(retryErr)) {
+          throw toRpcError(retryErr);
+        }
+        throw new WalletError(
+          "Your Stellar account has no sequence number on this network. " +
+            "Fund it with XLM before paying.",
+          "ACCOUNT_NOT_FOUND"
+        );
+      }
     }
     throw new WalletError(
       "Your Stellar account has no sequence number on this network. " +
@@ -87,8 +139,13 @@ export async function getNativeBalance(
   try {
     const entry = await server.getAccountEntry(publicKey);
     return BigInt(entry.balance().toString());
-  } catch {
-    return BigInt(0);
+  } catch (err) {
+    if (isAccountMissingError(err)) {
+      return BigInt(0);
+    }
+    // Surface RPC/network failures instead of reporting a fake 0 balance,
+    // so an outage is not mistaken for an empty wallet.
+    throw toRpcError(err);
   }
 }
 

--- a/tests/lib/stellar/account.test.ts
+++ b/tests/lib/stellar/account.test.ts
@@ -4,6 +4,7 @@ import {
   MIN_NATIVE_RESERVE,
   loadAccount,
   getNativeBalance,
+  isAccountMissingError,
 } from "../../../lib/stellar/account";
 
 describe("formatAmount", () => {
@@ -107,5 +108,26 @@ describe("loadAccount / getNativeBalance RPC error distinction", () => {
   it("returns BigInt(0) only for a genuine account-missing error", async () => {
     const server = makeServer(undefined, undefined, new Error("account not found"));
     await expect(getNativeBalance(server, publicKey)).resolves.toBe(BigInt(0));
+  });
+});
+
+describe("isAccountMissingError status detection", () => {
+  it("detects a numeric 404 status from err.status or err.response.status", () => {
+    expect(isAccountMissingError({ status: 404 })).toBe(true);
+    expect(isAccountMissingError({ response: { status: 404 } })).toBe(true);
+  });
+
+  it("treats other statuses as NOT account-missing", () => {
+    expect(isAccountMissingError({ status: 500 })).toBe(false);
+    expect(isAccountMissingError({ status: 503 })).toBe(false);
+    expect(isAccountMissingError({ response: { status: 403 } })).toBe(false);
+    expect(isAccountMissingError(null)).toBe(false);
+  });
+
+  it("keeps account-context requirement for text matches", () => {
+    // "not found" alone (e.g. a wrong endpoint path) must not read as a
+    // missing account; only account-specific phrasing does.
+    expect(isAccountMissingError(new Error("Resource not found"))).toBe(false);
+    expect(isAccountMissingError(new Error("account not found"))).toBe(true);
   });
 });

--- a/tests/lib/stellar/account.test.ts
+++ b/tests/lib/stellar/account.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from "vitest";
-import { formatAmount, MIN_NATIVE_RESERVE } from "../../../lib/stellar/account";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  formatAmount,
+  MIN_NATIVE_RESERVE,
+  loadAccount,
+  getNativeBalance,
+} from "../../../lib/stellar/account";
 
 describe("formatAmount", () => {
   it("formats MIN_NATIVE_RESERVE with 7 decimals correctly", () => {
@@ -41,5 +46,66 @@ describe("formatAmount", () => {
     const expectedFrac = (huge % 10000000n).toString().padStart(7, "0").replace(/0+$/, "");
     const expected = expectedFrac ? `${expectedInt}.${expectedFrac}` : expectedInt;
     expect(formatted).toBe(expected);
+  });
+});
+
+describe("loadAccount / getNativeBalance RPC error distinction", () => {
+  const publicKey = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7"; // valid StrKey-checksummed address
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function makeServer(accountErr?: unknown, account?: unknown, entryErr?: unknown, entry?: unknown) {
+    return {
+      getAccount: vi.fn().mockImplementation(() => {
+        if (accountErr) return Promise.reject(accountErr);
+        return Promise.resolve(account);
+      }),
+      getAccountEntry: vi.fn().mockImplementation(() => {
+        if (entryErr) return Promise.reject(entryErr);
+        return Promise.resolve(entry);
+      }),
+    } as unknown as Parameters<typeof loadAccount>[0];
+  }
+
+  it("does not call friendbot and rejects with RPC_ERROR when getAccount fails with a network error", async () => {
+    const server = makeServer(new Error("fetch failed: ECONNREFUSED"));
+    await expect(loadAccount(server, publicKey, { fund: true })).rejects.toMatchObject({
+      name: "WalletError",
+      code: "RPC_ERROR",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("still funds via friendbot when the rejection is an account-missing error", async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    const account = { accountId: () => publicKey, sequenceNumber: () => "1" };
+    const server = makeServer(undefined, account);
+    server.getAccount
+      .mockRejectedValueOnce(new Error("account not found"))
+      .mockResolvedValueOnce(account);
+    const result = await loadAccount(server, publicKey, { fund: true });
+    expect(result.funded).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("friendbot");
+  });
+
+  it("surfaces an RPC failure from getNativeBalance instead of returning BigInt(0)", async () => {
+    const server = makeServer(undefined, undefined, new Error("502 Bad Gateway"));
+    await expect(getNativeBalance(server, publicKey)).rejects.toMatchObject({
+      code: "RPC_ERROR",
+    });
+  });
+
+  it("returns BigInt(0) only for a genuine account-missing error", async () => {
+    const server = makeServer(undefined, undefined, new Error("account not found"));
+    await expect(getNativeBalance(server, publicKey)).resolves.toBe(BigInt(0));
   });
 });


### PR DESCRIPTION
## Summary
`loadAccount` wrapped `server.getAccount` in an untyped catch and, on testnet with `fund=true`, answered ANY failure (timeout, 5xx, auth) by calling `fundTestnetAccount` and presenting the generic "no sequence number" `WalletError`. `getNativeBalance` likewise caught everything and returned `0n`, so a dead RPC was indistinguishable from a truly empty wallet and users were told to top up XLM during an outage.

This change inspects the thrown error before treating it as an account-missing case:

- New `isAccountMissingError()` classifies only account-not-found style rejections (message/code patterns incl. `WalletError` `ACCOUNT_NOT_FOUND`) as "missing account"
- Every other rejection is wrapped in a distinct `WalletError` with code `RPC_ERROR` and rethrown - friendbot is never called for infrastructure failures
- `getNativeBalance` surfaces RPC failures instead of returning `BigInt(0)`; a genuine missing account still returns `BigInt(0)` as documented

## Acceptance criteria
- [x] A stubbed `rpc.Server` whose `getAccount` rejects with a network-style error never calls `FRIENDBOT_URL` and the promise rejects (on testnet)
- [x] An account-missing rejection still triggers the existing fund path (friendbot called once, then retry succeeds -> `funded: true`)
- [x] `getNativeBalance` test: an RPC rejection is surfaced as `RPC_ERROR` rather than returning `BigInt(0)`
- [x] `npm run type-check` passes; new tests pass (11/11 in `tests/lib/stellar/account.test.ts`)

## Testing
- 4 new stubbed-rpc tests in `tests/lib/stellar/account.test.ts` covering both win conditions (network failure -> `RPC_ERROR`, no friendbot; account-missing -> funding path / `0n`)
- `tsc --noEmit --skipLibCheck` clean

Fixes #19
