### PR TITLE
fix(stellar): reconcile canonical mainnet RPC default across code and docs (closes #108)

### DIFF
--- a/docs/MAINNET_DEPLOYMENT.md
+++ b/docs/MAINNET_DEPLOYMENT.md
@@ -149,8 +149,8 @@ Update your `.env.local` (or production environment variables):
 # Switch to mainnet
 NEXT_PUBLIC_STELLAR_NETWORK=mainnet
 
-# Mainnet RPC endpoint (use a reliable provider)
-NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-rpc.mainnet.stellar.gateway.fm
+# Mainnet RPC endpoint (defaults to https://soroban-rpc.stellar.org)
+NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-rpc.stellar.org
 
 # Mainnet passphrase
 NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE=Public Global Stellar Network ; September 2015

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -54,7 +54,7 @@ const STELLAR_DEFAULTS = {
       "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
   },
   mainnet: {
-    rpcUrl: "https://soroban-rpc.mainnet.stellar.gateway.fm",
+    rpcUrl: "https://soroban-rpc.stellar.org",
     networkPassphrase: "Public Global Stellar Network ; September 2015",
     usdcContractId: "", // Must be configured for mainnet
     nativeAssetContractId: "", // Must be configured for mainnet

--- a/tests/lib/env.test.ts
+++ b/tests/lib/env.test.ts
@@ -99,4 +99,19 @@ describe("validateEnv", () => {
     expect(config.emailjs.publicKey).toBe("pubkey_789");
     expect(config.admin.adminEmails).toContain("admin@store.org");
   });
+
+  it("resolves canonical mainnet RPC default when env var is unset", () => {
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_NETWORK", "mainnet");
+    vi.stubEnv("NEXT_PUBLIC_CHECKOUT_CONTRACT_ID", "CA1234567890TESTCONTRACTID");
+    vi.stubEnv("NEXT_PUBLIC_USDC_CONTRACT_ID", "CB1234567890TESTUSDCID");
+    vi.stubEnv("NEXT_PUBLIC_NATIVE_ASSET_CONTRACT_ID", "CC1234567890TESTNATIVEID");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://project.supabase.co");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key-123");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_SERVICE_ID", "service_abc");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_TEMPLATE_ID", "template_xyz");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_PUBLIC_KEY", "pubkey_789");
+
+    const config = validateEnv();
+    expect(config.stellar.rpcUrl).toBe("https://soroban-rpc.stellar.org");
+  });
 });


### PR DESCRIPTION
## Summary
Resolves #108 by establishing a single canonical default mainnet RPC endpoint (`https://soroban-rpc.stellar.org`) across code and documentation.

### Changes
1. **`lib/env.ts`**:
   - Updated `STELLAR_DEFAULTS.mainnet.rpcUrl` from gateway.fm to canonical `https://soroban-rpc.stellar.org`, aligning directly with `lib/stellar/config.ts`.
2. **`docs/MAINNET_DEPLOYMENT.md`**:
   - Updated the Step 6 `.env.local` snippet to document `NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-rpc.stellar.org`.
3. **`tests/lib/env.test.ts`**:
   - Added unit test asserting `validateEnv().stellar.rpcUrl` correctly defaults to `https://soroban-rpc.stellar.org` when `NEXT_PUBLIC_STELLAR_NETWORK=mainnet` and the RPC URL env var is unset.

### Acceptance Criteria Verification
- [x] `config.ts` and `env.ts` resolve the same mainnet RPC (`https://soroban-rpc.stellar.org`) when the env var is unset.
- [x] `MAINNET_DEPLOYMENT.md` documents the endpoint the code actually defaults to.
- [x] 12/12 unit tests in `tests/lib/env.test.ts` pass cleanly.
- [x] `npm run type-check` passes with zero errors.

Closes #108
Bounty: $90
