### PR TITLE
fix(collections): use fill prop with cover style and remove unused imports (closes #26)

### DIFF
--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -1,9 +1,9 @@
-import Image from 'next/image';
-import shoeImage1 from "/public/images/shoe4.png";
-import shoeImage2 from "/public/images/shoe3.png";
+import Image from "next/image";
+import shoeImage1 from "/public/images/shoe1.png";
+import shoeImage2 from "/public/images/shoe2.png";
 import shoeImage3 from "/public/images/shoe3.png";
 import shoeImage4 from "/public/images/shoe4.png";
-import shoeImage5 from "/public/images/shoe5.png";
+
 const shoes = [
   {
     id: 1,
@@ -15,19 +15,19 @@ const shoes = [
     id: 2,
     name: "Basketball Shoes",
     price: "$129.99",
-    imageUrl: shoeImage1,
+    imageUrl: shoeImage2,
   },
   {
     id: 3,
     name: "Casual Sneakers",
     price: "$79.99",
-    imageUrl: shoeImage1,
+    imageUrl: shoeImage3,
   },
   {
     id: 4,
     name: "Formal Shoes",
     price: "$149.99",
-    imageUrl: shoeImage1,
+    imageUrl: shoeImage4,
   },
 ];
 
@@ -42,8 +42,8 @@ export default function ShoesCollection() {
               <Image
                 src={shoe.imageUrl}
                 alt={shoe.name}
-                layout="fill"
-                objectFit="cover"
+                fill
+                style={{ objectFit: "cover" }}
                 className="rounded-t-lg"
               />
             </div>

--- a/tests/components/collections.test.tsx
+++ b/tests/components/collections.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/image", () => ({
+  default: ({ fill, style, ...props }: any) => (
+    <img data-fill={fill ? "true" : undefined} style={style} {...props} />
+  ),
+}));
+
+import ShoesCollection from "../../app/collections/page";
+
+describe("ShoesCollection Component", () => {
+  it("renders the collection title and 4 shoe products", () => {
+    render(<ShoesCollection />);
+
+    expect(screen.getByRole("heading", { level: 1, name: /shoes collection/i })).toBeDefined();
+
+    expect(screen.getByText("Running Shoes")).toBeDefined();
+    expect(screen.getByText("$99.99")).toBeDefined();
+
+    expect(screen.getByText("Basketball Shoes")).toBeDefined();
+    expect(screen.getByText("$129.99")).toBeDefined();
+
+    expect(screen.getByText("Casual Sneakers")).toBeDefined();
+    expect(screen.getByText("$79.99")).toBeDefined();
+
+    expect(screen.getByText("Formal Shoes")).toBeDefined();
+    expect(screen.getByText("$149.99")).toBeDefined();
+
+    const images = screen.getAllByRole("img");
+    expect(images).toHaveLength(4);
+  });
+
+  it("passes fill and cover objectFit style to images without legacy props", () => {
+    const { container } = render(<ShoesCollection />);
+    const images = container.querySelectorAll("img");
+    expect(images.length).toBe(4);
+
+    images.forEach((img) => {
+      expect(img.getAttribute("layout")).toBeNull();
+      expect(img.getAttribute("objectfit")).toBeNull();
+      expect(img.getAttribute("data-fill")).toBe("true");
+      expect(img.getAttribute("style")).toContain("object-fit: cover");
+    });
+  });
+});


### PR DESCRIPTION
### Description
Addresses issue #26:
- Replaced deprecated Next.js image props `layout="fill"` and `objectFit="cover"` in `app/collections/page.tsx` with standard `fill` and `style={{ objectFit: 'cover' }}` to eliminate legacy prop console errors in Next.js 13/14.
- Removed unused `shoeImage5` import and resolved path typos so that all 4 shoes have distinct product images (`shoeImage1` through `shoeImage4`).
- Added comprehensive unit tests in `tests/components/collections.test.tsx` verifying all product titles, prices, image count, and cover crop styling.

### Verification
- `npx vitest run tests/components/collections.test.tsx`: 2/2 tests passing.
- `npx tsc --noEmit --skipLibCheck`: Clean, 0 errors.
- `npm run lint`: Clean, 0 errors.
- `npx prettier --check app/collections/page.tsx tests/components/collections.test.tsx`: Clean, 0 errors.
- Verified twice locally.

Closes #26