### PR TITLE
fix(orders): avoid re-hashing event-derived 64-hex order IDs in dispatch/refund (#67)

### DIFF
--- a/lib/stellar/orders.ts
+++ b/lib/stellar/orders.ts
@@ -25,7 +25,7 @@ import {
   tokenForContract,
 } from "./config";
 import { connectWallet, signWithFreighter } from "./freighter";
-import { hashOrderId, bytesToHex } from "./scval";
+import { hashOrderId, resolveOrderIdHash, bytesToHex } from "./scval";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -85,7 +85,7 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
   const server = new rpc.Server(RPC_URL);
   const contract = new Contract(CHECKOUT_CONTRACT_ID);
 
-  const orderIdHashBytes = await hashOrderId(orderId);
+  const orderIdHashBytes = await resolveOrderIdHash(orderId);
   const orderIdHash = bytesToHex(orderIdHashBytes);
 
   const account = await server.getAccount(
@@ -219,7 +219,7 @@ export async function dispatchOrder(
     const server = new rpc.Server(RPC_URL);
     const contract = new Contract(CHECKOUT_CONTRACT_ID);
 
-    const orderIdHashBytes = await hashOrderId(orderId);
+    const orderIdHashBytes = await resolveOrderIdHash(orderId);
 
     const account = await server.getAccount(publicKey);
 
@@ -300,7 +300,7 @@ export async function refundOrder(orderId: string): Promise<OrderActionResult> {
     const server = new rpc.Server(RPC_URL);
     const contract = new Contract(CHECKOUT_CONTRACT_ID);
 
-    const orderIdHashBytes = await hashOrderId(orderId);
+    const orderIdHashBytes = await resolveOrderIdHash(orderId);
 
     const account = await server.getAccount(publicKey);
 

--- a/lib/stellar/scval.ts
+++ b/lib/stellar/scval.ts
@@ -126,3 +126,18 @@ export async function hashOrderId(orderId: string): Promise<Uint8Array> {
   const digest = await crypto.subtle.digest("SHA-256", data);
   return new Uint8Array(digest);
 }
+
+/**
+ * Resolves an order identifier into its 32-byte hash representation.
+ * If the input is already a 64-character hex string (e.g. from indexer contract events),
+ * it converts it directly to raw bytes without re-hashing. Otherwise, it computes the
+ * SHA-256 digest of the pre-image string.
+ */
+export async function resolveOrderIdHash(orderId: string): Promise<Uint8Array> {
+  const trimmed = orderId.trim();
+  const hexPattern = /^[0-9a-fA-F]{64}$/;
+  if (hexPattern.test(trimmed)) {
+    return hexToBytes(trimmed);
+  }
+  return hashOrderId(orderId);
+}

--- a/tests/app/admin/orders-dispatch-refund.test.tsx
+++ b/tests/app/admin/orders-dispatch-refund.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import OrdersManagement from "../../../app/admin/orders/page";
+import * as ordersModule from "../../../lib/stellar/orders";
+import { IndexedEvent } from "../../../lib/stellar/indexer";
+
+// Mock dependencies
+vi.mock("../../../components/AdminGuard", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../../components/StellarWalletButton", () => ({
+  default: () => <button>Wallet Connected</button>,
+}));
+
+const mockIndexedEvent: IndexedEvent = {
+  id: "evt-1",
+  contractId: "CADQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQP5KR",
+  symbol: "pay",
+  fields: {
+    order_id: "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90",
+    buyer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+    amount: "500000000",
+    token: "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA",
+    timestamp: "1741112400",
+  },
+  ledger: 12345,
+  txHash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  timestamp: 1741112400000,
+};
+
+vi.mock("../../../lib/stellar/indexer", () => {
+  return {
+    PaymentEventIndexer: class {
+      async start(callbacks: {
+        onEvent?: (event: IndexedEvent) => void;
+        onStatus?: (status: { running: boolean; eventsSeen: number }) => void;
+      } = {}) {
+        if (callbacks.onEvent) {
+          callbacks.onEvent(mockIndexedEvent);
+        }
+        if (callbacks.onStatus) {
+          callbacks.onStatus({ running: true, eventsSeen: 1 });
+        }
+      }
+      stop() {}
+    },
+  };
+});
+
+describe("Admin Orders Page - Event-derived hex order ID dispatch & refund", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes the event-derived hex order id directly into dispatchOrder unmodified", async () => {
+    const dispatchSpy = vi
+      .spyOn(ordersModule, "dispatchOrder")
+      .mockResolvedValue({ success: true, txHash: "tx123" });
+
+    render(<OrdersManagement />);
+
+    const shipButton = await screen.findByRole("button", { name: /Ship/i });
+    expect(shipButton).toBeInTheDocument();
+
+    fireEvent.click(shipButton);
+
+    await waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledTimes(1);
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+      );
+    });
+  });
+
+  it("passes the event-derived hex order id directly into refundOrder unmodified", async () => {
+    const refundSpy = vi
+      .spyOn(ordersModule, "refundOrder")
+      .mockResolvedValue({ success: true, txHash: "tx456" });
+
+    render(<OrdersManagement />);
+
+    const refundButton = await screen.findByRole("button", { name: /Refund/i });
+    expect(refundButton).toBeInTheDocument();
+
+    fireEvent.click(refundButton);
+
+    await waitFor(() => {
+      expect(refundSpy).toHaveBeenCalledTimes(1);
+      expect(refundSpy).toHaveBeenCalledWith(
+        "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+      );
+    });
+  });
+});

