### PR TITLE
fix: retry initial getLatestLedger in PaymentEventIndexer startup

### DIFF
--- a/lib/stellar/indexer.ts
+++ b/lib/stellar/indexer.ts
@@ -64,6 +64,7 @@ export class PaymentEventIndexer {
   private timer: ReturnType<typeof setInterval> | null = null;
   private running = false;
   private started = false;
+  private ledgerRetries = 0;
 
   constructor(
     opts: {
@@ -115,14 +116,26 @@ export class PaymentEventIndexer {
         1,
         this.latestLedger - EVENT_START_LEDGER_BACKFILL
       );
+      this.ledgerRetries = 0;
       callbacks.onStatus?.(this.status);
+      this.timer = setInterval(() => void this.poll(callbacks), this.pollMs);
+      void this.poll(callbacks);
     } catch (err) {
+      if (!this.running) return;
+      // Polling cannot begin until a start ledger is known, so retry the
+      // lookup with capped exponential backoff and surface the retrying
+      // state via onStatus instead of hard-failing. A transient startup
+      // RPC outage then recovers without a page reload.
+      this.ledgerRetries += 1;
       this.lastError = String(err instanceof Error ? err.message : err);
-      callbacks.onError?.(new Error(`Could not reach the Stellar RPC: ${this.lastError}`));
+      callbacks.onStatus?.(this.status);
+      const delay =
+        Math.min(this.pollMs, 1000) *
+        2 ** Math.min(this.ledgerRetries - 1, 2);
+      setTimeout(() => {
+        if (this.running) void this.initialize(callbacks);
+      }, delay);
     }
-
-    this.timer = setInterval(() => void this.poll(callbacks), this.pollMs);
-    void this.poll(callbacks);
   }
 
   private async poll(callbacks: IndexerCallbacks): Promise<void> {

--- a/tests/lib/stellar/indexer-init-retry.test.ts
+++ b/tests/lib/stellar/indexer-init-retry.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+
+const fake = vi.hoisted(() => ({
+  ledgerCalls: 0,
+  eventsCalls: 0,
+}));
+
+vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    rpc: {
+      ...actual.rpc,
+      Server: class {
+        async getLatestLedger() {
+          fake.ledgerCalls += 1;
+          if (fake.ledgerCalls === 1) throw new Error("rpc unreachable");
+          return { sequence: 100 };
+        }
+        async getEvents() {
+          fake.eventsCalls += 1;
+          return { events: [], cursor: "cursor-1", latestLedger: 100 };
+        }
+      },
+    },
+  };
+});
+
+import { PaymentEventIndexer } from "../../../lib/stellar/indexer";
+
+describe("PaymentEventIndexer initialize retry (#68)", () => {
+  it("recovers from a transient startup RPC outage and starts polling", async () => {
+    fake.ledgerCalls = 0;
+    fake.eventsCalls = 0;
+    const errors: Error[] = [];
+    const statuses: Array<{
+      latestLedger?: number;
+      lastCursor?: string;
+      lastError?: string;
+    }> = [];
+
+    const indexer = new PaymentEventIndexer({ pollMs: 10 });
+    indexer.start({
+      onEvent: () => {},
+      onStatus: (s) => statuses.push({ ...s }),
+      onError: (e) => errors.push(e),
+    });
+
+    // First getLatestLedger rejects; with a 10ms poll interval the capped
+    // backoff retries land well within this window.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    indexer.stop();
+
+    // The start ledger was eventually resolved and polling began.
+    expect(fake.ledgerCalls).toBeGreaterThanOrEqual(2);
+    expect(fake.eventsCalls).toBeGreaterThanOrEqual(1);
+    const last = statuses[statuses.length - 1];
+    expect(last.latestLedger).toBe(100);
+    expect(last.lastCursor).toBe("cursor-1");
+    // No hard "nothing to poll" error was ever emitted.
+    expect(
+      errors.some((e) => /no cursor or start ledger/i.test(e.message))
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #68

## Problem
`initialize()` only assigned startLedger after a successful `server.getLatestLedger()`. On failure it reported onError but still started the interval; every poll() then hit fetchEvents() with neither cursor nor start ledger and threw 'Indexer has no cursor or start ledger to poll from' forever, because recoverFromRetentionError() is a no-op when startLedger is undefined. StellarOrderWatch showed a permanent error until reload.

## Change
The interval/poll now starts only after a start ledger is known. On a failed getLatestLedger, initialize retries with capped exponential backoff (min(pollMs, 1000ms) x 2^n, capped at 4x) and surfaces the retrying state via onStatus (lastError) instead of a hard onError. A transient startup RPC outage now recovers without a page reload; stop() during a retry is respected.

## Verification
- New unit test (tests/lib/stellar/indexer-init-retry.test.ts) with a fake rpc.Server whose getLatestLedger rejects once then resolves: the indexer retries, resolves the start ledger and starts polling (latestLedger/lastCursor asserted)
- No 'no cursor or start ledger' error is emitted after recovery
- `npm run lint` / `npm run type-check` / `npm run test` pass with no new failures vs. main baseline