### PR TITLE
fix(sidebar): wire up search input to shop product filter and remove inert modal (closes #79)

### DIFF
--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { useCart } from "../../context/CartContext";
 import Image from "next/image";
 import Link from "next/link";
@@ -12,6 +13,8 @@ import { listProducts } from "../../lib/products";
 export default function Products() {
   const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } =
     useCart();
+  const searchParams = useSearchParams();
+  const searchQuery = searchParams ? searchParams.get("search") || "" : "";
   const [showModal, setShowModal] = useState(false);
   const [toast, setToast] = useState({ show: false, message: "" });
   const [isCheckingOut, setIsCheckingOut] = useState(false);
@@ -49,6 +52,12 @@ export default function Products() {
   const openModal = () => setShowModal(true);
   const closeModal = () => setShowModal(false);
 
+  const filteredProducts = searchQuery.trim()
+    ? products.filter((prod) =>
+        prod.name.toLowerCase().includes(searchQuery.toLowerCase().trim())
+      )
+    : products;
+
   return (
     <>
       <div className="w-full max-w-screen-xl mx-auto py-8">
@@ -58,34 +67,46 @@ export default function Products() {
             Welcome to Mova Store
           </span>
 
+          {searchQuery && (
+            <p className="text-center text-gray-600 mb-4">
+              Showing search results for &ldquo;{searchQuery}&rdquo;
+            </p>
+          )}
+
           {error && <p className="text-red-500 text-center">{error}</p>}
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
-            {products.map((prod) => (
-              <div key={prod.id} className="p-4 border rounded-lg shadow">
-                <Link href={`/shop/${prod.id}`}>
-                  <Image
-                    src={prod.img} // Ensure this URL is correct
-                    alt={prod.name}
-                    width={200}
-                    height={200}
-                    className="mb-2"
-                  />
-                  <h1 className="text-xl font-bold">{prod.name}</h1>
-                  <h2 className="text-lg">${prod.price}</h2>
-                </Link>
-                <button
-                  className="border-purple-800 rounded-full px-2 py-2 mt-2 border-2 hover:border-purple-600"
-                  onClick={() => {
-                    addToCart(prod);
-                    showToast("Item added to cart");
-                  }}
-                >
-                  <FaShoppingCart />
-                </button>
-              </div>
-            ))}
-          </div>
+          {filteredProducts.length === 0 && !error ? (
+            <p className="text-center text-gray-500 py-8">
+              No products found{searchQuery ? ` matching "${searchQuery}"` : ""}.
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+              {filteredProducts.map((prod) => (
+                <div key={prod.id} className="p-4 border rounded-lg shadow">
+                  <Link href={`/shop/${prod.id}`}>
+                    <Image
+                      src={prod.img} // Ensure this URL is correct
+                      alt={prod.name}
+                      width={200}
+                      height={200}
+                      className="mb-2"
+                    />
+                    <h1 className="text-xl font-bold">{prod.name}</h1>
+                    <h2 className="text-lg">${prod.price}</h2>
+                  </Link>
+                  <button
+                    className="border-purple-800 rounded-full px-2 py-2 mt-2 border-2 hover:border-purple-600"
+                    onClick={() => {
+                      addToCart(prod);
+                      showToast("Item added to cart");
+                    }}
+                  >
+                    <FaShoppingCart />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
         </section>
       </div>
 

--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import {
   FaHome,
   FaInfoCircle,
@@ -13,24 +14,38 @@ import {
 import { FaShoePrints } from "react-icons/fa6";
 import { FcSportsMode } from "react-icons/fc";
 import { useAuth } from "../lib/AuthContext";
-import Modal from "../components/Modal";
+
 export default function Sidebar() {
   const { user, isAdmin } = useAuth();
-  const [showModal, setShowModal] = useState(false);
-  const openModal = () => setShowModal(true);
-  const closeModal = () => setShowModal(false);
+  const router = useRouter();
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const handleSearchSubmit = (e) => {
+    e.preventDefault();
+    const query = searchTerm.trim();
+    if (query) {
+      router.push(`/shop?search=${encodeURIComponent(query)}`);
+    } else {
+      router.push("/shop");
+    }
+  };
   
   return (
     <>
       <aside className="w-64 bg-white text-gray-700 flex-shrink-0  hidden sm:block pt-10">
         <nav className="divide-y divide-gray-200">
           <ul className="px-5 py-6 space-y-2">
-            <li onClick={openModal}>
-              <input
-                type="text"
-                className="w-full bg-gray-100 rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent placeholder-gray-500"
-                placeholder="Search Shoes"
-              />
+            <li>
+              <form onSubmit={handleSearchSubmit}>
+                <input
+                  type="text"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="w-full bg-gray-100 rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent placeholder-gray-500"
+                  placeholder="Search Shoes"
+                  aria-label="Search Shoes"
+                />
+              </form>
             </li>
             <li>
               <Link
@@ -108,8 +123,14 @@ export default function Sidebar() {
       <aside className="flex flex-col justify-center  w-10 bg-purple-600 text-gray-700 flex-shrink-0  sm:hidden  pt-10">
         <nav className="divide-y divide-gray-200">
           <ul className="py-6 space-y-14 px-2">
-            <li className=" hover:text-white transition-colors duration-200">
-              <FaSearch size={20} className="mr-3" />
+            <li>
+              <Link
+                href="/shop"
+                className="hover:text-white transition-colors duration-200"
+                aria-label="Search shop"
+              >
+                <FaSearch size={20} className="mr-3" />
+              </Link>
             </li>
             <li>
               <Link
@@ -159,13 +180,6 @@ export default function Sidebar() {
           </ul>
         </nav>
       </aside>
-      <Modal show={showModal} onClose={closeModal}>
-        <input
-          type="text"
-          className="w-full bg-gray-100 rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent placeholder-gray-500"
-          placeholder="Search Shoes"
-        />
-      </Modal>
     </>
   );
 }

--- a/tests/components/Sidebar.test.tsx
+++ b/tests/components/Sidebar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import Sidebar from "../../components/Sidebar";
 
 // Mock AuthContext
@@ -9,10 +9,19 @@ vi.mock("../../lib/AuthContext", () => ({
   useAuth: () => mockUseAuth(),
 }));
 
-// Mock Modal component
-vi.mock("../../components/Modal", () => ({
-  default: ({ show, children }: { show: boolean; children: React.ReactNode }) =>
-    show ? <div data-testid="modal">{children}</div> : null,
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  useSearchParams: () => ({
+    get: vi.fn(),
+  }),
+  usePathname: () => "/",
 }));
 
 describe("Sidebar component", () => {
@@ -59,5 +68,39 @@ describe("Sidebar component", () => {
 
     const adminLinks = screen.queryAllByRole("link", { name: /admin/i });
     expect(adminLinks.length).toBe(0);
+  });
+
+  it("handles search input submit and navigates to shop with query parameter", () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAdmin: false,
+      loading: false,
+    });
+
+    render(<Sidebar />);
+
+    const searchInput = screen.getByRole("textbox", { name: /search shoes/i });
+    expect(searchInput).toBeInTheDocument();
+
+    fireEvent.change(searchInput, { target: { value: "Air Max" } });
+    fireEvent.submit(searchInput.closest("form")!);
+
+    expect(mockPush).toHaveBeenCalledWith("/shop?search=Air%20Max");
+  });
+
+  it("navigates to /shop when search is submitted empty", () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAdmin: false,
+      loading: false,
+    });
+
+    render(<Sidebar />);
+
+    const searchInput = screen.getByRole("textbox", { name: /search shoes/i });
+    fireEvent.change(searchInput, { target: { value: "   " } });
+    fireEvent.submit(searchInput.closest("form")!);
+
+    expect(mockPush).toHaveBeenCalledWith("/shop");
   });
 });

--- a/tests/shop/search.test.tsx
+++ b/tests/shop/search.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import Products from "../../app/shop/page";
+import * as productsModule from "../../lib/products";
+
+// Mock CartContext
+vi.mock("../../context/CartContext", () => ({
+  useCart: () => ({
+    itemCount: 0,
+    cartItems: [],
+    addToCart: vi.fn(),
+    removeFromCart: vi.fn(),
+    totalPrice: 0,
+  }),
+}));
+
+const mockGet = vi.fn();
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({
+    get: (key: string) => mockGet(key),
+  }),
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+  usePathname: () => "/shop",
+}));
+
+describe("Shop page search filter", () => {
+  const dummyProducts = [
+    { id: "1", name: "Nike Air Jordan 1", price: 150, img: "/img1.png", description: "Classic" },
+    { id: "2", name: "Adidas Ultraboost", price: 180, img: "/img2.png", description: "Running" },
+    { id: "3", name: "Nike Air Max 90", price: 130, img: "/img3.png", description: "Casual" },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(productsModule, "listProducts").mockResolvedValue(dummyProducts as never);
+  });
+
+  it("renders all products when no search param is set", async () => {
+    mockGet.mockReturnValue(null);
+
+    render(<Products />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Nike Air Jordan 1")).toBeInTheDocument();
+      expect(screen.getByText("Adidas Ultraboost")).toBeInTheDocument();
+      expect(screen.getByText("Nike Air Max 90")).toBeInTheDocument();
+    });
+  });
+
+  it("filters products matching the search query", async () => {
+    mockGet.mockImplementation((key: string) => (key === "search" ? "Air Max" : null));
+
+    render(<Products />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Nike Air Max 90")).toBeInTheDocument();
+      expect(screen.queryByText("Adidas Ultraboost")).not.toBeInTheDocument();
+      expect(screen.queryByText("Nike Air Jordan 1")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(/Showing search results for/i)).toBeInTheDocument();
+  });
+
+  it("shows empty state when no products match the query", async () => {
+    mockGet.mockImplementation((key: string) => (key === "search" ? "NonExistentShoe" : null));
+
+    render(<Products />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No products found matching "NonExistentShoe"/i)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
### Summary
Fixes #79 by replacing the inert `onClick={openModal}` wrapper and dead modal in `components/Sidebar.jsx` with a functional search form that navigates to `/shop?search=<query>` upon submit (or `/shop` when empty), and wiring up `app/shop/page.jsx` to dynamically filter products by name based on the `search` query parameter.

### Changes
1. **Sidebar (`components/Sidebar.jsx`)**:
   - Replaced `<li onClick={openModal}>` and duplicate popup modal with a `<form onSubmit={handleSearchSubmit}>` wrapping the text input with `aria-label="Search Shoes"`.
   - On submission with a non-empty term, navigates to `/shop?search=<query>`. On empty term, routes cleanly to `/shop`.
   - Updated mobile sidebar search icon link to point to `/shop` with `aria-label="Search shop"`.
   - Removed unused `Modal` import and state in Sidebar.

2. **Shop Page (`app/shop/page.jsx`)**:
   - Reads `useSearchParams().get("search")` to filter products client-side by case-insensitive name substring matching.
   - Shows active search feedback ("Showing search results for ...") and a clean empty state ("No products found matching ...") when no items match.

3. **Tests**:
   - Added unit tests in `tests/components/Sidebar.test.tsx` verifying input change and form submission routing with and without search term.
   - Added unit tests in `tests/shop/search.test.tsx` verifying product listing filtering and empty states.

### Validation
- Ran vitest unit tests:
  ```bash
  npx vitest run tests/components/Sidebar.test.tsx tests/shop/search.test.tsx
  ```
  All 8 tests passed across both test files.
