### PR TITLE
test: cover error-classification helpers in lib/errors

### DIFF
--- a/tests/lib/errors.test.ts
+++ b/tests/lib/errors.test.ts
@@ -79,3 +79,70 @@ describe("Error Handling & Stellar Error Reconciliation Tests", () => {
     expect(isRecoverable(new WalletError("Wrong net", "WRONG_NETWORK"))).toBe(true);
   });
 });
+
+describe("parseError fallbacks and delegation (#33)", () => {
+  it("returns the generic Unknown error for null/undefined", () => {
+    for (const input of [null, undefined]) {
+      const parsed = parseError(input);
+      expect(parsed.code).toBe("UNKNOWN_ERROR");
+      expect(parsed.userMessage).toBe(
+        "Something unexpected happened. Please try again."
+      );
+    }
+  });
+
+  it("classifies balance-related messages via the pattern fallback", () => {
+    const parsed = parseError("Insufficient USDC balance");
+    expect(parsed.code).toBe("ACCOUNT_INSUFFICIENT_BALANCE");
+    expect(parsed.recoverable).toBe(true);
+  });
+
+  it("matches timeout and user-rejection patterns by message", () => {
+    expect(parseError(new Error("request timeout")).code).toBe(
+      STELLAR_ERRORS.TX_TIMEOUT.code
+    );
+    expect(parseError("user cancelled the transaction").code).toBe(
+      STELLAR_ERRORS.USER_REJECTED.code
+    );
+  });
+
+  it("falls back to the generic error for unlisted contract errors", () => {
+    // NOTE: the issue text references a STELLAR_ORDER_ALREADY_PAID entry, but
+    // no ORDER_ALREADY_PAID key exists in STELLAR_ERRORS and the substring
+    // matcher cannot bridge the "OrderAlreadyPaid" / "order_already_paid"
+    // spelling gap, so both spellings land in the generic fallback. These
+    // assertions pin that behaviour.
+    for (const input of [new Error("OrderAlreadyPaid"), "order already paid"]) {
+      const parsed = parseError(input);
+      const raw = typeof input === "string" ? input : input.message;
+      expect(parsed.code).toBe("UNKNOWN_ERROR");
+      expect(parsed.message).toBe(raw);
+      expect(parsed.userMessage).toBe(raw);
+    }
+  });
+
+  it("collapses userMessage for messages over 100 characters", () => {
+    const long = "x".repeat(150);
+    const parsed = parseError(long);
+    expect(parsed.code).toBe("UNKNOWN_ERROR");
+    expect(parsed.message).toBe(long);
+    expect(parsed.userMessage).toBe("An error occurred. Please try again.");
+  });
+
+  it("getUserMessage delegates to parseError.userMessage", () => {
+    expect(getUserMessage(new Error("timeout"))).toBe(
+      STELLAR_ERRORS.TX_TIMEOUT.userMessage
+    );
+    expect(getUserMessage("some raw message")).toBe("some raw message");
+    expect(getUserMessage(new WalletError("gone", "FREIGHTER_NOT_FOUND"))).toBe(
+      STELLAR_ERRORS.FREIGHTER_NOT_FOUND.userMessage
+    );
+  });
+
+  it("isRecoverable reflects the resolved AppError flag", () => {
+    // Every table entry reachable through the current matchers is recoverable.
+    expect(isRecoverable(new WalletError("x", "FREIGHTER_NOT_FOUND"))).toBe(true);
+    expect(isRecoverable(new Error("timeout"))).toBe(true);
+    expect(isRecoverable("anything at all")).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #33

## Problem
`parseError`, `parseErrorMessage`, `getUserMessage` and `isRecoverable` classify raw Errors/strings against the STELLAR_ERRORS, AUTH_ERRORS and GENERAL_ERRORS tables with a >100-char message fallback. They are pure and deterministic but had no coverage of the fallbacks, pattern matching and delegation.

## Change
Extended tests/lib/errors.test.ts pinning the fallbacks, pattern matches, and delegation.

## Verification
- `parseError(null/undefined)` returns the generic Unknown error
- 'Insufficient USDC balance' maps to ACCOUNT_INSUFFICIENT_BALANCE; timeout/cancelled messages map to TX_TIMEOUT / WALLET_USER_REJECTED
- Messages over 100 chars fall back to the generic userMessage
- `getUserMessage` returns userMessage and `isRecoverable` reflects the recoverable flag
- `npm run lint` / `npm run type-check` / `npm run test` pass with no new failures vs. main baseline

## Note
The issue text references a STELLAR_ORDER_ALREADY_PAID entry, but no ORDER_ALREADY_PAID key exists in STELLAR_ERRORS today and the substring matcher cannot bridge the 'OrderAlreadyPaid' / 'order_already_paid' spelling gap, so both spellings land in the generic fallback. The new test pins that actual behaviour; if a dedicated entry is wanted it would be a small follow-up.