### PR TITLE
fix(stellar): retry getLatestLedger on startup RPC outage and defer polling (closes #68)

### DIFF
--- a/lib/stellar/indexer.ts
+++ b/lib/stellar/indexer.ts
@@ -64,6 +64,8 @@ export class PaymentEventIndexer {
   private timer: ReturnType<typeof setInterval> | null = null;
   private running = false;
   private started = false;
+  private initializing = false;
+  private initialized = false;
 
   constructor(
     opts: {
@@ -96,7 +98,8 @@ export class PaymentEventIndexer {
     this.running = true;
     this.started = true;
 
-    void this.initialize(callbacks);
+    this.timer = setInterval(() => void this.tick(callbacks), this.pollMs);
+    void this.tick(callbacks);
   }
 
   stop(): void {
@@ -107,7 +110,23 @@ export class PaymentEventIndexer {
     }
   }
 
-  private async initialize(callbacks: IndexerCallbacks): Promise<void> {
+  private async tick(callbacks: IndexerCallbacks): Promise<void> {
+    if (!this.running) return;
+
+    if (!this.initialized) {
+      await this.ensureInitialized(callbacks);
+      if (!this.initialized) {
+        return;
+      }
+    }
+
+    await this.poll(callbacks);
+  }
+
+  private async ensureInitialized(callbacks: IndexerCallbacks): Promise<void> {
+    if (this.initializing) return;
+    this.initializing = true;
+
     try {
       const latest = await this.server.getLatestLedger();
       this.latestLedger = latest.sequence;
@@ -115,18 +134,20 @@ export class PaymentEventIndexer {
         1,
         this.latestLedger - EVENT_START_LEDGER_BACKFILL
       );
+      this.initialized = true;
+      this.lastError = undefined;
       callbacks.onStatus?.(this.status);
     } catch (err) {
       this.lastError = String(err instanceof Error ? err.message : err);
       callbacks.onError?.(new Error(`Could not reach the Stellar RPC: ${this.lastError}`));
+      callbacks.onStatus?.(this.status);
+    } finally {
+      this.initializing = false;
     }
-
-    this.timer = setInterval(() => void this.poll(callbacks), this.pollMs);
-    void this.poll(callbacks);
   }
 
   private async poll(callbacks: IndexerCallbacks): Promise<void> {
-    if (!this.running) return;
+    if (!this.running || !this.initialized) return;
 
     try {
       const res = await this.fetchEvents();

--- a/tests/lib/stellar/indexer.test.ts
+++ b/tests/lib/stellar/indexer.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { PaymentEventIndexer } from "../../../lib/stellar/indexer";
+
+describe("PaymentEventIndexer startup retry", () => {
+  it("retries getLatestLedger when initial call fails and recovers without 'no cursor' error", async () => {
+    let getLatestLedgerAttempts = 0;
+    let getEventsCalled = false;
+
+    const fakeServer = {
+      getLatestLedger: vi.fn().mockImplementation(async () => {
+        getLatestLedgerAttempts++;
+        if (getLatestLedgerAttempts === 1) {
+          throw new Error("RPC unavailable");
+        }
+        return { sequence: 100 };
+      }),
+      getEvents: vi.fn().mockImplementation(async () => {
+        getEventsCalled = true;
+        return {
+          latestLedger: 100,
+          cursor: "cursor-1",
+          events: [],
+        };
+      }),
+    };
+
+    const indexer = new PaymentEventIndexer({ pollMs: 50 });
+    (indexer as unknown as { server: unknown }).server = fakeServer;
+
+    const errors: string[] = [];
+    const statuses: unknown[] = [];
+
+    indexer.start({
+      onEvent: () => {},
+      onError: (err) => errors.push(err.message),
+      onStatus: (st) => statuses.push(st),
+    });
+
+    // Wait for first attempt to run and fail
+    await new Promise((r) => setTimeout(r, 10));
+    expect(getLatestLedgerAttempts).toBe(1);
+    expect(getEventsCalled).toBe(false);
+    expect(errors.some((e) => e.includes("Could not reach the Stellar RPC"))).toBe(true);
+    expect(errors.some((e) => e.includes("no cursor or start ledger"))).toBe(false);
+
+    // Wait for second tick interval
+    await new Promise((r) => setTimeout(r, 60));
+    expect(getLatestLedgerAttempts).toBeGreaterThanOrEqual(2);
+    expect(getEventsCalled).toBe(true);
+    expect(errors.some((e) => e.includes("no cursor or start ledger"))).toBe(false);
+    expect(indexer.status.lastCursor).toBe("cursor-1");
+
+    indexer.stop();
+  });
+});
+
+  it("handles continuous poll updates when initialized normally", async () => {
+    let callCount = 0;
+    const fakeServer = {
+      getLatestLedger: vi.fn().mockResolvedValue({ sequence: 200 }),
+      getEvents: vi.fn().mockImplementation(async () => {
+        callCount++;
+        return {
+          latestLedger: 200 + callCount,
+          cursor: `cursor-${callCount}`,
+          events: [],
+        };
+      }),
+    };
+
+    const indexer = new PaymentEventIndexer({ pollMs: 40 });
+    (indexer as unknown as { server: unknown }).server = fakeServer;
+
+    indexer.start({
+      onEvent: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+    expect(callCount).toBeGreaterThanOrEqual(2);
+    expect(indexer.status.latestLedger).toBeGreaterThanOrEqual(202);
+
+    indexer.stop();
+  });


### PR DESCRIPTION
### Summary
Fixes #68 by ensuring `PaymentEventIndexer` retries `server.getLatestLedger()` on tick intervals when the initial RPC call fails, rather than starting an immediate event polling loop without a valid start ledger or cursor.

### Root Cause
Previously, `initialize()` attempted `server.getLatestLedger()` once on startup. If that failed, it reported `onError` but still started the interval timer. Each subsequent `poll()` call reached `fetchEvents()` without `cursor` or `startLedger`, throwing `Indexer has no cursor or start ledger to poll from` continuously because `recoverFromRetentionError()` is a no-op when `startLedger` is undefined.

### Changes
1. **Deferred Polling Until Initialization**: Added `ensureInitialized()` lifecycle logic in `tick()`. If `getLatestLedger()` fails during startup, the indexer marks the status with `lastError` and `onError`, and retries initializing on the configured tick interval until it succeeds.
2. **Safe Event Polling**: `poll()` only runs once `initialized === true` and `startLedger` or `cursor` is established.
3. **Unit Tests**: Added `tests/lib/stellar/indexer.test.ts` verifying that:
   - A transient initial `getLatestLedger` failure retries and recovers seamlessly without throwing "no cursor or start ledger".
   - Regular indexer polling runs smoothly across intervals.

### Validation
- Ran unit tests with Vitest:
  ```bash
  npx vitest run tests/lib/stellar/indexer.test.ts
  ```
  All tests passed (2/2 passed).
