### PR TITLE
fix(footer): point legal and support links to real destinations and fix wording (closes #80)

### DIFF
--- a/app/privacy/page.jsx
+++ b/app/privacy/page.jsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "Privacy Policy | Mova Store",
+  description: "Privacy policy describing how Mova Store handles customer data and Stellar transactions.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-screen bg-mova-ink text-white py-16 px-6">
+      <div className="max-w-4xl mx-auto space-y-8">
+        <Link href="/" className="text-purple-400 hover:underline text-sm inline-block">
+          &larr; Back to Home
+        </Link>
+        <h1 className="text-3xl sm:text-4xl font-bold bg-gradient-to-r from-white via-purple-200 to-purple-400 bg-clip-text text-transparent">
+          Privacy Policy
+        </h1>
+        <p className="text-white/80 leading-relaxed">
+          At Mova Store, we value your privacy and security. This Privacy Policy explains our data collection and protection practices.
+        </p>
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-purple-300">1. Information Collection</h2>
+          <p className="text-white/70 leading-relaxed text-sm">
+            We only collect essential information required for order fulfillment and customer communications,
+            such as contact email, delivery address, and public blockchain transaction identifiers.
+          </p>
+        </section>
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-purple-300">2. Blockchain Transparency</h2>
+          <p className="text-white/70 leading-relaxed text-sm">
+            Please note that payment transactions conducted on the Stellar ledger are public by nature.
+            We do not store private keys, seed phrases, or sensitive wallet signing material.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/terms/page.jsx
+++ b/app/terms/page.jsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "Terms of Use | Mova Store",
+  description: "Terms and conditions for using the Mova Store platform and Stellar checkout services.",
+};
+
+export default function TermsPage() {
+  return (
+    <main className="min-h-screen bg-mova-ink text-white py-16 px-6">
+      <div className="max-w-4xl mx-auto space-y-8">
+        <Link href="/" className="text-purple-400 hover:underline text-sm inline-block">
+          &larr; Back to Home
+        </Link>
+        <h1 className="text-3xl sm:text-4xl font-bold bg-gradient-to-r from-white via-purple-200 to-purple-400 bg-clip-text text-transparent">
+          Terms of Use
+        </h1>
+        <p className="text-white/80 leading-relaxed">
+          Welcome to Mova Store. By accessing or using our decentralized storefront, smart contracts,
+          or payment integrations on the Stellar network, you agree to comply with and be bound by these Terms of Use.
+        </p>
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-purple-300">1. Decentralized Transactions</h2>
+          <p className="text-white/70 leading-relaxed text-sm">
+            All crypto and stablecoin transactions initiated through Mova Store are executed directly on the
+            Stellar blockchain and Soroban smart contracts. Once confirmed on the ledger, blockchain transactions are irreversible.
+          </p>
+        </section>
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-purple-300">2. Customer Responsibilities</h2>
+          <p className="text-white/70 leading-relaxed text-sm">
+            You are responsible for safeguarding your wallet credentials and ensuring accurate order and shipping details
+            during the checkout process.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -8,25 +8,25 @@ export default function Footer() {
       <section className="container mx-auto flex h-28 flex-col items-center justify-between divide-black text-center font-normal sm:flex-row sm:divide-x-2 sm:divide-white/30">
         <span className="my-10 hidden gap-2 text-sm sm:my-0 sm:flex">
           <Link
-            href="/"
+            href="/terms"
             className="transition hover:underline hover:underline-offset-1"
           >
-            Term of use
+            Terms of Use
           </Link>
           <Link
-            href="/"
+            href="/privacy"
             className="transition hover:underline hover:underline-offset-1"
           >
             Privacy Policy
           </Link>
           <Link
-            href="/"
+            href="/#aboutus"
             className="transition hover:underline hover:underline-offset-1"
           >
             About us
           </Link>
           <Link
-            href="/"
+            href="/#contact"
             className="transition hover:underline hover:underline-offset-1"
           >
             24/7 Customer Service

--- a/tests/components/Footer.test.tsx
+++ b/tests/components/Footer.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Footer from "../../components/Footer";
+
+describe("Footer component", () => {
+  it("renders all footer navigation links with correct destinations and grammar", () => {
+    render(<Footer />);
+
+    const termsLink = screen.getByRole("link", { name: /Terms of Use/i });
+    expect(termsLink).toBeInTheDocument();
+    expect(termsLink).toHaveAttribute("href", "/terms");
+
+    const privacyLink = screen.getByRole("link", { name: /Privacy Policy/i });
+    expect(privacyLink).toBeInTheDocument();
+    expect(privacyLink).toHaveAttribute("href", "/privacy");
+
+    const aboutLink = screen.getByRole("link", { name: /About us/i });
+    expect(aboutLink).toBeInTheDocument();
+    expect(aboutLink).toHaveAttribute("href", "/#aboutus");
+
+    const supportLink = screen.getByRole("link", { name: /24\/7 Customer Service/i });
+    expect(supportLink).toBeInTheDocument();
+    expect(supportLink).toHaveAttribute("href", "/#contact");
+  });
+
+  it("does not hardcode any link to '/'", () => {
+    render(<Footer />);
+    const links = screen.getAllByRole("link");
+    links.forEach((link) => {
+      expect(link.getAttribute("href")).not.toBe("/");
+    });
+  });
+});


### PR DESCRIPTION
### Summary
Closes #80

Fixes ungrammatical wording and replaces dummy  links in  with real navigation destinations:
- **** -> **** linking to  (added ).
- **** -> linking to  (added ).
- **** -> linking to  (smooth navigation to the landing page About Us section).
- **** -> linking to  (smooth navigation to the landing page Contact Us section).

### Testing
- Created  verifying all 4 links point to their correct real routes and that none hardcode .
- Passed 
 RUN  v1.6.1 /home/ranjeet/mova-store

 ✓ tests/components/Footer.test.tsx  (2 tests) 112ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  00:43:22
   Duration  1.55s (transform 72ms, setup 127ms, collect 117ms, tests 112ms, environment 528ms, prepare 150ms) (2/2 passing).
- Passed 
> mova-store@1.0.0 type-check
> tsc --noEmit --skipLibCheck.
