### PR TITLE
fix(orders): resolve 64-hex order ids directly without re-hashing in dispatch and refund (closes #67)

### DIFF
--- a/lib/stellar/orders.ts
+++ b/lib/stellar/orders.ts
@@ -25,7 +25,24 @@ import {
   tokenForContract,
 } from "./config";
 import { connectWallet, signWithFreighter } from "./freighter";
-import { hashOrderId, bytesToHex } from "./scval";
+import { hashOrderId, hexToBytes, bytesToHex } from "./scval";
+
+const HASHED_ORDER_ID_RE = /^[0-9a-fA-F]{64}$/;
+
+/**
+ * Resolves an order ID into a 32-byte hash (Uint8Array).
+ * If the input is already a 64-character hex string (e.g. from an indexer event),
+ * it converts it directly to bytes without re-hashing.
+ * If it is a raw pre-image (e.g. "SS-2024-0001"), it hashes it via SHA-256.
+ */
+export async function resolveOrderIdHash(orderId: string): Promise<Uint8Array> {
+  const trimmed = orderId.trim();
+  const clean = trimmed.startsWith("0x") ? trimmed.slice(2) : trimmed;
+  if (HASHED_ORDER_ID_RE.test(clean)) {
+    return hexToBytes(clean);
+  }
+  return hashOrderId(orderId);
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -85,12 +102,14 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
   const server = new rpc.Server(RPC_URL);
   const contract = new Contract(CHECKOUT_CONTRACT_ID);
 
-  const orderIdHashBytes = await hashOrderId(orderId);
+  const orderIdHashBytes = await resolveOrderIdHash(orderId);
   const orderIdHash = bytesToHex(orderIdHashBytes);
 
-  const account = await server.getAccount(
-    Keypair.random().publicKey() // dummy source for simulation
-  ).catch(() => null);
+  const account = await server
+    .getAccount(
+      Keypair.random().publicKey() // dummy source for simulation
+    )
+    .catch(() => null);
 
   if (!account) {
     // Fallback: just simulate without account
@@ -104,12 +123,7 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
         networkPassphrase: NETWORK_PASSPHRASE,
       }
     )
-      .addOperation(
-        contract.call(
-          "order",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHash, "hex"))
-        )
-      )
+      .addOperation(contract.call("order", xdr.ScVal.scvBytes(Buffer.from(orderIdHash, "hex"))))
       .setTimeout(30)
       .build();
 
@@ -147,25 +161,20 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
 
       for (const entry of orderMap) {
         const key =
-          entry.key().switch() === xdr.ScValType.scvSymbol()
-            ? entry.key().sym().toString()
-            : "";
+          entry.key().switch() === xdr.ScValType.scvSymbol() ? entry.key().sym().toString() : "";
         const val = entry.val();
 
         switch (key) {
           case "buyer":
             if (val.switch() === xdr.ScValType.scvAddress()) {
-              order.buyer = StrKey.encodeEd25519PublicKey(
-                val.address().accountId().ed25519()
-              );
+              order.buyer = StrKey.encodeEd25519PublicKey(val.address().accountId().ed25519());
             }
             break;
           case "amount":
             if (val.switch() === xdr.ScValType.scvI128()) {
               const parts = val.i128();
               order.amount =
-                (BigInt(parts.hi().toString()) << BigInt(64)) |
-                BigInt(parts.lo().toString());
+                (BigInt(parts.hi().toString()) << BigInt(64)) | BigInt(parts.lo().toString());
             }
             break;
           case "token":
@@ -187,9 +196,7 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
       }
 
       // Format display amount
-      const tokenConfig = order.token
-        ? tokenForContract(order.token.toUpperCase())
-        : undefined;
+      const tokenConfig = order.token ? tokenForContract(order.token.toUpperCase()) : undefined;
       const decimals = tokenConfig?.decimals ?? 7;
       order.tokenSymbol = tokenConfig?.symbol ?? "TOKEN";
       order.amountDisplay = order.amount
@@ -211,15 +218,13 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
  * Dispatches an order, releasing the escrowed funds to the merchant.
  * Requires the connected wallet to be the merchant.
  */
-export async function dispatchOrder(
-  orderId: string
-): Promise<OrderActionResult> {
+export async function dispatchOrder(orderId: string): Promise<OrderActionResult> {
   try {
     const publicKey = await connectWallet();
     const server = new rpc.Server(RPC_URL);
     const contract = new Contract(CHECKOUT_CONTRACT_ID);
 
-    const orderIdHashBytes = await hashOrderId(orderId);
+    const orderIdHashBytes = await resolveOrderIdHash(orderId);
 
     const account = await server.getAccount(publicKey);
 
@@ -227,12 +232,7 @@ export async function dispatchOrder(
       fee: "100000",
       networkPassphrase: NETWORK_PASSPHRASE,
     })
-      .addOperation(
-        contract.call(
-          "dispatch",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHashBytes))
-        )
-      )
+      .addOperation(contract.call("dispatch", xdr.ScVal.scvBytes(Buffer.from(orderIdHashBytes))))
       .setTimeout(TX_TIMEOUT_SECONDS)
       .build();
 
@@ -258,10 +258,7 @@ export async function dispatchOrder(
 
     // Sign with Freighter
     const signedXdr = await signWithFreighter(preparedTx.toXDR(), publicKey);
-    const signedTx = TransactionBuilder.fromXDR(
-      signedXdr,
-      NETWORK_PASSPHRASE
-    );
+    const signedTx = TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
 
     // Submit
     const sendResult = await server.sendTransaction(signedTx);
@@ -300,7 +297,7 @@ export async function refundOrder(orderId: string): Promise<OrderActionResult> {
     const server = new rpc.Server(RPC_URL);
     const contract = new Contract(CHECKOUT_CONTRACT_ID);
 
-    const orderIdHashBytes = await hashOrderId(orderId);
+    const orderIdHashBytes = await resolveOrderIdHash(orderId);
 
     const account = await server.getAccount(publicKey);
 
@@ -308,12 +305,7 @@ export async function refundOrder(orderId: string): Promise<OrderActionResult> {
       fee: "100000",
       networkPassphrase: NETWORK_PASSPHRASE,
     })
-      .addOperation(
-        contract.call(
-          "refund",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHashBytes))
-        )
-      )
+      .addOperation(contract.call("refund", xdr.ScVal.scvBytes(Buffer.from(orderIdHashBytes))))
       .setTimeout(TX_TIMEOUT_SECONDS)
       .build();
 
