### PR TITLE
fix: order merge carries only lifecycle fields, preserving buyer/token (#73)

### DIFF
--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -6,6 +6,7 @@ import { PaymentEventIndexer, IndexedEvent } from "../../../lib/stellar/indexer"
 import {
   dispatchOrder,
   refundOrder,
+  mergeOrderEvent,
   OrderEvent,
   eventToOrder,
   OrderStatus,
@@ -201,7 +202,7 @@ const OrdersManagementContent = () => {
             if (existing) {
               // Update status if the new event is more recent
               if (event.ledger > (existing.ledger || 0)) {
-                newMap.set(order.orderId, { ...existing, ...order });
+                newMap.set(order.orderId, mergeOrderEvent(existing, order));
               }
             } else {
               newMap.set(order.orderId, order);

--- a/lib/stellar/orders.ts
+++ b/lib/stellar/orders.ts
@@ -500,3 +500,28 @@ export function eventToOrder(
     txHash,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Order Merge (admin dashboard reducer)
+// ---------------------------------------------------------------------------
+
+/**
+ * Merges a newer event-derived order (dispatch/refund) into an existing row.
+ *
+ * Only lifecycle fields carry forward: status, ledger and txHash. Dispatch
+ * events carry [order_id, merchant] in their topics, so the event-derived
+ * "buyer" is the *merchant* address - blindly spreading the incoming row over
+ * the existing one would replace the stored buyer and could clobber
+ * tokenSymbol with the unknown-contract fallback.
+ */
+export function mergeOrderEvent(
+  existing: OrderEvent,
+  incoming: OrderEvent
+): OrderEvent {
+  return {
+    ...existing,
+    status: incoming.status,
+    ledger: incoming.ledger,
+    txHash: incoming.txHash,
+  };
+}

--- a/tests/lib/stellar/orders-merge.test.ts
+++ b/tests/lib/stellar/orders-merge.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  mergeOrderEvent,
+  OrderEvent,
+} from "../../../lib/stellar/orders";
+
+function makeOrder(overrides: Partial<OrderEvent> = {}): OrderEvent {
+  return {
+    orderId: "a".repeat(64),
+    buyer: "GTESTBUYERBUYERBUYERBUYERBUYERBUYERBUYERBUYERBUYERBUYERB",
+    amount: "10.00",
+    amountRaw: 10000000n,
+    token: "CUSDCUSDCUSDCUSDCUSDCUSDCUSDCUSDCUSDCUSDCUSDCUSDCUSDCUSDC",
+    tokenSymbol: "USDC",
+    status: "Paid",
+    timestamp: 1700000000000,
+    ledger: 100,
+    txHash: "b".repeat(64),
+    ...overrides,
+  };
+}
+
+describe("mergeOrderEvent", () => {
+  it("carries forward only lifecycle fields when a dispatch event merges over a Paid row", () => {
+    const existing = makeOrder({
+      status: "Paid",
+      ledger: 100,
+      txHash: "b".repeat(64),
+    });
+    // dispatch topics are [order_id, merchant], so the event-derived buyer
+    // is the merchant and the token may fall back to the unknown symbol.
+    const incoming = makeOrder({
+      status: "Shipped",
+      buyer: "GMERCHANTMERCHANTMERCHANTMERCHANTMERCHANTMERCHANTMERCHANTM",
+      tokenSymbol: "TOKEN",
+      amount: "0.00",
+      amountRaw: 0n,
+      ledger: 110,
+      txHash: "c".repeat(64),
+    });
+
+    const merged = mergeOrderEvent(existing, incoming);
+
+    // lifecycle fields come from the newer event
+    expect(merged.status).toBe("Shipped");
+    expect(merged.ledger).toBe(110);
+    expect(merged.txHash).toBe("c".repeat(64));
+    // identity fields from the original pay event are preserved
+    expect(merged.buyer).toBe(existing.buyer);
+    expect(merged.tokenSymbol).toBe("USDC");
+    expect(merged.amount).toBe("10.00");
+    expect(merged.amountRaw).toBe(10000000n);
+    expect(merged.token).toBe(existing.token);
+    expect(merged.orderId).toBe(existing.orderId);
+    expect(merged.timestamp).toBe(existing.timestamp);
+  });
+
+  it("preserves the original row when a refund event merges over it", () => {
+    const existing = makeOrder({ status: "Paid", ledger: 200 });
+    const incoming = makeOrder({
+      status: "Refunded",
+      buyer: "GMERCHANT2",
+      ledger: 210,
+      txHash: "d".repeat(64),
+    });
+
+    const merged = mergeOrderEvent(existing, incoming);
+
+    expect(merged.status).toBe("Refunded");
+    expect(merged.buyer).toBe(existing.buyer);
+    expect(merged.tokenSymbol).toBe("USDC");
+    expect(merged.amount).toBe("10.00");
+    expect(merged.ledger).toBe(210);
+    expect(merged.txHash).toBe("d".repeat(64));
+  });
+
+  it("does not mutate either input and returns a new object", () => {
+    const existing = makeOrder();
+    const incoming = makeOrder({ status: "Shipped", ledger: 101 });
+
+    const merged = mergeOrderEvent(existing, incoming);
+
+    expect(merged).not.toBe(existing);
+    expect(merged).not.toBe(incoming);
+    expect(existing.status).toBe("Paid");
+    expect(existing.ledger).toBe(100);
+    expect(existing.txHash).toBe("b".repeat(64));
+    expect(incoming.status).toBe("Shipped");
+  });
+});


### PR DESCRIPTION
Closes #73

## Problem

The admin orders reducer merges newer events with
`newMap.set(order.orderId, { ...existing, ...order })`. Dispatch/refund
events carry `[order_id, merchant]` in their topics, so the event-derived
row's `buyer` is the **merchant** address - spreading it over the existing
row replaces the real buyer, and the `token`/`tokenSymbol` pair can be
clobbered with the unknown-contract fallback.

## Change

- New pure helper in `lib/stellar/orders.ts`:
  `mergeOrderEvent(existing, incoming)` carries forward only lifecycle
  fields (`status`, `ledger`, `txHash`); buyer/amount/token/tokenSymbol
  stay from the original pay event.
- The admin page reducer now calls `mergeOrderEvent(existing, order)`
  instead of spreading.

## Verification

- 3 new unit tests (`tests/lib/stellar/orders-merge.test.ts`): dispatch
  merge preserves buyer/token/amount while advancing status/ledger/txHash;
  same for refund; no input mutation.
- `npm run lint` / `npm run type-check` pass.
- `npm run test`: no new failures vs. the main baseline.

## Note

PR #234 also targets this issue; happy to close as a duplicate if preferred.