### PR TITLE
refactor(ui): extract shared useToast hook, drop 9 copy-pasted toast timers

### DIFF
--- a/app/(landingpage)/ContactUs.jsx
+++ b/app/(landingpage)/ContactUs.jsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { FaGithub, FaTwitter, FaDiscord } from "react-icons/fa";
 import sendMail from "../../lib/sendmail";
+import { useToast } from "@/hooks/useToast";
 
 const socialLinks = [
   {
@@ -30,7 +31,7 @@ const ContactUs = () => {
     email: "",
     message: "",
   });
-  const [toast, setToast] = useState({ show: false, message: "" });
+  const { toast, showToast, hideToast } = useToast(5000);
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -56,10 +57,6 @@ const ContactUs = () => {
     setIsLoading(false);
   };
 
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 5000);
-  };
 
   return (
     <div
@@ -207,7 +204,7 @@ const ContactUs = () => {
         <div className="fixed bottom-5 right-5 bg-gray-800 text-white p-3 rounded shadow-lg transition-transform transform translate-y-0 ease-in-out duration-300">
           {toast.message}
           <button
-            onClick={() => setToast({ show: false, message: "" })}
+            onClick={hideToast}
             className="ml-4 text-purple-500"
           >
             ✕

--- a/app/(landingpage)/Hero.jsx
+++ b/app/(landingpage)/Hero.jsx
@@ -1,19 +1,15 @@
 "use client";
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../../lib/AuthContext";
 import Toast from "../../components/Toast";
 import Link from "next/link";
+import { useToast } from "@/hooks/useToast";
 
 export default function Hero() {
   const { user } = useAuth();
   const router = useRouter();
-  const [toast, setToast] = useState({ show: false, message: "" });
+  const { toast, showToast, hideToast } = useToast(5000);
 
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 5000);
-  };
 
   const handleProtectedLinkClick = (e, path) => {
     if (!user) {
@@ -63,7 +59,8 @@ export default function Hero() {
       <Toast
         message={toast.message}
         show={toast.show}
-        onClose={() => setToast({ show: false, message: "" })}
+        time={5000}
+        onClose={hideToast}
       />
     </>
   );

--- a/app/(landingpage)/newsletter.jsx
+++ b/app/(landingpage)/newsletter.jsx
@@ -1,14 +1,11 @@
 import Toast from "../../components/Toast";
 import { useState } from "react";
 import { validateEmail } from "../../lib/validation";
+import { useToast } from "@/hooks/useToast";
 
 export default function Newsletter() {
-  const [toast, setToast] = useState({ show: false, message: "" });
+  const { toast, showToast, hideToast } = useToast(5000);
   const [email, setEmail] = useState("");
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 5000);
-  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -66,7 +63,8 @@ export default function Newsletter() {
       <Toast
         message={toast.message}
         show={toast.show}
-        onClose={() => setToast({ show: false, message: "" })}
+        time={5000}
+        onClose={hideToast}
       />
     </div>
   );

--- a/app/admin/AddProductForm.jsx
+++ b/app/admin/AddProductForm.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from "react";
 import Toast from "../../components/Toast";
 import { createProduct, uploadProductImage } from "../../lib/products";
+import { useToast } from "@/hooks/useToast";
 
 const AddProductForm = ({ onProductAdded }) => {
   const [productName, setProductName] = useState("");
@@ -9,11 +10,7 @@ const AddProductForm = ({ onProductAdded }) => {
   const [productImage, setProductImage] = useState(null);
   const [loading, setLoading] = useState(false);
 
-  const [toast, setToast] = useState({ show: false, message: "" });
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 3000);
-  };
+  const { toast, showToast, hideToast } = useToast(3000);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -100,7 +97,7 @@ const AddProductForm = ({ onProductAdded }) => {
       <Toast
         message={toast.message}
         show={toast.show}
-        onClose={() => setToast({ show: false, message: "" })}
+        onClose={hideToast}
       />
     </div>
   );

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -33,6 +33,7 @@ import {
   validateCardExpiry,
   validateCardCVV,
 } from "../../lib/validation";
+import { useToast } from "@/hooks/useToast";
 
 const Checkout = () => {
 
@@ -45,7 +46,7 @@ const Checkout = () => {
   const [totalPrice, setTotalPrice] = useState(0);
   const [cartItems, setCartItems] = useState<any[]>([]);
   const [isLoaded, setIsLoaded] = useState(false);
-  const [toast, setToast] = useState({ show: false, message: "" });
+  const { toast, showToast, hideToast } = useToast(4000);
   const [stage, setStage] = useState(1);
   const [isOtpSending, setIsOtpSending] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -61,10 +62,6 @@ const Checkout = () => {
     subject: "YOUR ORDER CONFIRMATION",
   });
 
-  const showToast = (message: string) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 5000);
-  };
 
   const [orderId] = useState(() =>
     `SS-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
@@ -484,7 +481,7 @@ const Checkout = () => {
       <Toast
         message={toast.message}
         show={toast.show}
-        onClose={() => setToast({ show: false, message: "" })}
+        onClose={hideToast}
         time={4000}
       />
     </>

--- a/app/profile/login/page.jsx
+++ b/app/profile/login/page.jsx
@@ -8,9 +8,10 @@ import { AiOutlineLoading3Quarters } from "react-icons/ai";
 import { FcGoogle } from "react-icons/fc";
 import { FaRegEye, FaRegEyeSlash } from "react-icons/fa";
 import img from "../../../public/images/welcome-mova.png";
+import { useToast } from "@/hooks/useToast";
 
 const AuthPage = () => {
-  const [toast, setToast] = useState({ show: false, message: "" });
+  const { toast, showToast, hideToast } = useToast(3000);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -21,10 +22,6 @@ const AuthPage = () => {
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [isLoginMode, setIsLoginMode] = useState(true);
 
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 3000);
-  };
 
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -247,7 +244,7 @@ const AuthPage = () => {
       <Toast
         message={toast.message}
         show={toast.show}
-        onClose={() => setToast({ show: false, message: "" })}
+        onClose={hideToast}
       />
     </section>
   );

--- a/app/shop/[id]/page.jsx
+++ b/app/shop/[id]/page.jsx
@@ -8,6 +8,7 @@ import Toast from "../../../components/Toast";
 import Cart from "../../../components/Cart";
 import { getProductById } from "../../../lib/products";
 import LoadingSpinner from "../../../components/LoadingSpinner";
+import { useToast } from "@/hooks/useToast";
 
 const ProductPage = ({ params }) => {
   const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } =
@@ -16,7 +17,7 @@ const ProductPage = ({ params }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [showModal, setShowModal] = useState(false);
-  const [toast, setToast] = useState({ show: false, message: "" });
+  const { toast, showToast, hideToast } = useToast(3000);
   const { id } = params;
 
   useEffect(() => {
@@ -40,10 +41,6 @@ const ProductPage = ({ params }) => {
     }
   }, [id]);
 
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 3000);
-  };
 
   const handleCheckout = () => {
     if (cartItems.length > 0) {
@@ -95,7 +92,7 @@ const ProductPage = ({ params }) => {
       <Toast
         message={toast.message}
         show={toast.show}
-        onClose={() => setToast({ show: false, message: "" })}
+        onClose={hideToast}
       />
       <Modal show={showModal} onClose={closeModal}>
         <h2 className="text-2xl mb-4">Cart Items</h2>

--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -8,12 +8,13 @@ import Cart from "../../components/Cart";
 import Modal from "../../components/Modal";
 import Toast from "../../components/Toast";
 import { listProducts } from "../../lib/products";
+import { useToast } from "@/hooks/useToast";
 
 export default function Products() {
   const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } =
     useCart();
   const [showModal, setShowModal] = useState(false);
-  const [toast, setToast] = useState({ show: false, message: "" });
+  const { toast, showToast, hideToast } = useToast(3000);
   const [isCheckingOut, setIsCheckingOut] = useState(false);
   const [products, setProducts] = useState([]);
   const [error, setError] = useState(null);
@@ -31,10 +32,6 @@ export default function Products() {
     fetchProducts();
   }, []);
 
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 3000);
-  };
 
   const handleCheckout = (e) => {
     setIsCheckingOut(true);
@@ -92,7 +89,7 @@ export default function Products() {
       <Toast
         message={toast.message}
         show={toast.show}
-        onClose={() => setToast({ show: false, message: "" })}
+        onClose={hideToast}
       />
       <Modal show={showModal} onClose={closeModal}>
         <h2 className="text-2xl mb-4">Cart Items</h2>

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -8,6 +8,7 @@ import { logout } from "../lib/auth";
 import Toast from "../components/Toast";
 import { useRouter } from "next/navigation";
 import { TfiAngleRight } from "react-icons/tfi";
+import { useToast } from "@/hooks/useToast";
 
 const navLinkClass =
   "text-md font-medium text-mova-ink/80 hover:text-purple-600 transition-colors duration-200";
@@ -52,11 +53,7 @@ function Navbar() {
       );
     };
   }, [router]);
-  const [toast, setToast] = useState({ show: false, message: "" });
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 3000);
-  };
+  const { toast, showToast, hideToast } = useToast(3000);
 
   const [showNav, setShowNav] = useState(false);
   const { user } = useAuth();
@@ -257,7 +254,7 @@ function Navbar() {
         <Toast
           message={toast.message}
           show={toast.show}
-          onClose={() => setToast({ show: false, message: "" })}
+          onClose={hideToast}
         />
       </nav>
     </>

--- a/hooks/useToast.js
+++ b/hooks/useToast.js
@@ -1,0 +1,49 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Shared toast state for pages that surface feedback via
+ * components/Toast.jsx (or the inline toast on the contact page).
+ *
+ * components/Toast.jsx still owns the visual dismissal timing through its
+ * `time` prop and calls the returned `hideToast` on close; the hook keeps
+ * its own auto-dismiss timer as the fallback (and as the sole timer for
+ * inline toasts that do not render <Toast />). The pending timer is cleared
+ * on unmount, so no state update can fire after a page unmounts.
+ */
+export function useToast(autoHideMs = 3000) {
+  const [toast, setToast] = useState({ show: false, message: "" });
+  const timerRef = useRef(null);
+
+  const hideToast = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setToast({ show: false, message: "" });
+  }, []);
+
+  const showToast = useCallback(
+    (message) => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        setToast({ show: false, message: "" });
+      }, autoHideMs);
+      setToast({ show: true, message });
+    },
+    [autoHideMs]
+  );
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    []
+  );
+
+  return { toast, showToast, hideToast };
+}
+
+export default useToast;

--- a/tests/hooks/useToast.test.jsx
+++ b/tests/hooks/useToast.test.jsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useToast } from "@/hooks/useToast";
+
+describe("useToast", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("shows a message and auto-hides after the configured duration", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useToast(3000));
+
+    act(() => result.current.showToast("Item added to cart"));
+    expect(result.current.toast).toEqual({
+      show: true,
+      message: "Item added to cart",
+    });
+
+    act(() => vi.advanceTimersByTime(2999));
+    expect(result.current.toast.show).toBe(true);
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current.toast).toEqual({ show: false, message: "" });
+  });
+
+  it("clears the pending timer on unmount so no state update fires afterwards", () => {
+    vi.useFakeTimers();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result, unmount } = renderHook(() => useToast(3000));
+
+    act(() => result.current.showToast("hi"));
+    unmount();
+    act(() => vi.advanceTimersByTime(5000));
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("hideToast dismisses immediately and cancels the pending auto-hide", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useToast(3000));
+
+    act(() => result.current.showToast("hi"));
+    act(() => result.current.hideToast());
+    expect(result.current.toast).toEqual({ show: false, message: "" });
+
+    act(() => vi.advanceTimersByTime(5000));
+    expect(result.current.toast).toEqual({ show: false, message: "" });
+  });
+
+  it("restarting showToast resets the timer instead of firing the stale one", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useToast(3000));
+
+    act(() => result.current.showToast("first"));
+    act(() => vi.advanceTimersByTime(2000));
+    act(() => result.current.showToast("second"));
+
+    act(() => vi.advanceTimersByTime(2000));
+    expect(result.current.toast).toEqual({
+      show: true,
+      message: "second",
+    });
+
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current.toast).toEqual({ show: false, message: "" });
+  });
+});


### PR DESCRIPTION
## Summary
The identical toast pattern - `useState({ show: false, message: "" })` plus a raw `setTimeout` that is never cleared - was copy-pasted across nine client files (Navbar, Hero, newsletter, ContactUs, AddProductForm, checkout, login, both shop pages). The timers were not cleaned up on unmount (setState-after-unmount risk) and duplicated dismissal logic that `components/Toast.jsx` already owns via its `time` prop.

This change adds `hooks/useToast.js` returning `{ toast, showToast, hideToast }`:

- the hook keeps an auto-dismiss timer cleared in an effect cleanup, so unmounting a page within the toast window can never fire a state update (it also covers the inline toast on the contact page, which does not render `<Toast />`)
- `Toast.jsx` keeps owning the visual dismissal timing through its `time` prop and calls `hideToast` on close - the two are idempotent; the 5000ms call sites now pass `time={5000}` explicitly and checkout matches its existing `time={4000}`
- `rg 'setTimeout(() => setToast'` no longer matches any of the listed files

## Acceptance criteria
- [x] `rg 'setTimeout(() => setToast'` returns no matches in the listed files
- [x] Unmounting a page within the toast window produces no React state-update warning (covered by the unmount test)
- [x] `npm run test` and lint pass; toast behaviour unchanged (same 7 pre-existing failures as clean `main`, all unrelated: validation / checkout / ContactUs / events)
- [x] `npm run type-check` clean

## Testing
- New `tests/hooks/useToast.test.jsx` (4 cases, fake timers): auto-hide fires at the configured duration, unmount clears the pending timer, manual `hideToast` dismisses immediately and cancels the pending timer, and a repeat `showToast` resets the timer instead of firing the stale one.
- Full suite result identical to clean `main` baseline.

Fixes #31
