### PR TITLE
feat: add loading skeleton and empty state to shop products grid (#105)

### DIFF
--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -8,6 +8,7 @@ import Cart from "../../components/Cart";
 import Modal from "../../components/Modal";
 import Toast from "../../components/Toast";
 import { listProducts } from "../../lib/products";
+import { ProductGridSkeleton } from "../../components/Skeleton";
 
 export default function Products() {
   const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } =
@@ -17,6 +18,7 @@ export default function Products() {
   const [isCheckingOut, setIsCheckingOut] = useState(false);
   const [products, setProducts] = useState([]);
   const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchProducts = async () => {
@@ -25,6 +27,8 @@ export default function Products() {
         setProducts(data);
       } catch (err) {
         setError(err.message);
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -60,6 +64,18 @@ export default function Products() {
 
           {error && <p className="text-red-500 text-center">{error}</p>}
 
+          {loading ? (
+            <ProductGridSkeleton />
+          ) : products.length === 0 ? (
+            <div className="py-16 text-center">
+              <p className="text-2xl font-semibold text-mova-ink">
+                No products yet
+              </p>
+              <p className="text-gray-500 mt-2">
+                Check back soon - new arrivals are on the way.
+              </p>
+            </div>
+          ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
             {products.map((prod) => (
               <div key={prod.id} className="p-4 border rounded-lg shadow">
@@ -86,6 +102,7 @@ export default function Products() {
               </div>
             ))}
           </div>
+          )}
         </section>
       </div>
 

--- a/tests/app/shop/page.test.jsx
+++ b/tests/app/shop/page.test.jsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+let listProductsImpl;
+
+vi.mock("../../../lib/products", () => ({
+  listProducts: (...args) => listProductsImpl(...args),
+}));
+
+vi.mock("../../../context/CartContext", () => ({
+  useCart: () => ({
+    itemCount: 0,
+    cartItems: [],
+    addToCart: () => {},
+    removeFromCart: () => {},
+    totalPrice: 0,
+  }),
+}));
+
+import Products from "../../../app/shop/page";
+
+function pendingProducts() {
+  let resolve;
+  const promise = new Promise((r) => {
+    resolve = r;
+  });
+  listProductsImpl = () => promise;
+  return resolve;
+}
+
+describe("shop products grid states", () => {
+  beforeEach(() => {
+    listProductsImpl = () => new Promise(() => {}); // stays pending
+  });
+
+  it("shows the loading skeleton while listProducts is pending", async () => {
+    const { container } = render(<Products />);
+    expect(container.querySelector(".animate-pulse")).toBeTruthy();
+    expect(screen.queryByText(/no products yet/i)).toBeNull();
+  });
+
+  it("shows an explicit empty state when the list resolves empty", async () => {
+    const resolve = pendingProducts();
+    render(<Products />);
+    expect(screen.queryByText(/no products yet/i)).toBeNull();
+    resolve([]);
+    await screen.findByText(/no products yet/i);
+  });
+
+  it("renders products once the list resolves with items", async () => {
+    const resolve = pendingProducts();
+    render(<Products />);
+    resolve([
+      { id: "p1", name: "Test Shoes", price: 99.99, img: "http://x/y.png" },
+    ]);
+    await screen.findByText("Test Shoes");
+  });
+
+  it("keeps the error state on rejection", async () => {
+    listProductsImpl = async () => {
+      throw new Error("products failed");
+    };
+    render(<Products />);
+    await screen.findByText("products failed");
+  });
+});


### PR DESCRIPTION
Closes #105

## Problem

`app/shop/page.jsx` renders a bare `<div className="grid ...">` that is empty
while `listProducts()` is in flight and stays an empty area when the catalog
is empty - users see a blank region with no loading or empty-state feedback
(the error case was already handled).

## Change

- Add a `loading` state (initially `true`, cleared in `finally`).
- While pending, render the existing `ProductGridSkeleton`
  (`components/Skeleton.tsx`).
- When the list resolves empty, render an explicit "No products yet" empty
  state.
- Error state and the product grid render exactly as before.

## Verification

- 4 new tests (`tests/app/shop/page.test.jsx`): skeleton visible while
  `listProducts` is pending; explicit empty state on `[]`; products render
  once the list resolves; rejection still shows the error message.
- `npm run lint` / `npm run type-check` pass.
- `npm run test`: no new failures vs. the main baseline.

## Note

PR #141 also targets this issue; happy to close as a duplicate if preferred.