### PR TITLE
fix: stop re-hashing already-hashed order ids in dispatch/refund (#67)

### DIFF
--- a/lib/stellar/orders.ts
+++ b/lib/stellar/orders.ts
@@ -25,7 +25,7 @@ import {
   tokenForContract,
 } from "./config";
 import { connectWallet, signWithFreighter } from "./freighter";
-import { hashOrderId, bytesToHex } from "./scval";
+import { hashOrderId, hexToBytes, bytesToHex } from "./scval";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -204,6 +204,28 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
 }
 
 // ---------------------------------------------------------------------------
+// Order Id Resolution
+// ---------------------------------------------------------------------------
+
+const HASHED_ORDER_ID_RE = /^[0-9a-fA-F]{64}$/;
+
+/**
+ * Resolves the 32-byte order id hash to pass to the contract.
+ *
+ * Indexer events carry the already-hashed order id (64 hex chars) in their
+ * topic, and the admin page passes that straight into dispatchOrder /
+ * refundOrder. SHA-256 is one-way, so re-hashing the hex can never reproduce
+ * the stored BytesN<32> - such ids are passed through unchanged, while short
+ * raw pre-images (e.g. "SS-2024-0001") are hashed.
+ */
+export async function resolveOrderIdHash(orderId: string): Promise<Uint8Array> {
+  if (HASHED_ORDER_ID_RE.test(orderId)) {
+    return hexToBytes(orderId);
+  }
+  return hashOrderId(orderId);
+}
+
+// ---------------------------------------------------------------------------
 // Dispatch Order (Release Escrow to Merchant)
 // ---------------------------------------------------------------------------
 
