### PR TITLE
docs: drop Debug Mode instructions for an unimplemented logging flag (#115)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -292,13 +292,6 @@ If you can't resolve an issue:
 
 ## Debug Mode
 
-Enable verbose logging:
-
-```javascript
-// In browser console
-localStorage.setItem('debug', 'mova-store:*');
-```
-
 Check Stellar transaction details:
 
 ```bash


### PR DESCRIPTION
Closes #115

## Problem

`docs/TROUBLESHOOTING.md` ("Debug Mode") tells users to enable verbose logging
with `localStorage.setItem('debug', 'mova-store:*')` in the browser console.
No code in the repository reads a `debug` localStorage flag or uses a
`mova-store:*` console matcher (grep across the whole tree returns zero
hits), so the instructions do nothing.

## Change

Removed the "Enable verbose logging" block and its code sample. The remaining
"Check Stellar transaction details" and "Monitor contract events" subsections
are kept - they describe real Soroban CLI steps.

## Verification

- Docs-only change; `npm run lint` / `npm run type-check` / `npm run test`
  all pass, identical to the main baseline.

## Note

PR #140 also targets this issue; happy to close as a duplicate if preferred.