--- a/tests/lib/stellar/resolve-order-id-hash.test.ts
+++ b/tests/lib/stellar/resolve-order-id-hash.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { resolveOrderIdHash, hashOrderId, bytesToHex, hexToBytes } from "../../../lib/stellar/scval";
+
+describe("resolveOrderIdHash", () => {
+  it("passes an already-hashed 64-character hex string through as raw bytes without re-hashing", async () => {
+    const hexInput = "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90";
+    const result = await resolveOrderIdHash(hexInput);
+
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(32);
+    expect(bytesToHex(result)).toBe(hexInput.toLowerCase());
+    expect(result).toEqual(hexToBytes(hexInput));
+  });
+
+  it("handles uppercase and mixed-case 64-character hex strings correctly", async () => {
+    const hexInput = "A1B2C3D4E5F60718293A4B5C6D7E8F90A1B2C3D4E5F60718293A4B5C6D7E8F90";
+    const result = await resolveOrderIdHash(hexInput);
+
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(32);
+    expect(bytesToHex(result)).toBe(hexInput.toLowerCase());
+  });
+
+  it("hashes a short pre-image order ID using SHA-256", async () => {
+    const rawId = "SS-1741112400-ABCD";
+    const result = await resolveOrderIdHash(rawId);
+    const expectedHash = await hashOrderId(rawId);
+
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(32);
+    expect(result).toEqual(expectedHash);
+  });
+
+  it("hashes non-hex strings of arbitrary length using SHA-256", async () => {
+    const rawId = "order-xyz-123";
+    const result = await resolveOrderIdHash(rawId);
+    const expected = await hashOrderId(rawId);
+
+    expect(result).toEqual(expected);
+  });
+});


### PR DESCRIPTION
### Summary
Fixes #67 by introducing a pure helper `resolveOrderIdHash` in `lib/stellar/scval.ts` that detects whether the order identifier is already a 32-byte 64-character hex string (emitted by contract events and used in `app/admin/orders/page.tsx`) and passes its raw bytes directly without re-hashing via SHA-256. Raw short pre-image order IDs are hashed as before.

### Changes
1. **Helper `resolveOrderIdHash`**:
   - Accepts pre-image string or 64-hex string.
   - If 64 hex characters: converts directly to raw bytes via `hexToBytes`.
   - Otherwise: hashes using `hashOrderId`.
2. **Usage in `lib/stellar/orders.ts`**:
   - `readOrder`, `dispatchOrder`, and `refundOrder` use `resolveOrderIdHash`.
3. **Tests**:
   - Unit tests covering both raw pre-image hashing and 64-hex passthrough in `tests/lib/stellar/resolve-order-id-hash.test.ts`.
   - Component/integration test asserting that `app/admin/orders/page.tsx` passes event-derived hex IDs to `dispatchOrder` and `refundOrder` unmodified in `tests/app/admin/orders-dispatch-refund.test.tsx`.