@@ -337,10 +329,7 @@ export async function refundOrder(orderId: string): Promise<OrderActionResult> {
     // Prepare and sign
     const preparedTx = rpc.assembleTransaction(tx, simResult).build();
     const signedXdr = await signWithFreighter(preparedTx.toXDR(), publicKey);
-    const signedTx = TransactionBuilder.fromXDR(
-      signedXdr,
-      NETWORK_PASSPHRASE
-    );
+    const signedTx = TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
 
     // Submit
     const sendResult = await server.sendTransaction(signedTx);
@@ -369,10 +358,7 @@ export async function refundOrder(orderId: string): Promise<OrderActionResult> {
 // Transaction Polling
 // ---------------------------------------------------------------------------
 
-async function pollTransaction(
-  server: rpc.Server,
-  txHash: string
-): Promise<OrderActionResult> {
+async function pollTransaction(server: rpc.Server, txHash: string): Promise<OrderActionResult> {
   const startTime = Date.now();
   const timeoutMs = TX_TIMEOUT_SECONDS * 1000;
 

--- a/tests/app/admin/orders-dispatch.test.tsx
+++ b/tests/app/admin/orders-dispatch.test.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+
+const HEX64_ORDER_ID = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+const hoisted = vi.hoisted(() => {
+  let startCallback: ((event: any) => void) | null = null;
+
+  class MockPaymentEventIndexer {
+    start(handlers: {
+      onEvent: (event: any) => void;
+      onStatus: (status: any) => void;
+      onError: (err: any) => void;
+    }) {
+      startCallback = handlers.onEvent;
+      handlers.onStatus({ running: true, eventsSeen: 1 });
+    }
+    stop() {}
+  }
+
+  const mockDispatchOrder = vi.fn().mockResolvedValue({ success: true });
+  const mockRefundOrder = vi.fn().mockResolvedValue({ success: true });
+
+  return {
+    MockPaymentEventIndexer,
+    mockDispatchOrder,
+    mockRefundOrder,
+    getStartCallback: () => startCallback,
+  };
+});
+
+vi.mock("../../../lib/stellar/indexer", () => ({
+  PaymentEventIndexer: hoisted.MockPaymentEventIndexer,
+}));
+
+vi.mock("../../../lib/stellar/orders", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../lib/stellar/orders")>();
+  return {
+    ...actual,
+    dispatchOrder: hoisted.mockDispatchOrder,
+    refundOrder: hoisted.mockRefundOrder,
+  };
+});
+
+vi.mock("../../../components/AdminGuard", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../../components/StellarWalletButton", () => ({
+  default: () => <button>Wallet</button>,
+}));
+
+import OrdersManagement from "../../../app/admin/orders/page";
+
+describe("Admin Orders Page - Event ID dispatch and refund", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes the event-derived hex order id into dispatchOrder unmodified when Ship is clicked", async () => {
+    render(<OrdersManagement />);
+
+    const emitEvent = hoisted.getStartCallback();
+    expect(emitEvent).toBeTruthy();
+
+    await act(async () => {
+      emitEvent!({
+        symbol: "pay",
+        fields: {
+          order_id: HEX64_ORDER_ID,
+          buyer: "GBUYER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+          amount: "50000000",
+          token: "USDC",
+        },
+        ledger: 123456,
+        txHash: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      });
+    });
+
+    const shipBtn = await screen.findByRole("button", { name: /ship/i });
+    expect(shipBtn).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(shipBtn);
+    });
+
+    await waitFor(() => {
+      expect(hoisted.mockDispatchOrder).toHaveBeenCalledTimes(1);
+    });
+
+    expect(hoisted.mockDispatchOrder).toHaveBeenCalledWith(HEX64_ORDER_ID);
+  });
+
+  it("passes the event-derived hex order id into refundOrder unmodified when Refund is clicked", async () => {
+    render(<OrdersManagement />);
+
+    const emitEvent = hoisted.getStartCallback();
+    expect(emitEvent).toBeTruthy();
+
+    await act(async () => {
+      emitEvent!({
+        symbol: "pay",
+        fields: {
+          order_id: HEX64_ORDER_ID,
+          buyer: "GBUYER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+          amount: "50000000",
+          token: "USDC",
+        },
+        ledger: 123456,
+        txHash: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      });
+    });
+
+    const refundBtn = await screen.findByRole("button", { name: /refund/i });
+    expect(refundBtn).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(refundBtn);
+    });
+
+    await waitFor(() => {
+      expect(hoisted.mockRefundOrder).toHaveBeenCalledTimes(1);
+    });
+
+    expect(hoisted.mockRefundOrder).toHaveBeenCalledWith(HEX64_ORDER_ID);
+  });
+});

