### PR TITLE
feat(products): add updated_at column, maintenance trigger and surface in mapProduct (closes #106)

### DIFF
--- a/lib/products.js
+++ b/lib/products.js
@@ -6,13 +6,17 @@ import { PRODUCTS_TABLE, PRODUCTS_BUCKET } from "./collections";
  */
 export function mapProduct(row) {
   if (!row) return null;
-  return {
+  const product = {
     id: row.id,
     name: row.name,
     price: Number(row.price),
     img: row.img,
     created_at: row.created_at,
   };
+  if (row.updated_at !== undefined) {
+    product.updated_at = row.updated_at;
+  }
+  return product;
 }
 
 export async function listProducts() {

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -7,10 +7,30 @@ create table if not exists public.products (
   name text not null,
   price numeric(12, 2) not null check (price >= 0),
   img text not null,
-  created_at timestamptz not null default now()
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
 );
 
+-- Idempotently ensure updated_at exists on existing tables
+alter table public.products add column if not exists updated_at timestamptz not null default now();
+
 create index if not exists products_created_at_idx on public.products (created_at desc);
+create index if not exists products_updated_at_idx on public.products (updated_at desc);
+
+-- Updated_at maintenance function & trigger
+create or replace function public.set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists set_products_updated_at on public.products;
+create trigger set_products_updated_at
+  before update on public.products
+  for each row
+  execute function public.set_updated_at();
 
 -- Public read; authenticated write (tighten further for production admins)
 alter table public.products enable row level security;

--- a/tests/lib/products.test.ts
+++ b/tests/lib/products.test.ts
@@ -69,6 +69,27 @@ describe("lib/products data layer", () => {
       const mapped = mapProduct(raw);
       expect(mapped?.price).toBe(25);
     });
+
+    it("surfaces updated_at when present on raw product row", () => {
+      const raw = {
+        id: "prod-456",
+        name: "Jacket",
+        price: "89.99",
+        img: "https://example.com/jacket.jpg",
+        created_at: "2026-09-01T00:00:00Z",
+        updated_at: "2026-09-04T12:00:00Z",
+      };
+      const mapped = mapProduct(raw);
+      expect(mapped).toEqual({
+        id: "prod-456",
+        name: "Jacket",
+        price: 89.99,
+        img: "https://example.com/jacket.jpg",
+        created_at: "2026-09-01T00:00:00Z",
+        updated_at: "2026-09-04T12:00:00Z",
+      });
+      expect(mapped?.updated_at).toBe("2026-09-04T12:00:00Z");
+    });
   });
 
   describe("listProducts", () => {


### PR DESCRIPTION
### Summary
Closes #106

Adds an  timestamp column and automatic maintenance trigger to , and exposes  through .

### Changes
1. ****:
   - Added  to .
   - Added idempotent  for existing tables.
   - Added  index.
   - Added  trigger function and  trigger on .
2. ****:
   - Updated  to surface  when present.
3. ****:
   - Added unit test asserting  correctly surfaces  when present on raw rows.

### Verification
- Ran 
 RUN  v1.6.1 /home/ranjeet/mova-store

 ✓ tests/lib/products.test.ts  (17 tests) 19ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
   Start at  00:41:00
   Duration  1.48s (transform 161ms, setup 124ms, collect 106ms, tests 19ms, environment 481ms, prepare 151ms): 17/17 tests passing cleanly.
