### PR TITLE
test: fix decodePaymentEvent fixture for CHECKOUT_CONTRACT_ID scoping; drop empty validation suite

### DIFF
--- a/tests/lib/stellar/events.test.ts
+++ b/tests/lib/stellar/events.test.ts
@@ -1,7 +1,6 @@
 import { StrKey, xdr, Address } from "@stellar/stellar-sdk";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 
-import { decodePaymentEvent } from "../../../lib/stellar/events";
 import { i128ToScVal } from "../../../lib/stellar/scval";
 
 // ---------------------------------------------------------------------------
@@ -9,7 +8,24 @@ import { i128ToScVal } from "../../../lib/stellar/scval";
 // decodePaymentEvent is pure over these — no RPC access needed.
 // ---------------------------------------------------------------------------
 
+// decodePaymentEvent (via lib/stellar/config.ts) reads
+// NEXT_PUBLIC_CHECKOUT_CONTRACT_ID at module scope and ignores pay events
+// emitted by any other contract. Point the env var at the fixture contract
+// and load the module after stubbing.
 const CONTRACT_ID = new Uint8Array(32).fill(7);
+const CHECKOUT_CONTRACT_ID_STR = StrKey.encodeContract(CONTRACT_ID as never);
+
+vi.stubEnv("NEXT_PUBLIC_CHECKOUT_CONTRACT_ID", CHECKOUT_CONTRACT_ID_STR);
+vi.resetModules();
+
+let decodePaymentEvent: (
+  tx: unknown
+) => import("../../../lib/stellar/events").PaymentReceipt | null;
+
+beforeAll(async () => {
+  const ev = await import("../../../lib/stellar/events");
+  decodePaymentEvent = ev.decodePaymentEvent as never;
+});
 const TOKEN = "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA";
 const BUYER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 const MERCHANT = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
@@ -73,7 +89,7 @@ describe("decodePaymentEvent", () => {
     expect(receipt).not.toBeNull();
     expect(receipt?.txHash).toBe(TX_HASH);
     expect(receipt?.ledger).toBe(LEDGER);
-    expect(receipt?.contractId).toBe(StrKey.encodeContract(CONTRACT_ID));
+    expect(receipt?.contractId).toBe(CHECKOUT_CONTRACT_ID_STR);
     expect(receipt?.token).toBe(TOKEN);
     expect(receipt?.buyer).toBe(BUYER);
     expect(receipt?.merchant).toBe(MERCHANT);


### PR DESCRIPTION
Two test-only fixes for the red CI on main (no behavior changes):

1. `tests/lib/stellar/events.test.ts` (merged via #156) now fails because `decodePaymentEvent` gained contract scoping in #69: it ignores pay events whose contract id differs from `NEXT_PUBLIC_CHECKOUT_CONTRACT_ID`. The test setup pins that env var to a placeholder string that is not a valid contract strkey, so every fixture event was rejected and the receipt came back null.

   Fix: the test now stubs `NEXT_PUBLIC_CHECKOUT_CONTRACT_ID` to the encoded fixture contract (via `vi.stubEnv` + `vi.resetModules` + dynamic import) and asserts against that value. 7/7 pass.

2. `tests/lib/validation.test.ts` was committed as a 0-byte file, which vitest rejects with 'No test suite found'. Removed.

This takes main from 9 failing tests / 5 failing files down to 6 failing tests in 3 component test files (ContactUs alert duplication and checkout button-state tests, which I left to the maintainers since they pair with recent component rework). No changes to runtime code.