### PR TITLE
fix(cart): give each line item a unique lineId so duplicate rows are independent

### DIFF
--- a/app/shop/[id]/page.jsx
+++ b/app/shop/[id]/page.jsx
@@ -105,7 +105,7 @@ const ProductPage = ({ params }) => {
           <div>
             {cartItems.map((item) => (
               <div
-                key={item.id}
+                key={item.lineId ?? item.id}
                 className="flex justify-between items-center mb-2"
               >
                 <div className="w-16 h-16 flex-shrink-0">

--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -102,7 +102,7 @@ export default function Products() {
           <div>
             {cartItems.map((item) => (
               <div
-                key={item.id}
+                key={item.lineId ?? item.id}
                 className="flex justify-between items-center mb-2"
               >
                 <div className="w-16 h-16 flex-shrink-0">

--- a/context/CartContext.jsx
+++ b/context/CartContext.jsx
@@ -5,6 +5,23 @@ const CartContext = createContext();
 
 export const useCart = () => useContext(CartContext);
 
+// Unique per-cart-line identifier. Adding the same product twice must create
+// two independent rows (each removable on its own, each with a unique React
+// key), so every line item gets a `lineId` that is unique across the cart
+// lifetime and stable across localStorage persistence.
+let lineIdSequence = 0;
+const makeLineId = (productId) => {
+  lineIdSequence += 1;
+  return `${productId}#${lineIdSequence}-${Date.now().toString(36)}`;
+};
+
+// Normalize items restored from localStorage: carts persisted by an older
+// version of this context have no `lineId` yet.
+const ensureLineId = (item) =>
+  item && typeof item === "object" && !item.lineId
+    ? { ...item, lineId: makeLineId(item.id) }
+    : item;
+
 export const CartProvider = ({ children }) => {
   const [cartItems, setCartItems] = useState([]);
   const [itemCount, setItemCount] = useState(0);
@@ -51,14 +68,15 @@ export const CartProvider = ({ children }) => {
       storedTotalPrice = 0;
     }
 
-    setCartItems(storedCartItems);
+    setCartItems(storedCartItems.map(ensureLineId));
     setItemCount(storedItemCount);
     setTotalPrice(storedTotalPrice);
   }, []);
 
   const addToCart = (product) => {
     setCartItems((prevCartItems) => {
-      const updatedCartItems = [...prevCartItems, product];
+      const lineItem = ensureLineId(product);
+      const updatedCartItems = [...prevCartItems, lineItem];
       localStorage.setItem("cartItems", JSON.stringify(updatedCartItems));
       return updatedCartItems;
     });
@@ -76,7 +94,14 @@ export const CartProvider = ({ children }) => {
 
   const removeFromCart = (product) => {
     setCartItems((prevCartItems) => {
-      const index = prevCartItems.findIndex((item) => item.id === product.id);
+      // Remove the exact line instance (by lineId) so that, with duplicate
+      // products in the cart, only the row whose Remove button was clicked
+      // disappears. Fall back to product id matching for legacy callers that
+      // pass a bare product object.
+      const index =
+        product?.lineId != null
+          ? prevCartItems.findIndex((item) => item.lineId === product.lineId)
+          : prevCartItems.findIndex((item) => item.id === product?.id);
       if (index === -1) return prevCartItems;
 
       const removedItem = prevCartItems[index];

--- a/tests/lib/cart-context.test.jsx
+++ b/tests/lib/cart-context.test.jsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import React, { act } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { CartProvider, useCart } from "../../context/CartContext";
+
+const PRODUCT = {
+  id: 42,
+  name: "Test Product",
+  price: 10,
+  img: "/test.png",
+};
+
+function TestConsumer() {
+  const { cartItems, itemCount, totalPrice, addToCart, removeFromCart } =
+    useCart();
+  return (
+    <div>
+      <div data-testid="count">{itemCount}</div>
+      <div data-testid="total">{totalPrice}</div>
+      <ul data-testid="rows">
+        {cartItems.map((item) => (
+          <li key={item.lineId ?? item.id} data-lineid={item.lineId}>
+            {item.name}
+            <button onClick={() => removeFromCart(item)}>remove</button>
+          </li>
+        ))}
+      </ul>
+      <button onClick={() => addToCart(PRODUCT)}>add</button>
+    </div>
+  );
+}
+
+function renderCart() {
+  return render(
+    <CartProvider>
+      <TestConsumer />
+    </CartProvider>
+  );
+}
+
+describe("CartContext duplicate line items", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("adds the same product twice as two rows with unique lineIds and no duplicate keys", () => {
+    const { container } = renderCart();
+    const add = screen.getByText("add");
+    act(() => {
+      fireEvent.click(add);
+      fireEvent.click(add);
+    });
+
+    expect(screen.getByTestId("count").textContent).toBe("2");
+    expect(screen.getByTestId("total").textContent).toBe("20");
+
+    const rows = screen.getAllByRole("listitem");
+    expect(rows).toHaveLength(2);
+    const lineIds = rows.map((r) => r.getAttribute("data-lineid"));
+    expect(new Set(lineIds).size).toBe(2);
+    // Every line id is unique in the DOM (no React duplicate-key warnings)
+    expect(container.querySelectorAll("[data-lineid]").length).toBe(2);
+  });
+
+  it("removes only the clicked duplicate row (lower one leaves the upper intact)", () => {
+    renderCart();
+    const add = screen.getByText("add");
+    act(() => {
+      fireEvent.click(add);
+      fireEvent.click(add);
+    });
+    const [firstRow, secondRow] = screen.getAllByRole("listitem");
+
+    act(() => {
+      fireEvent.click(firstRow.querySelector("button"));
+    });
+
+    const remaining = screen.getAllByRole("listitem");
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].getAttribute("data-lineid")).toBe(
+      secondRow.getAttribute("data-lineid")
+    );
+    expect(screen.getByTestId("count").textContent).toBe("1");
+    expect(screen.getByTestId("total").textContent).toBe("10");
+  });
+
+  it("removing the upper duplicate row leaves the lower one intact", () => {
+    renderCart();
+    const add = screen.getByText("add");
+    act(() => {
+      fireEvent.click(add);
+      fireEvent.click(add);
+    });
+    const [firstRow] = screen.getAllByRole("listitem");
+
+    act(() => {
+      fireEvent.click(screen.getAllByRole("listitem")[1].querySelector("button"));
+    });
+
+    const remaining = screen.getAllByRole("listitem");
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].getAttribute("data-lineid")).toBe(
+      firstRow.getAttribute("data-lineid")
+    );
+  });
+
+  it("keeps itemCount and totalPrice correct across duplicate add/remove cycles", () => {
+    renderCart();
+    const add = screen.getByText("add");
+    act(() => {
+      fireEvent.click(add);
+      fireEvent.click(add);
+      fireEvent.click(add);
+    });
+    expect(screen.getByTestId("count").textContent).toBe("3");
+    expect(screen.getByTestId("total").textContent).toBe("30");
+
+    act(() => {
+      fireEvent.click(screen.getAllByRole("listitem")[1].querySelector("button"));
+    });
+    expect(screen.getByTestId("count").textContent).toBe("2");
+    expect(screen.getByTestId("total").textContent).toBe("20");
+  });
+
+  it("assigns lineIds to legacy persisted carts that have none", () => {
+    localStorage.setItem(
+      "cartItems",
+      JSON.stringify([{ ...PRODUCT }, { ...PRODUCT }])
+    );
+    localStorage.setItem("itemCount", "2");
+    localStorage.setItem("totalPrice", "20");
+
+    renderCart();
+
+    const rows = screen.getAllByRole("listitem");
+    expect(rows).toHaveLength(2);
+    const lineIds = rows.map((r) => r.getAttribute("data-lineid"));
+    expect(lineIds.every(Boolean)).toBe(true);
+    expect(new Set(lineIds).size).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
`addToCart` pushed one bare product per click with no quantity grouping, so `cartItems` could hold the same `product.id` multiple times. Both cart modals mapped rows with `key={item.id}` (duplicate React keys), and `removeFromCart` spliced the first matching index, so removing the second identical row deleted the first.

This change assigns each line item a unique `lineId` at add time:

- `addToCart` wraps the product in a line item carrying a unique `lineId`
- Carts restored from `localStorage` by older versions are backfilled with `lineId`s on mount
- Both cart modals key rows on `item.lineId` (falling back to `item.id`)
- `removeFromCart` removes by `lineId`, falling back to product-id matching for legacy callers that pass a bare product object

## Acceptance criteria
- [x] Adding the same product twice renders two rows with unique keys (lineIds unique, count/total = 2 / 2x price)
- [x] Removing the lower duplicate row leaves the upper one intact and vice versa
- [x] itemCount and totalPrice stay correct across duplicate add/remove cycles
- [x] `npm run type-check` passes; new tests pass (5/5)

## Testing
- New `tests/lib/cart-context.test.jsx` (5 cases): duplicate adds render independent rows, each row removes independently (both directions), counters stay correct, and legacy persisted carts without `lineId` are migrated
- `tsc --noEmit --skipLibCheck` clean; eslint clean on changed files

Fixes #24
