### PR TITLE
docs: use one canonical mainnet RPC default (soroban-rpc.stellar.org) in code and docs

### DIFF
--- a/docs/MAINNET_DEPLOYMENT.md
+++ b/docs/MAINNET_DEPLOYMENT.md
@@ -150,7 +150,7 @@ Update your `.env.local` (or production environment variables):
 NEXT_PUBLIC_STELLAR_NETWORK=mainnet
 
 # Mainnet RPC endpoint (use a reliable provider)
-NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-rpc.mainnet.stellar.gateway.fm
+NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-rpc.stellar.org
 
 # Mainnet passphrase
 NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE=Public Global Stellar Network ; September 2015

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -54,7 +54,7 @@ const STELLAR_DEFAULTS = {
       "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
   },
   mainnet: {
-    rpcUrl: "https://soroban-rpc.mainnet.stellar.gateway.fm",
+    rpcUrl: "https://soroban-rpc.stellar.org",
     networkPassphrase: "Public Global Stellar Network ; September 2015",
     usdcContractId: "", // Must be configured for mainnet
     nativeAssetContractId: "", // Must be configured for mainnet


### PR DESCRIPTION
Closes #108

## Problem

Three places, two endpoints, no single source of truth:

- `lib/stellar/config.ts` defaults the mainnet RPC to `https://soroban-rpc.stellar.org`
- `lib/env.ts` hard-codes `https://soroban-rpc.mainnet.stellar.gateway.fm`
  (`STELLAR_DEFAULTS.mainnet.rpcUrl`)
- `docs/MAINNET_DEPLOYMENT.md` tells operators to set the gateway.fm endpoint

## Change

Picked `https://soroban-rpc.stellar.org` (the SDF-operated endpoint that `config.ts`
already uses) as the canonical default and aligned the other two places:

- `lib/env.ts`: `STELLAR_DEFAULTS.mainnet.rpcUrl` -> `https://soroban-rpc.stellar.org`
- `docs/MAINNET_DEPLOYMENT.md`: `NEXT_PUBLIC_STELLAR_RPC_URL` line -> same endpoint

No testnet behaviour changes (testnet default untouched); no runtime change for
deployments that set `NEXT_PUBLIC_STELLAR_RPC_URL` explicitly.

## Verification

- When the env var is unset, `config.ts` (`RPC_URL`) and `lib/env.ts`
  (`loadStellarConfig().rpcUrl`) now resolve to the same mainnet RPC
- `docs/MAINNET_DEPLOYMENT.md` documents the endpoint the code actually defaults to
- `grep -rn 'gateway.fm' lib/ docs/` returns no matches
- `npm run test` / `type-check` / `lint` - no new failures (test-only baseline unchanged)

## Acceptance criteria (#108)

- [x] `config.ts` and `env.ts` resolve the same mainnet RPC when the env var is unset
- [x] `MAINNET_DEPLOYMENT.md` documents the endpoint the code actually defaults to