### PR TITLE
docs: fix stale wasm32-unknown-unknown target references (use wasm32v1-none)

### DIFF
--- a/docs/MAINNET_DEPLOYMENT.md
+++ b/docs/MAINNET_DEPLOYMENT.md
@@ -50,7 +50,7 @@ cd contracts/checkout
 stellar contract build
 
 # The optimized wasm is at:
-# target/wasm32-unknown-unknown/release/movastore_checkout.wasm
+# target/wasm32v1-none/release/movastore_checkout.wasm
 ```
 
 ### Verify the Build
@@ -60,14 +60,14 @@ stellar contract build
 cargo test
 
 # Check the wasm size (should be under 64KB)
-ls -la target/wasm32-unknown-unknown/release/movastore_checkout.wasm
+ls -la target/wasm32v1-none/release/movastore_checkout.wasm
 ```
 
 ## Step 3: Deploy to Mainnet
 
 ```bash
 stellar contract deploy \
-  --wasm target/wasm32-unknown-unknown/release/movastore_checkout.wasm \
+  --wasm target/wasm32v1-none/release/movastore_checkout.wasm \
   --source-account merchant-mainnet \
   --network mainnet
 ```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -198,7 +198,7 @@ Common issues and solutions for Mova Store development and production.
 **Solutions:**
 1. Install wasm target:
    ```bash
-   rustup target add wasm32-unknown-unknown
+   rustup target add wasm32v1-none
    ```
 2. Update Rust:
    ```bash
@@ -208,7 +208,7 @@ Common issues and solutions for Mova Store development and production.
    ```bash
    cd contracts/checkout
    cargo clean
-   cargo build --target wasm32-unknown-unknown --release
+   cargo build --target wasm32v1-none --release
    ```
 
 ### Deploy fails with "account not found"


### PR DESCRIPTION
Closes #48

## Problem

`docs/TROUBLESHOOTING.md` instructed `rustup target add wasm32-unknown-unknown` /
`cargo build --target wasm32-unknown-unknown --release`, and
`docs/MAINNET_DEPLOYMENT.md` referenced the artifact at
`target/wasm32-unknown-unknown/release/`. Every other source in the repo
(`README.md`, `ci.yml`, `scripts/deploy-testnet.sh`, `contracts/checkout/README.md`)
uses the `wasm32v1-none` target, so the doc artifact paths were internally inconsistent
with the repo's own CI and deploy script.

## Change

Doc-only: updated both files to `wasm32v1-none` and the matching artifact path
`target/wasm32v1-none/release/movastore_checkout.wasm`

- `docs/TROUBLESHOOTING.md` - 2 references (rustup target add, cargo build --target)
- `docs/MAINNET_DEPLOYMENT.md` - 3 references (build command, ls check, soroban --wasm flag)

## Verification

- `grep -rn 'wasm32-unknown-unknown' docs/` returns no matches
- corrected paths match the artifact emitted by `scripts/deploy-testnet.sh`
  (`cargo build --target wasm32v1-none --release`)
- doc-only change; no code or test impact
- `npm run test` / `type-check` / `lint` - no new failures

## Acceptance criteria (#48)

- [x] `grep -rn 'wasm32-unknown-unknown' docs/` returns no matches
- [x] The corrected paths match the artifact emitted by `scripts/deploy-testnet.sh`
- [x] Doc-only change