### PR TITLE
ci: install cargo-audit via prebuilt binary action (closes #104)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           toolchain: stable
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        uses: taiki-e/install-action@cargo-audit
 
       - name: Run cargo audit
         working-directory: contracts/checkout


### PR DESCRIPTION
### Summary
Closes #104

Replaces the source compilation  in the  CI job with .

### Benefits
- Installs prebuilt  binary directly from GitHub releases in seconds instead of compiling from source.
- Eliminates 3-5 minutes of redundant compile time on every CI run without requiring local binary compilation or large un-cached build artifacts.

### Verification
- Verified  is removed from .
-  fetches prebuilt artifacts on runner environments.
