### PR TITLE
fix: reject invalid hex characters in hexToBytes

### DIFF
--- a/lib/stellar/scval.ts
+++ b/lib/stellar/scval.ts
@@ -107,7 +107,11 @@ export function hexToBytes(hex: string): Uint8Array {
   }
   const out = new Uint8Array(clean.length / 2);
   for (let i = 0; i < out.length; i++) {
-    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+    const chunk = clean.slice(i * 2, i * 2 + 2);
+    if (!/^[0-9a-fA-F]{2}$/.test(chunk)) {
+      throw new Error(`invalid hex character at position ${i * 2}: "${chunk}"`);
+    }
+    out[i] = parseInt(chunk, 16);
   }
   return out;
 }

--- a/tests/lib/stellar/scval.test.ts
+++ b/tests/lib/stellar/scval.test.ts
@@ -111,3 +111,47 @@ describe("ScVal helpers", () => {
     });
   });
 });
+
+describe("hexToBytes validation (#8)", () => {
+  it("parses valid hex (case-insensitive) and round-trips lowercase", () => {
+    expect(Array.from(hexToBytes("00ff10"))).toEqual([0, 255, 16]);
+    expect(Array.from(hexToBytes("ABcd"))).toEqual([171, 205]);
+    expect(bytesToHex(hexToBytes("ABcd00"))).toBe("abcd00");
+  });
+
+  it("accepts an optional 0x prefix", () => {
+    expect(Array.from(hexToBytes("0x01ff"))).toEqual([1, 255]);
+  });
+
+  it("throws on non-hex characters instead of coercing NaN to 0", () => {
+    expect(() => hexToBytes("gggg")).toThrow(/invalid hex character/);
+    expect(() => hexToBytes("0xzz")).toThrow(/invalid hex character/);
+    // parseInt("0g", 16) === 0, so this would silently zero-fill without
+    // explicit per-chunk validation.
+    expect(() => hexToBytes("0g0g")).toThrow(/invalid hex character/);
+  });
+
+  it("still rejects odd-length input", () => {
+    expect(() => hexToBytes("abc")).toThrow(/odd length/);
+  });
+});
+
+describe("bytes32ToScVal with hex input (#8)", () => {
+  it("rejects a 64-character non-hex string instead of zero-filling", () => {
+    expect(() => bytes32ToScVal("g".repeat(64))).toThrow(
+      /invalid hex character/
+    );
+    expect(() => bytes32ToScVal("zz".repeat(32))).toThrow(
+      /invalid hex character/
+    );
+  });
+
+  it("accepts a valid 64-character hex string as 32 bytes", () => {
+    const scv = bytes32ToScVal("00".repeat(31) + "ff");
+    expect(scv.switch()).toBe(xdr.ScValType.scvBytes());
+  });
+
+  it("still enforces the 32-byte length for valid hex", () => {
+    expect(() => bytes32ToScVal("ff")).toThrow(/exactly 32 bytes/);
+  });
+});


### PR DESCRIPTION
Closes #8

## Problem
`hexToBytes` parsed each two-character chunk with `parseInt(chunk, 16)` and assigned the result straight into a `Uint8Array`. Malformed input such as `hexToBytes("gggg")` or `hexToBytes("0xzz")` coerced `NaN` to `0` and silently produced zero bytes. Worse, `parseInt("0g", 16) === 0`, so even hex-looking input with a trailing bad character silently zero-filled. Its only caller, `bytes32ToScVal`, then built a `BytesN<32>` scval from those zero bytes as if it were a valid 32-byte order hash, defeating the strict length guard.

## Change
After the existing `0x`-prefix strip and odd-length check, each chunk is now validated against `^[0-9a-fA-F]{2}$` and a descriptive `Error` naming the offending position and characters is thrown on mismatch. Behaviour for valid input is unchanged (case-insensitive parse, lowercase output via `bytesToHex`).

## Verification
- New tests in tests/lib/stellar/scval.test.ts: valid round-trips (case-insensitive, lowercase output), 0x prefix, `gggg` / `0xzz` / `0g0g` throw, odd length still throws, `bytes32ToScVal("g".repeat(64))` throws instead of zero-filling, valid 64-hex accepted, 32-byte length still enforced
- `npm run lint` / `npm run type-check` / `npm run test` pass with no new failures vs. main baseline