### PR TITLE
fix: classify RPC failures vs missing account in loadAccount/getNativeBalance (#19)

### DIFF
--- a/lib/stellar/account.ts
+++ b/lib/stellar/account.ts
@@ -17,6 +17,17 @@ import { readTokenBalance, readTokenDecimals } from "./simulate";
 /** Classic account minimum reserve: 1 XLM (10,000,000 stroops). */
 export const MIN_NATIVE_RESERVE = BigInt(10000000);
 
+/**
+ * The SDK reports a missing account as `Error("Account not found: <address>")`
+ * (see rpc.Server#getAccount / getAccountEntry). Anything else - timeouts,
+ * 5xx responses, offline - is an RPC failure and must not be treated as an
+ * "account missing" case.
+ */
+export function isAccountNotFoundError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /account not found/i.test(message);
+}
+
 export interface LoadedAccount {
   account: Account;
   funded: boolean;
@@ -55,16 +66,24 @@ export async function loadAccount(
   try {
     const account = await server.getAccount(publicKey);
     return { account, funded: false };
-  } catch {
-    if (!IS_MAINNET && fund) {
-      await fundTestnetAccount(publicKey);
-      const account = await server.getAccount(publicKey);
-      return { account, funded: true };
+  } catch (err) {
+    if (isAccountNotFoundError(err)) {
+      if (!IS_MAINNET && fund) {
+        await fundTestnetAccount(publicKey);
+        const account = await server.getAccount(publicKey);
+        return { account, funded: true };
+      }
+      throw new WalletError(
+        "Your Stellar account has no sequence number on this network. " +
+          "Fund it with XLM before paying.",
+        "ACCOUNT_NOT_FOUND"
+      );
     }
     throw new WalletError(
-      "Your Stellar account has no sequence number on this network. " +
-        "Fund it with XLM before paying.",
-      "ACCOUNT_NOT_FOUND"
+      `Could not verify your Stellar account: ${
+        err instanceof Error ? err.message : String(err)
+      }. The RPC node may be unreachable - try again in a moment.`,
+      "RPC_ERROR"
     );
   }
 }
@@ -87,8 +106,16 @@ export async function getNativeBalance(
   try {
     const entry = await server.getAccountEntry(publicKey);
     return BigInt(entry.balance().toString());
-  } catch {
-    return BigInt(0);
+  } catch (err) {
+    if (isAccountNotFoundError(err)) {
+      return BigInt(0);
+    }
+    throw new WalletError(
+      `Could not read the native balance: ${
+        err instanceof Error ? err.message : String(err)
+      }. The RPC node may be unreachable - try again in a moment.`,
+      "RPC_ERROR"
+    );
   }
 }
 

--- a/tests/lib/stellar/account.test.ts
+++ b/tests/lib/stellar/account.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from "vitest";
-import { formatAmount, MIN_NATIVE_RESERVE } from "../../../lib/stellar/account";
+import { describe, it, expect, vi } from "vitest";
+import {
+  formatAmount,
+  MIN_NATIVE_RESERVE,
+  loadAccount,
+  getNativeBalance,
+  isAccountNotFoundError,
+} from "../../../lib/stellar/account";
+import { WalletError } from "../../../lib/stellar/freighter";
 
 describe("formatAmount", () => {
   it("formats MIN_NATIVE_RESERVE with 7 decimals correctly", () => {
@@ -41,5 +48,128 @@ describe("formatAmount", () => {
     const expectedFrac = (huge % 10000000n).toString().padStart(7, "0").replace(/0+$/, "");
     const expected = expectedFrac ? `${expectedInt}.${expectedFrac}` : expectedInt;
     expect(formatted).toBe(expected);
+  });
+});
+
+
+describe("isAccountNotFoundError", () => {
+  it("matches the SDK account-missing message", () => {
+    expect(isAccountNotFoundError(new Error("Account not found: GTEST"))).toBe(true);
+    expect(isAccountNotFoundError(new Error("account not found"))).toBe(true);
+  });
+
+  it("does not match network or RPC failures", () => {
+    expect(isAccountNotFoundError(new TypeError("fetch failed"))).toBe(false);
+    expect(isAccountNotFoundError(new Error("502 Bad Gateway"))).toBe(false);
+    expect(isAccountNotFoundError("Account not found: GTEST")).toBe(true);
+  });
+});
+
+describe("loadAccount error classification", () => {
+  const PUB = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+  it("surfaces RPC/network failures without calling friendbot (testnet)", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const server = {
+      getAccount: vi.fn().mockRejectedValue(new TypeError("fetch failed")),
+    };
+    await expect(loadAccount(server, PUB, { fund: true })).rejects.toMatchObject({
+      name: "WalletError",
+      code: "RPC_ERROR",
+    });
+    expect(server.getAccount).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it("still funds a genuinely missing account on testnet", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+    const account = { sequence: "42" };
+    const server = {
+      getAccount: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Account not found: " + PUB))
+        .mockResolvedValueOnce(account),
+    };
+    const loaded = await loadAccount(server, PUB, { fund: true });
+    expect(loaded.funded).toBe(true);
+    expect(loaded.account).toBe(account);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(server.getAccount).toHaveBeenCalledTimes(2);
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects with ACCOUNT_NOT_FOUND when funding is disabled", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const server = {
+      getAccount: vi
+        .fn()
+        .mockRejectedValue(new Error("Account not found: " + PUB)),
+    };
+    await expect(loadAccount(server, PUB, { fund: false })).rejects.toMatchObject({
+      name: "WalletError",
+      code: "ACCOUNT_NOT_FOUND",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects a missing account on mainnet without funding", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_NETWORK", "mainnet");
+    vi.resetModules();
+    const { loadAccount: loadAccountMainnet } = await import(
+      "../../../lib/stellar/account"
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const server = {
+      getAccount: vi
+        .fn()
+        .mockRejectedValue(new Error("Account not found: " + PUB)),
+    };
+    await expect(
+      loadAccountMainnet(server, PUB, { fund: true })
+    ).rejects.toMatchObject({
+      name: "WalletError",
+      code: "ACCOUNT_NOT_FOUND",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+});
+
+describe("getNativeBalance error classification", () => {
+  it("returns 0n only for a genuinely missing account", async () => {
+    const server = {
+      getAccountEntry: vi
+        .fn()
+        .mockRejectedValue(new Error("Account not found: GTEST")),
+    };
+    await expect(getNativeBalance(server, "GTEST")).resolves.toBe(BigInt(0));
+  });
+
+  it("surfaces RPC failures instead of returning 0n", async () => {
+    const server = {
+      getAccountEntry: vi.fn().mockRejectedValue(new TypeError("fetch failed")),
+    };
+    await expect(getNativeBalance(server, "GTEST")).rejects.toMatchObject({
+      name: "WalletError",
+      code: "RPC_ERROR",
+    });
+  });
+
+  it("reads the balance from a resolved entry", async () => {
+    const server = {
+      getAccountEntry: vi
+        .fn()
+        .mockResolvedValue({ balance: () => ({ toString: () => "12345678" }) }),
+    };
+    await expect(getNativeBalance(server, "GTEST")).resolves.toBe(
+      BigInt("12345678")
+    );
   });
 });


### PR DESCRIPTION
Closes #19

## Problem

`loadAccount` catches **every** error from `server.getAccount` and treats it
as "account not found": on testnet it pings friendbot on plain network
failures and reports the account as funded; on mainnet it reports an
unfunded account when the RPC node is simply unreachable.
`getNativeBalance` has the same flaw - any RPC failure silently returns `0n`,
which checkout surfaces as "insufficient native balance".

## Change

- New exported `isAccountNotFoundError(err)` matching the SDK's
  `Account not found: <address>` message (what `rpc.Server#getAccount` /
  `getAccountEntry` throw for missing accounts).
- `loadAccount`: missing account -> existing friendbot fund path (testnet) or
  `ACCOUNT_NOT_FOUND` (mainnet / fund disabled), unchanged; any other error
  -> `WalletError(..., "RPC_ERROR")` **without** calling friendbot.
- `getNativeBalance`: missing account -> `0n` (unchanged); any other error
  -> `WalletError(..., "RPC_ERROR")` so the failure is surfaced instead of
  masquerading as a zero balance.

## Verification

- 9 new unit tests (`tests/lib/stellar/account.test.ts`):
  - classifier: SDK missing-account message vs `TypeError("fetch failed")`
    / `502`
  - `loadAccount` network error (testnet): rejects `RPC_ERROR`, friendbot
    `fetch` **not** called, `getAccount` called once
  - `loadAccount` genuinely missing (testnet): funds via friendbot and
    returns `{ funded: true }`
  - `loadAccount` missing with `fund: false`: `ACCOUNT_NOT_FOUND`
  - `loadAccount` missing on mainnet: `ACCOUNT_NOT_FOUND`, no friendbot
  - `getNativeBalance`: missing -> `0n`; network error -> `RPC_ERROR`;
    resolved entry -> correct bigint balance
- `npm run lint` / `npm run type-check` pass.
- `npm run test`: no new failures vs. the main baseline.

## Note

PR #252 also targets this issue; happy to close as a duplicate if preferred.