### PR TITLE
docs: fix dead Paying-with-USDC anchors to the real heading (#46)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,7 +219,7 @@ npm run build        # Production build must succeed
 
 If your PR touches the Stellar payment flow, describe in the PR how you tested
 it against testnet (Freighter + USDC faucet account). Follow the flow in the
-root [README](README.md#paying-with-usdc-testnet).
+root [README](README.md#paying-with-stellar-testnet).
 
 ## Commit Message Style
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ buyer ──pay──▶ contract (escrow) ──dispatch──▶ merchant
   - [Step 5b — Whitelist the tokens you accept](#step-5b--whitelist-the-tokens-you-accept)
   - [Step 6 — Wire the deployed contract to the storefront](#step-6--wire-the-deployed-contract-to-the-storefront)
   - [Convenience script](#convenience-script)
-- [Paying with USDC (testnet)](#paying-with-usdc-testnet)
+- [Paying with Stellar (testnet)](#paying-with-stellar-testnet)
 - [Environment Variables Reference](#environment-variables-reference)
 - [Security Notes](#security-notes)
 - [Contributing](#contributing)


### PR DESCRIPTION
Closes #46

## Problem

`README.md` (line 85) and `CONTRIBUTING.md` (line 222) deep-link to
`#paying-with-usdc-testnet`, but the heading was renamed to
`## Paying with Stellar (testnet)` - both links 404 on the rendered page.

## Change

Two one-line anchor fixes: `#paying-with-usdc-testnet` ->
`#paying-with-stellar-testnet` in both files. All other TOC deep links were
checked against their heading slugs and resolve correctly.

## Verification

- `npm run lint` / `npm run type-check` / `npm run test` all pass (docs-only
  change; test suite identical to the main baseline).

## Note

Several other PRs also fix this issue (#65, #225, #227, #247). Happy to close
this one as a duplicate if a different implementation is preferred.