### PR TITLE
fix(slider): render images once with stable keys without duplicating DOM (closes #75)

### DIFF
--- a/app/(landingpage)/Slider.jsx
+++ b/app/(landingpage)/Slider.jsx
@@ -12,9 +12,9 @@ const Slider = () => {
   return (
     <section className="py-14 overflow-hidden bg-mova-surface/60">
       <div className="flex gap-6 overflow-x-auto px-6 md:px-10 pb-2">
-        {[...images, ...images].map((src, index) => (
+        {images.map((src) => (
           <Image
-            key={index}
+            key={src}
             src={src}
             alt="Mova Store footwear"
             width={240}

--- a/tests/(landingpage)/landingpage.test.tsx
+++ b/tests/(landingpage)/landingpage.test.tsx
@@ -5,6 +5,7 @@ import FAQ from "../../app/(landingpage)/FAQ";
 import Newsletter from "../../app/(landingpage)/newsletter";
 import ContactUs from "../../app/(landingpage)/ContactUs";
 import * as sendMailModule from "../../lib/sendmail";
+import Slider from "../../app/(landingpage)/Slider";
 
 describe("Landing Page Components", () => {
   describe("FAQ Component", () => {
@@ -86,6 +87,22 @@ describe("Landing Page Components", () => {
       await waitFor(() => {
         expect(screen.getByText("Unable to send message, please try again later")).toBeDefined();
       });
+    });
+  });
+
+  describe("Slider Component", () => {
+    it("renders exactly 5 images with unique stable keys and no duplicated DOM", () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      render(<Slider />);
+
+      const images = screen.getAllByRole("img");
+      expect(images).toHaveLength(5);
+
+      const srcs = images.map((img) => img.getAttribute("src"));
+      expect(new Set(srcs).size).toBe(5);
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
### Description
Addresses issue #75:
- `app/(landingpage)/Slider.jsx` previously rendered `[...images, ...images]` and used array index for keys, leading to duplicate React key warnings and 10 DOM `<img>` elements instead of 5.
- Fixed to render the 5 images once directly using each image's unique URL as the key (`key={src}`).
- Added unit tests in `tests/(landingpage)/landingpage.test.tsx` asserting:
  - Exactly 5 images rendered (no duplicated strip).
  - All 5 image URLs are unique with stable src keys.
  - Zero duplicate-key console warnings or errors.

### Verification
- `npx vitest run tests/(landingpage)/landingpage.test.tsx`: 5/5 tests passing.
- `npx tsc --noEmit --skipLibCheck`: Clean, 0 errors.
- `npm run lint`: Clean, 0 errors.

Closes #75