### PR TITLE
test(checkout): lock down event topic layout per lifecycle step; add missing event-name prefixes

### DIFF
--- a/contracts/checkout/src/events.rs
+++ b/contracts/checkout/src/events.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{contractevent, Address, BytesN};
 ///
 /// Topics: `pay`, token, buyer, merchant, order_id
 /// Data:   `{ amount }` (i128, raw token units)
-#[contractevent]
+#[contractevent(topics = ["pay"])]
 pub struct PaymentReceived {
     /// The SEP-41 token contract used for the payment.
     #[topic]
@@ -26,7 +26,7 @@ pub struct PaymentReceived {
 ///
 /// Topics: `create_order`, token, buyer, order_id
 /// Data:   `{ amount, timestamp }`
-#[contractevent]
+#[contractevent(topics = ["create_order"])]
 pub struct OrderCreated {
     /// The SEP-41 token the buyer intends to pay with.
     #[topic]
@@ -47,7 +47,7 @@ pub struct OrderCreated {
 ///
 /// Topics: `dispatch`, order_id, merchant
 /// Data:   `{ amount }`
-#[contractevent]
+#[contractevent(topics = ["dispatch"])]
 pub struct OrderShipped {
     /// The 32-byte order id that was dispatched.
     #[topic]
@@ -63,7 +63,7 @@ pub struct OrderShipped {
 ///
 /// Topics: `refund`, order_id, buyer
 /// Data:   `{ amount }`
-#[contractevent]
+#[contractevent(topics = ["refund"])]
 pub struct OrderRefunded {
     /// The 32-byte order id that was refunded.
     #[topic]

--- a/contracts/checkout/src/test.rs
+++ b/contracts/checkout/src/test.rs
@@ -503,6 +503,35 @@ fn test_events_emitted() {
     assert_eq!(topic_address(&env, shipped, 2), merchant);
 }
 
+#[test]
+fn test_refund_event_emitted() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, token, _, buyer, checkout) = setup_usdc(&env);
+    let id = order_id(&env, 9);
+
+    client.pay(&token, &buyer, &id, &100_000);
+    client.refund(&id);
+
+    // refund: topics = [refund, order_id, buyer], data = { amount }
+    let evs = env.events().all().filter_by_contract(&checkout);
+    assert_eq!(evs.events().len(), 1, "expected exactly one refund event");
+    let refunded = &evs.events()[0].clone();
+    assert_eq!(topic_symbol(&env, refunded), Symbol::new(&env, "refund"));
+    assert_eq!(event_topics(refunded).len(), 3);
+    assert_eq!(topic_bytes32(&env, refunded, 1), id);
+    assert_eq!(topic_address(&env, refunded, 2), buyer);
+    let data_map = Map::<Symbol, i128>::try_from_val(&env, event_data(refunded))
+        .expect("refund data is a symbol-keyed map");
+    assert_eq!(
+        data_map
+            .get(Symbol::new(&env, "amount"))
+            .expect("amount is present in refund data"),
+        100_000
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Event inspection helpers (xdr access differs from the sdk Val-level API)
 // ---------------------------------------------------------------------------

--- a/contracts/checkout/src/test.rs
+++ b/contracts/checkout/src/test.rs
@@ -2,7 +2,10 @@
 
 use soroban_sdk::testutils::{Address as _, Events};
 use soroban_sdk::token::{StellarAssetClient, TokenClient};
-use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env};
+use soroban_sdk::xdr;
+use soroban_sdk::{
+    contract, contractimpl, contracttype, Address, BytesN, Env, Map, Symbol, TryFromVal,
+};
 
 use crate::errors::Error;
 use crate::order::Status;
@@ -437,17 +440,97 @@ fn test_events_emitted() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (client, token, _, buyer, checkout) = setup_usdc(&env);
+    let (client, token, merchant, buyer, checkout) = setup_usdc(&env);
     let id = order_id(&env, 5);
 
     client.create_order(&buyer, &id, &token, &10_000);
-    client.pay(&token, &buyer, &id, &10_000);
-    client.dispatch(&id);
+    // Events::all() covers the LAST contract invocation, so capture after
+    // each step.
+    let created = {
+        let evs = env.events().all().filter_by_contract(&checkout);
+        assert_eq!(
+            evs.events().len(),
+            1,
+            "expected exactly one create_order event"
+        );
+        &evs.events()[0].clone()
+    };
 
-    // At least one contract event should be recorded for the lifecycle.
-    let events = env.events().all().filter_by_contract(&checkout);
-    assert!(
-        !events.events().is_empty(),
-        "expected contract events for create/pay/dispatch"
+    client.pay(&token, &buyer, &id, &10_000);
+    let paid = {
+        let evs = env.events().all().filter_by_contract(&checkout);
+        assert_eq!(evs.events().len(), 1, "expected exactly one pay event");
+        &evs.events()[0].clone()
+    };
+
+    client.dispatch(&id);
+    let shipped = {
+        let evs = env.events().all().filter_by_contract(&checkout);
+        assert_eq!(evs.events().len(), 1, "expected exactly one dispatch event");
+        &evs.events()[0].clone()
+    };
+
+    // create_order: topics = [create_order, token, buyer, order_id]
+    assert_eq!(
+        topic_symbol(&env, created),
+        Symbol::new(&env, "create_order")
     );
+    assert_eq!(event_topics(created).len(), 4);
+    assert_eq!(topic_address(&env, created, 1), token);
+    assert_eq!(topic_address(&env, created, 2), buyer);
+    assert_eq!(topic_bytes32(&env, created, 3), id);
+
+    // pay: topics = [pay, token, buyer, merchant, order_id], data = { amount }
+    assert_eq!(topic_symbol(&env, paid), Symbol::new(&env, "pay"));
+    assert_eq!(event_topics(paid).len(), 5);
+    assert_eq!(topic_address(&env, paid, 1), token);
+    assert_eq!(topic_address(&env, paid, 2), buyer);
+    assert_eq!(topic_address(&env, paid, 3), merchant);
+    assert_eq!(topic_bytes32(&env, paid, 4), id);
+    let data_map = Map::<Symbol, i128>::try_from_val(&env, event_data(paid))
+        .expect("pay data is a symbol-keyed map");
+    assert_eq!(
+        data_map
+            .get(Symbol::new(&env, "amount"))
+            .expect("amount is present in pay data"),
+        10_000
+    );
+
+    // dispatch: topics = [dispatch, order_id, merchant], data = { amount }
+    assert_eq!(topic_symbol(&env, shipped), Symbol::new(&env, "dispatch"));
+    assert_eq!(event_topics(shipped).len(), 3);
+    assert_eq!(topic_bytes32(&env, shipped, 1), id);
+    assert_eq!(topic_address(&env, shipped, 2), merchant);
+}
+
+// ---------------------------------------------------------------------------
+// Event inspection helpers (xdr access differs from the sdk Val-level API)
+// ---------------------------------------------------------------------------
+
+fn event_topics(e: &xdr::ContractEvent) -> &[xdr::ScVal] {
+    match &e.body {
+        xdr::ContractEventBody::V0(v0) => &v0.topics,
+        _ => panic!("unexpected contract event body"),
+    }
+}
+
+fn event_data(e: &xdr::ContractEvent) -> &xdr::ScVal {
+    match &e.body {
+        xdr::ContractEventBody::V0(v0) => &v0.data,
+        _ => panic!("unexpected contract event body"),
+    }
+}
+
+fn topic_symbol(env: &Env, e: &xdr::ContractEvent) -> Symbol {
+    let topics = event_topics(e);
+    let first = topics.first().expect("event has at least one topic");
+    Symbol::try_from_val(env, first).expect("first topic is a Symbol")
+}
+
+fn topic_address(env: &Env, e: &xdr::ContractEvent, i: usize) -> Address {
+    Address::try_from_val(env, &event_topics(e)[i]).expect("topic is an Address")
+}
+
+fn topic_bytes32(env: &Env, e: &xdr::ContractEvent, i: usize) -> BytesN<32> {
+    BytesN::try_from_val(env, &event_topics(e)[i]).expect("topic is a BytesN<32>")
 }


### PR DESCRIPTION
Closes #91

## Problem

`contracts/checkout/src/test.rs` — `test_events_emitted` only asserted that at least one event was recorded, so the topic layout the JS indexer depends on was never locked down. While strengthening the assertions, a real integration bug surfaced:

The `#[contractevent]` derives in `contracts/checkout/src/events.rs` emitted **no event-name symbol at all**. The SDK's generated topics are exactly the `topics = [...]` prefix plus the `#[topic]` fields, so the wire layout was `[token, buyer, merchant, order_id]` with no leading symbol. Consumers therefore never matched what the contract actually emitted:

- `lib/stellar/indexer.ts:82` — `watchedSymbols = ["pay", "create_order", "dispatch", "refund"]`, first topic matched as event name (`indexer.ts:217`)
- `lib/stellar/indexer.ts` `decodePaymentEvent` — expects `topics[0]` to be the `scvSymbol` `"pay"`
- the documented layout in `events.rs` itself ("Topics: `pay`, ...")

## Changes

1. **`contracts/checkout/src/events.rs`** — add the missing `topics = ["pay" | "create_order" | "dispatch" | "refund"]` prefixes so the emitted wire layout matches the documented one.
2. **`contracts/checkout/src/test.rs`** — replace the weak at-least-one-event assertion with per-step checks:
   - first-topic symbol matches the event name
   - exact topic count and payload order (`create_order`: token/buyer/order_id; `pay`: token/buyer/merchant/order_id plus data map `{amount}`; `dispatch`: order_id/merchant)
   - events captured after each invocation because `Events::all()` covers only the last contract invocation

## Acceptance criteria (from #91)

- [x] Topic layout asserted per event, not just "some event emitted"
- [x] `cargo test` passes with the stronger assertions (19 passed, includes the full escrow lifecycle suite)
