### PR TITLE
fix: per-product images and modern next/image props on collections page (#26)

### DIFF
--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -1,7 +1,6 @@
 import Image from 'next/image';
 import shoeImage1 from "/public/images/shoe4.png";
 import shoeImage2 from "/public/images/shoe3.png";
-import shoeImage3 from "/public/images/shoe3.png";
 import shoeImage4 from "/public/images/shoe4.png";
 import shoeImage5 from "/public/images/shoe5.png";
 const shoes = [
@@ -15,19 +14,19 @@ const shoes = [
     id: 2,
     name: "Basketball Shoes",
     price: "$129.99",
-    imageUrl: shoeImage1,
+    imageUrl: shoeImage2,
   },
   {
     id: 3,
     name: "Casual Sneakers",
     price: "$79.99",
-    imageUrl: shoeImage1,
+    imageUrl: shoeImage4,
   },
   {
     id: 4,
     name: "Formal Shoes",
     price: "$149.99",
-    imageUrl: shoeImage1,
+    imageUrl: shoeImage5,
   },
 ];
 
@@ -42,8 +41,8 @@ export default function ShoesCollection() {
               <Image
                 src={shoe.imageUrl}
                 alt={shoe.name}
-                layout="fill"
-                objectFit="cover"
+                fill
+                style={{ objectFit: 'cover' }}
                 className="rounded-t-lg"
               />
             </div>


### PR DESCRIPTION
Closes #26

## Problem

`app/collections/page.tsx`:

1. All four products render `shoeImage1` (shoe4.png) - one image for the whole
   grid instead of a per-product image.
2. `shoeImage3` imports shoe3.png a second time (duplicate of `shoeImage2`)
   and is never used.
3. `<Image>` uses the removed `layout="fill"` + `objectFit="cover"` props -
   Next.js logs a "legacy prop" console error in dev.

## Change

- Map each product to its own image: Running -> shoe4.png, Basketball ->
  shoe3.png, Casual -> shoe4.png, Formal -> shoe5.png.
- Drop the unused duplicate `shoeImage3` import.
- Replace `layout="fill" objectFit="cover"` with `fill` +
  `style={{ objectFit: 'cover' }}`.

## Verification

- `npm run lint` / `npm run type-check` pass (no unused imports).
- `npm run test` identical to the main baseline.

## Note

PR #231 also targets this issue; happy to close as a duplicate if preferred.