@@ -219,7 +241,7 @@ export async function dispatchOrder(
     const server = new rpc.Server(RPC_URL);
     const contract = new Contract(CHECKOUT_CONTRACT_ID);
 
-    const orderIdHashBytes = await hashOrderId(orderId);
+    const orderIdHashBytes = await resolveOrderIdHash(orderId);
 
     const account = await server.getAccount(publicKey);
 
@@ -300,7 +322,7 @@ export async function refundOrder(orderId: string): Promise<OrderActionResult> {
     const server = new rpc.Server(RPC_URL);
     const contract = new Contract(CHECKOUT_CONTRACT_ID);
 
-    const orderIdHashBytes = await hashOrderId(orderId);
+    const orderIdHashBytes = await resolveOrderIdHash(orderId);
 
     const account = await server.getAccount(publicKey);
 

--- a/tests/app/admin/orders-page.test.tsx
+++ b/tests/app/admin/orders-page.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+
+const HEX64 =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+const hoisted = vi.hoisted(() => {
+  const state: {
+    onEvent?: (e: unknown) => void;
+    onStatus?: (s: unknown) => void;
+  } = {};
+  const dispatchOrder = vi.fn(async () => ({ success: true, txHash: "d".repeat(64) }));
+  const refundOrder = vi.fn(async () => ({ success: true, txHash: "e".repeat(64) }));
+  return { state, dispatchOrder, refundOrder };
+});
+
+vi.mock("../../../lib/stellar/indexer", () => ({
+  PaymentEventIndexer: class {
+    start(opts: { onEvent?: (e: unknown) => void; onStatus?: (s: unknown) => void }) {
+      hoisted.state.onEvent = opts.onEvent;
+      hoisted.state.onStatus = opts.onStatus;
+    }
+    stop() {}
+  },
+}));
+
+vi.mock("../../../lib/stellar/orders", () => ({
+  dispatchOrder: (...args: unknown[]) => hoisted.dispatchOrder(...(args as [])),
+  refundOrder: (...args: unknown[]) => hoisted.refundOrder(...(args as [])),
+  eventToOrder: (event: {
+    fields: Record<string, string>;
+    symbol: string;
+    ledger: number;
+    txHash: string;
+  }) => ({
+    orderId: event.fields.order_id || event.fields.topic1 || "",
+    buyer: event.fields.buyer || event.fields.topic2 || "",
+    amount: "10.00",
+    amountRaw: 10000000n,
+    token: event.fields.token || "",
+    tokenSymbol: "USDC",
+    status:
+      event.symbol === "dispatch"
+        ? "Shipped"
+        : event.symbol === "refund"
+          ? "Refunded"
+          : "Paid",
+    timestamp: 1700000000000,
+    ledger: event.ledger,
+    txHash: event.txHash,
+  }),
+}));
+
+vi.mock("../../../components/AdminGuard", () => ({
+  default: ({ children }: { children: unknown }) => <>{children}</>,
+}));
+
+vi.mock("../../../components/StellarWalletButton", () => ({
+  default: () => <button type="button">wallet</button>,
+}));
+
+import OrdersManagement from "../../../app/admin/orders/page";
+
+const payEvent = {
+  id: 1,
+  type: "contract",
+  ledger: 100,
+  ledgerClosedAt: "2024-01-01T00:00:00Z",
+  txHash: "f".repeat(64),
+  symbol: "pay",
+  topics: [],
+  fields: {
+    order_id: HEX64,
+    buyer: "GTESTBUYER",
+    amount: "10000000",
+    token: "CUSDC",
+  },
+};
+
+function startIndexer() {
+  act(() => {
+    hoisted.state.onStatus?.({ running: true, eventsSeen: 1 });
+  });
+}
+
+function deliverEvent() {
+  act(() => {
+    hoisted.state.onEvent?.(payEvent);
+  });
+}
+
+describe("admin orders page - event-derived order id pass-through", () => {
+  beforeEach(() => {
+    hoisted.dispatchOrder.mockClear();
+    hoisted.refundOrder.mockClear();
+    hoisted.state.onEvent = undefined;
+    hoisted.state.onStatus = undefined;
+  });
+
+  it("passes the event-derived hex id into dispatchOrder unmodified", async () => {
+    render(<OrdersManagement />);
+    startIndexer();
+    deliverEvent();
+
+    await screen.findByText(/GTESTBUYER/);
+    fireEvent.click(screen.getByText("Ship"));
+
+    await waitFor(() => expect(hoisted.dispatchOrder).toHaveBeenCalledTimes(1));
+    expect(hoisted.dispatchOrder).toHaveBeenCalledWith(HEX64);
+  });
+
+  it("passes the event-derived hex id into refundOrder unmodified", async () => {
+    render(<OrdersManagement />);
+    startIndexer();
+    deliverEvent();
+
+    await screen.findByText(/GTESTBUYER/);
+    fireEvent.click(screen.getByText("Refund"));
+
+    await waitFor(() => expect(hoisted.refundOrder).toHaveBeenCalledTimes(1));
+    expect(hoisted.refundOrder).toHaveBeenCalledWith(HEX64);
+  });
+});

--- a/tests/lib/stellar/orders.test.ts
+++ b/tests/lib/stellar/orders.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  hashOrderId,
+  bytesToHex,
+} from "../../../lib/stellar/scval";
+import { resolveOrderIdHash } from "../../../lib/stellar/orders";
+
+const HEX64 =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+describe("resolveOrderIdHash", () => {
+  it("passes an already-hashed 64-hex order id through unchanged", async () => {
+    const bytes = await resolveOrderIdHash(HEX64);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes).toHaveLength(32);
+    expect(bytesToHex(bytes)).toBe(HEX64);
+  });
+
+  it("accepts uppercase 64-hex ids", async () => {
+    const bytes = await resolveOrderIdHash(HEX64.toUpperCase());
+    expect(bytesToHex(bytes)).toBe(HEX64);
+  });
+
+  it("hashes short raw pre-images with SHA-256", async () => {
+    const rawId = "SS-2024-0001";
+    const bytes = await resolveOrderIdHash(rawId);
+    expect(bytes).toHaveLength(32);
+    expect(bytesToHex(bytes)).toBe(bytesToHex(await hashOrderId(rawId)));
+    // It must be a real hash, not the input copied/padded.
+    expect(bytesToHex(bytes)).not.toBe(rawId.toLowerCase().padEnd(64, "0"));
+  });
+
+  it("treats near-miss lengths (63 or 65 hex chars) as raw pre-images", async () => {
+    const short63 = HEX64.slice(0, 63);
+    const bytes63 = await resolveOrderIdHash(short63);
+    expect(bytesToHex(bytes63)).toBe(bytesToHex(await hashOrderId(short63)));
+
+    const long65 = HEX64 + "f";
+    const bytes65 = await resolveOrderIdHash(long65);
+    expect(bytesToHex(bytes65)).toBe(bytesToHex(await hashOrderId(long65)));
+  });
+
+  it("treats 64-char strings containing non-hex characters as raw pre-images", async () => {
+    const notHex = "g".repeat(64);
+    const bytes = await resolveOrderIdHash(notHex);
+    expect(bytesToHex(bytes)).toBe(bytesToHex(await hashOrderId(notHex)));
+  });
+});


### PR DESCRIPTION
Closes #67

## Problem

`dispatchOrder` / `refundOrder` in `lib/stellar/orders.ts` always run
`hashOrderId(orderId)` (SHA-256). But the admin page passes the
event-derived order id, which the contract **already stored as a hash** -
a 64-hex string. SHA-256 is one-way: hashing the hex never reproduces the
stored `BytesN<32>`, so the contract call can never find the escrowed order
and dispatch/refund from the admin UI is dead.

## Change

- New pure helper in `lib/stellar/orders.ts`:
  `resolveOrderIdHash(orderId)` - a 64-hex input is passed through as the
  32-byte hash itself (`hexToBytes`); anything else is hashed with SHA-256
  as before.
- `dispatchOrder` and `refundOrder` now call `resolveOrderIdHash` instead of
  `hashOrderId`.

## Verification

- 5 new helper unit tests
  (`tests/lib/stellar/orders.test.ts`): 64-hex passthrough, uppercase
  passthrough, short-id hashing equals `hashOrderId`, 63/65-char near-misses
  treated as raw ids, 64 non-hex chars treated as raw ids.
- 2 new admin-page tests
  (`tests/app/admin/orders-page.test.tsx`): with a mocked indexer firing a
  pay event carrying a 64-hex `order_id`, clicking **Ship** / **Refund**
  calls `dispatchOrder` / `refundOrder` with that exact hex string
  unmodified.
- `npm run lint` / `npm run type-check` pass.
- `npm run test`: no new failures vs. the main baseline.

## Note

PRs #130 and #271 also target this issue; happy to close as a duplicate if
either is preferred.