### PR TITLE
ci: pin third-party actions to release tags (closes #103)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: wasm32v1-none
@@ -115,7 +115,7 @@ jobs:
         run: npm audit --audit-level=high
 
       - name: Check for secrets
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.97.4
         with:
           extra_args: --only-verified
 
@@ -130,7 +130,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
 


### PR DESCRIPTION
### Summary
Closes #103

Pins mutable third-party GitHub action references in  to released tags:
-  ->  (in both  and  jobs)
-  ->  (in  job)

### Verification
- Verified no  or  references remain in .
- All third-party actions are now pinned to released tags (, , ), preventing unreviewed upstream changes from altering CI behavior.
