### PR TITLE
test(cart): add unit tests for floating Cart badge button (closes #99)

### DIFF
--- a/tests/components/Cart.test.jsx
+++ b/tests/components/Cart.test.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Cart from "../../components/Cart";
+
+describe("Cart component", () => {
+  it("does not render item count badge when itemCount is 0", () => {
+    const handleClick = vi.fn();
+    render(<Cart itemCount={0} onClick={handleClick} />);
+
+    expect(screen.queryByText("0")).toBeNull();
+    expect(screen.queryByText("3")).toBeNull();
+  });
+
+  it("renders the item count badge when itemCount is positive", () => {
+    const handleClick = vi.fn();
+    render(<Cart itemCount={3} onClick={handleClick} />);
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("calls onClick handler when the cart button is clicked", () => {
+    const handleClick = vi.fn();
+    render(<Cart itemCount={3} onClick={handleClick} />);
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #99.

Adds component unit tests for `components/Cart.jsx` asserting:
- Badge is absent when `itemCount=0` (and queryByText('0') / queryByText('3') are null).
- Badge is present and renders `'3'` when `itemCount=3`.
- Clicking the button fires the `onClick` handler exactly once.

## Acceptance Criteria
- [x] `queryByText('3')` is null when `itemCount=0` and present when `itemCount=3`
- [x] `fireEvent.click` on the button calls `onClick` exactly once; `npx vitest run tests/components/Cart.test.jsx` passes
