### PR TITLE
fix: queue pre-hydration cart adds instead of clobbering stored cart

### DIFF
--- a/context/CartContext.jsx
+++ b/context/CartContext.jsx
@@ -1,62 +1,94 @@
 "use client"
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 
 const CartContext = createContext();
 
 export const useCart = () => useContext(CartContext);
 
+const readStoredItems = () => {
+  try {
+    const raw = localStorage.getItem("cartItems");
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed;
+    }
+  } catch {
+    // fall through to empty
+  }
+  return [];
+};
+
+const readStoredCount = () => {
+  try {
+    const raw = localStorage.getItem("itemCount");
+    if (raw) {
+      const parsed = parseInt(raw, 10);
+      if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+    }
+  } catch {
+    // fall through to zero
+  }
+  return 0;
+};
+
+const readStoredTotal = () => {
+  try {
+    const raw = localStorage.getItem("totalPrice");
+    if (raw) {
+      const parsed = parseFloat(raw);
+      if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+    }
+  } catch {
+    // fall through to zero
+  }
+  return 0;
+};
+
 export const CartProvider = ({ children }) => {
   const [cartItems, setCartItems] = useState([]);
   const [itemCount, setItemCount] = useState(0);
   const [totalPrice, setTotalPrice] = useState(0);
+  const [hydrated, setHydrated] = useState(false);
+  // Adds that land before the hydration effect has run. They are queued here
+  // and merged with the stored snapshot once hydration completes, so a fast
+  // "Add to cart" click after a hard load can no longer clobber the saved cart.
+  const pendingAdds = useRef([]);
 
   useEffect(() => {
-    let storedCartItems = [];
-    let storedItemCount = 0;
-    let storedTotalPrice = 0;
+    const storedCartItems = readStoredItems();
+    const storedItemCount = readStoredCount();
+    const storedTotalPrice = readStoredTotal();
 
-    try {
-      const rawItems = localStorage.getItem("cartItems");
-      if (rawItems) {
-        const parsed = JSON.parse(rawItems);
-        if (Array.isArray(parsed)) {
-          storedCartItems = parsed;
-        }
-      }
-    } catch {
-      storedCartItems = [];
+    const pending = pendingAdds.current;
+    pendingAdds.current = [];
+
+    if (pending.length > 0) {
+      const merged = [...storedCartItems, ...pending];
+      const mergedCount = storedItemCount + pending.length;
+      const mergedTotal =
+        storedTotalPrice + pending.reduce((sum, item) => sum + (item.price || 0), 0);
+
+      setCartItems(merged);
+      setItemCount(mergedCount);
+      setTotalPrice(mergedTotal);
+      localStorage.setItem("cartItems", JSON.stringify(merged));
+      localStorage.setItem("itemCount", mergedCount.toString());
+      localStorage.setItem("totalPrice", mergedTotal.toString());
+    } else {
+      setCartItems(storedCartItems);
+      setItemCount(storedItemCount);
+      setTotalPrice(storedTotalPrice);
     }
 
-    try {
-      const rawCount = localStorage.getItem("itemCount");
-      if (rawCount) {
-        const parsedCount = parseInt(rawCount, 10);
-        if (Number.isFinite(parsedCount) && parsedCount >= 0) {
-          storedItemCount = parsedCount;
-        }
-      }
-    } catch {
-      storedItemCount = 0;
-    }
-
-    try {
-      const rawPrice = localStorage.getItem("totalPrice");
-      if (rawPrice) {
-        const parsedPrice = parseFloat(rawPrice);
-        if (Number.isFinite(parsedPrice) && parsedPrice >= 0) {
-          storedTotalPrice = parsedPrice;
-        }
-      }
-    } catch {
-      storedTotalPrice = 0;
-    }
-
-    setCartItems(storedCartItems);
-    setItemCount(storedItemCount);
-    setTotalPrice(storedTotalPrice);
+    setHydrated(true);
   }, []);
 
   const addToCart = (product) => {
+    if (!hydrated) {
+      pendingAdds.current.push(product);
+      return;
+    }
+
     setCartItems((prevCartItems) => {
       const updatedCartItems = [...prevCartItems, product];
       localStorage.setItem("cartItems", JSON.stringify(updatedCartItems));
@@ -104,6 +136,7 @@ export const CartProvider = ({ children }) => {
     setCartItems([]);
     setItemCount(0);
     setTotalPrice(0);
+    pendingAdds.current = [];
     localStorage.removeItem("cartItems");
     localStorage.removeItem("itemCount");
     localStorage.removeItem("totalPrice");
@@ -115,6 +148,7 @@ export const CartProvider = ({ children }) => {
         cartItems,
         itemCount,
         totalPrice,
+        hydrated,
         addToCart,
         removeFromCart,
         clearCart,

--- a/tests/context/CartContext.hydration.test.jsx
+++ b/tests/context/CartContext.hydration.test.jsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, cleanup, act } from "@testing-library/react";
+import { useEffect } from "react";
+
+import { CartProvider, useCart } from "../../context/CartContext";
+
+const A = { id: "a", name: "Item A", price: 10 };
+const B = { id: "b", name: "Item B", price: 5 };
+
+describe("CartProvider hydration race (#71)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps stored items when an add lands before the hydration effect", () => {
+    localStorage.setItem("cartItems", JSON.stringify([A]));
+    localStorage.setItem("itemCount", "1");
+    localStorage.setItem("totalPrice", "10");
+
+    let cart = null;
+    function Child() {
+      const c = useCart();
+      cart = c;
+      // Child passive effects flush before the provider's hydration effect,
+      // so this add lands while the provider still holds the empty initial
+      // state -- exactly the race from the issue.
+      useEffect(() => {
+        c.addToCart(B);
+      }, []);
+      return null;
+    }
+
+    render(
+      <CartProvider>
+        <Child />
+      </CartProvider>
+    );
+
+    expect(cart.cartItems).toEqual([A, B]);
+    expect(cart.itemCount).toBe(2);
+    expect(cart.totalPrice).toBe(15);
+    expect(JSON.parse(localStorage.getItem("cartItems"))).toEqual([A, B]);
+    expect(localStorage.getItem("itemCount")).toBe("2");
+    expect(localStorage.getItem("totalPrice")).toBe("15");
+  });
+
+  it("queues multiple pre-hydration adds and merges them all", () => {
+    localStorage.setItem("cartItems", JSON.stringify([A]));
+    localStorage.setItem("itemCount", "1");
+    localStorage.setItem("totalPrice", "10");
+
+    const C = { id: "c", name: "Item C", price: 1 };
+    let cart = null;
+    function Child() {
+      const c = useCart();
+      cart = c;
+      useEffect(() => {
+        c.addToCart(B);
+        c.addToCart(C);
+      }, []);
+      return null;
+    }
+
+    render(
+      <CartProvider>
+        <Child />
+      </CartProvider>
+    );
+
+    expect(cart.cartItems).toEqual([A, B, C]);
+    expect(cart.itemCount).toBe(3);
+    expect(cart.totalPrice).toBe(16);
+  });
+
+  it("leaves post-hydration behaviour unchanged", () => {
+    localStorage.setItem("cartItems", JSON.stringify([A]));
+    localStorage.setItem("itemCount", "1");
+    localStorage.setItem("totalPrice", "10");
+
+    let cart = null;
+    function Child() {
+      const c = useCart();
+      cart = c;
+      return null;
+    }
+
+    render(
+      <CartProvider>
+        <Child />
+      </CartProvider>
+    );
+
+    expect(cart.hydrated).toBe(true);
+    act(() => {
+      cart.addToCart(B);
+    });
+    expect(cart.cartItems).toEqual([A, B]);
+    expect(cart.itemCount).toBe(2);
+    expect(cart.totalPrice).toBe(15);
+    expect(JSON.parse(localStorage.getItem("cartItems"))).toEqual([A, B]);
+  });
+});


### PR DESCRIPTION
Closes #71

## Problem
CartProvider hydrates from localStorage in a useEffect after mount while cartItems starts as []. addToCart appended to the in-memory array and wrote it straight back to localStorage, so an add that landed before the hydration effect executed read prevCartItems=[] and overwrote the stored snapshot with only the new product; the hydration effect then read that overwritten value and the previously stored cart was lost.

## Change
Gated writes behind hydration: `addToCart` called while `hydrated` is false now queues the product in a ref instead of touching state/storage. The hydration effect merges any queued adds with the stored snapshot in a single write (state and localStorage), then flips `hydrated`. Post-hydration behaviour is byte-for-byte the existing code path. The extracted localStorage readers (readStoredItems/Count/Total) deduplicate the three try/catch blocks in the effect. `hydrated` is exposed on the context for consumers/tests.

## Verification
- New regression test (tests/context/CartContext.hydration.test.jsx) uses the fact that child passive effects flush before the provider's hydration effect, so it deterministically replays the pre-hydration add ordering: stored items + new item survive in both state and localStorage, and badge count/total match the merged contents
- Multiple pre-hydration adds are all merged
- Post-hydration behaviour unchanged (dedicated test)
- `npm run lint` / `npm run type-check` / `npm run test` pass with no new failures vs. main baseline