### PR TITLE
docs: remove unimplemented debug mode localStorage instructions (closes #115)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -292,13 +292,6 @@ If you can't resolve an issue:
 
 ## Debug Mode
 
-Enable verbose logging:
-
-```javascript
-// In browser console
-localStorage.setItem('debug', 'mova-store:*');
-```
-
 Check Stellar transaction details:
 
 ```bash


### PR DESCRIPTION
## Summary
Resolves #115 by removing the unimplemented browser console `localStorage.setItem('debug', 'mova-store:*')` snippet from `docs/TROUBLESHOOTING.md`.

### Changes
- Removed the verbose logging localStorage instructions from `docs/TROUBLESHOOTING.md`.
- Preserved the existing, valid Stellar CLI debugging commands (`stellar tx details` and `stellar events`).

### Acceptance Criteria Verification
- [x] No doc step instructs using an unimplemented console flag.
- [x] Preserves valid Stellar CLI troubleshooting commands.

Closes #115
Bounty: $60