--- a/tests/lib/stellar/orders.test.ts
+++ b/tests/lib/stellar/orders.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { hashOrderId, bytesToHex, hexToBytes } from "../../../lib/stellar/scval";
+import { resolveOrderIdHash } from "../../../lib/stellar/orders";
+
+const HEX64 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+describe("resolveOrderIdHash", () => {
+  it("passes an already-hashed 64-hex order id through unchanged", async () => {
+    const bytes = await resolveOrderIdHash(HEX64);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBe(32);
+    expect(bytesToHex(bytes)).toBe(HEX64);
+    expect(bytes).toEqual(hexToBytes(HEX64));
+  });
+
+  it("handles uppercase and mixed-case 64-hex order ids without re-hashing", async () => {
+    const mixedHex = HEX64.toUpperCase();
+    const bytes = await resolveOrderIdHash(mixedHex);
+    expect(bytesToHex(bytes)).toBe(HEX64.toLowerCase());
+  });
+
+  it("handles 64-hex order ids with 0x prefix", async () => {
+    const bytes = await resolveOrderIdHash(`0x${HEX64}`);
+    expect(bytesToHex(bytes)).toBe(HEX64);
+  });
+
+  it("hashes a short raw pre-image via SHA-256 matching hashOrderId", async () => {
+    const rawId = "SS-2024-0001";
+    const resolved = await resolveOrderIdHash(rawId);
+    const expected = await hashOrderId(rawId);
+    expect(resolved).toEqual(expected);
+    expect(resolved.length).toBe(32);
+  });
+
+  it("hashes an arbitrary pre-image string via SHA-256", async () => {
+    const rawId = "order-xyz-987654321";
+    const resolved = await resolveOrderIdHash(rawId);
+    const expected = await hashOrderId(rawId);
+    expect(resolved).toEqual(expected);
+  });
+
+  it("trims surrounding whitespace on 64-hex string", async () => {
+    const bytes = await resolveOrderIdHash(`  ${HEX64}  \n`);
+    expect(bytesToHex(bytes)).toBe(HEX64);
+  });
+});


### PR DESCRIPTION
### Summary of Changes

This PR resolves issue #67 where `dispatchOrder` and `refundOrder` (and `readOrder`) in `lib/stellar/orders.ts` unconditionally ran `await hashOrderId(orderId)`. When called from `app/admin/orders/page.tsx`, the order ID is already the 32-byte event-derived SHA-256 hash formatted as a 64-character hex string. Re-hashing the 64-hex ASCII string produced a completely different SHA-256 digest, resulting in contract calls failing with `OrderNotFound`.

### Key Changes
1. **Helper `resolveOrderIdHash`** in `lib/stellar/orders.ts`:
   - Pure, robust resolver that checks if `orderId` matches a 64-character hex string (`^[0-9a-fA-F]{64}$`, with optional `0x` prefix and trimmed whitespace).
   - If already a 64-hex hash, it converts it directly via `hexToBytes` without re-hashing.
   - If a short raw pre-image (e.g. `"SS-2024-0001"`), it computes SHA-256 via `hashOrderId`.
2. **Usage in Order Management Operations**:
   - Used in `dispatchOrder`, `refundOrder`, and `readOrder` in `lib/stellar/orders.ts`.
   - Leaves `app/admin/orders/page.tsx` passing the indexer event-derived hex ID unmodified.
3. **Comprehensive Unit Tests**:
   - `tests/lib/stellar/orders.test.ts`: Verifies 64-hex bypass (lower/upper/mixed case, 0x prefix, whitespace) and SHA-256 computation for raw pre-images.
   - `tests/app/admin/orders-dispatch.test.tsx`: Asserts the admin page passes the event-derived hex ID directly to `dispatchOrder` and `refundOrder` without modification.

### Verification (2x Verified)
- `npx vitest run tests/lib/stellar/orders.test.ts tests/app/admin/orders-dispatch.test.tsx` (8/8 tests pass, 0 warnings)
- `npm run type-check` (0 errors)
- `npm run lint` (0 errors)
- `npx prettier --check` (100% formatted)

Closes #67
