### PR TITLE
feat(shop): add loading skeleton and empty state to products grid (closes #105)

### DIFF
--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -8,27 +8,42 @@ import Cart from "../../components/Cart";
 import Modal from "../../components/Modal";
 import Toast from "../../components/Toast";
 import { listProducts } from "../../lib/products";
+import { ProductGridSkeleton } from "../../components/Skeleton";
 
 export default function Products() {
-  const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } =
-    useCart();
+  const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } = useCart();
   const [showModal, setShowModal] = useState(false);
   const [toast, setToast] = useState({ show: false, message: "" });
   const [isCheckingOut, setIsCheckingOut] = useState(false);
   const [products, setProducts] = useState([]);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    let isMounted = true;
     const fetchProducts = async () => {
       try {
+        setLoading(true);
+        setError(null);
         const data = await listProducts();
-        setProducts(data);
+        if (isMounted) {
+          setProducts(data || []);
+        }
       } catch (err) {
-        setError(err.message);
+        if (isMounted) {
+          setError(err.message);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
       }
     };
 
     fetchProducts();
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   const showToast = (message) => {
@@ -58,34 +73,45 @@ export default function Products() {
             Welcome to Mova Store
           </span>
 
-          {error && <p className="text-red-500 text-center">{error}</p>}
+          {error && <p className="text-red-500 text-center py-4">{error}</p>}
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
-            {products.map((prod) => (
-              <div key={prod.id} className="p-4 border rounded-lg shadow">
-                <Link href={`/shop/${prod.id}`}>
-                  <Image
-                    src={prod.img} // Ensure this URL is correct
-                    alt={prod.name}
-                    width={200}
-                    height={200}
-                    className="mb-2"
-                  />
-                  <h1 className="text-xl font-bold">{prod.name}</h1>
-                  <h2 className="text-lg">${prod.price}</h2>
-                </Link>
-                <button
-                  className="border-purple-800 rounded-full px-2 py-2 mt-2 border-2 hover:border-purple-600"
-                  onClick={() => {
-                    addToCart(prod);
-                    showToast("Item added to cart");
-                  }}
-                >
-                  <FaShoppingCart />
-                </button>
-              </div>
-            ))}
-          </div>
+          {loading ? (
+            <div data-testid="products-loading" className="py-4">
+              <ProductGridSkeleton />
+            </div>
+          ) : !error && products.length === 0 ? (
+            <div data-testid="products-empty" className="text-center text-gray-500 py-16">
+              <p className="text-xl font-medium">No products yet</p>
+              <p className="text-sm text-gray-400 mt-2">Check back soon for new arrivals!</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+              {products.map((prod) => (
+                <div key={prod.id} className="p-4 border rounded-lg shadow">
+                  <Link href={`/shop/${prod.id}`}>
+                    <Image
+                      src={prod.img} // Ensure this URL is correct
+                      alt={prod.name}
+                      width={200}
+                      height={200}
+                      className="mb-2"
+                    />
+                    <h1 className="text-xl font-bold">{prod.name}</h1>
+                    <h2 className="text-lg">${prod.price}</h2>
+                  </Link>
+                  <button
+                    className="border-purple-800 rounded-full px-2 py-2 mt-2 border-2 hover:border-purple-600"
+                    onClick={() => {
+                      addToCart(prod);
+                      showToast("Item added to cart");
+                    }}
+                  >
+                    <FaShoppingCart />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
         </section>
       </div>
 
@@ -101,10 +127,7 @@ export default function Products() {
         ) : (
           <div>
             {cartItems.map((item) => (
-              <div
-                key={item.id}
-                className="flex justify-between items-center mb-2"
-              >
+              <div key={item.id} className="flex justify-between items-center mb-2">
                 <div className="w-16 h-16 flex-shrink-0">
                   <Image
                     src={item.img} // Ensure this URL is correct
@@ -129,11 +152,7 @@ export default function Products() {
         <div className="flex justify-between items-center mt-4 mx-5 sm:mx-10">
           <div>
             {cartItems.length > 0 && <strong>Total:</strong>}
-            {totalPrice ? (
-              <span className="ml-2 font-bold ">${totalPrice.toFixed(2)}</span>
-            ) : (
-              ""
-            )}
+            {totalPrice ? <span className="ml-2 font-bold ">${totalPrice.toFixed(2)}</span> : ""}
           </div>
           {cartItems.length > 0 && (
             <button

--- a/tests/app/shop/page.test.tsx
+++ b/tests/app/shop/page.test.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const { mockListProducts, mockUseCart } = vi.hoisted(() => ({
+  mockListProducts: vi.fn(),
+  mockUseCart: vi.fn(),
+}));
+
+vi.mock("../../../lib/products", () => ({
+  listProducts: () => mockListProducts(),
+}));
+
+vi.mock("../../../context/CartContext", () => ({
+  useCart: () => mockUseCart(),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt, ...props }: any) => (
+    <img src={typeof src === "string" ? src : "/placeholder.png"} alt={alt} {...props} />
+  ),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("../../../components/Cart", () => ({
+  default: ({ itemCount }: { itemCount: number }) => (
+    <div data-testid="cart-badge">Cart ({itemCount})</div>
+  ),
+}));
+
+vi.mock("../../../components/Modal", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../../components/Toast", () => ({
+  default: () => null,
+}));
+
+import Products from "../../../app/shop/page";
+
+describe("Shop Products Grid - Loading, Empty, and Error States", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCart.mockReturnValue({
+      itemCount: 0,
+      cartItems: [],
+      addToCart: vi.fn(),
+      removeFromCart: vi.fn(),
+      totalPrice: 0,
+    });
+  });
+
+  it("renders ProductGridSkeleton while listProducts is pending", () => {
+    // Return an unresolved promise to keep pending state
+    mockListProducts.mockReturnValue(new Promise(() => {}));
+
+    render(<Products />);
+
+    expect(screen.getByTestId("products-loading")).toBeInTheDocument();
+    expect(screen.queryByTestId("products-empty")).not.toBeInTheDocument();
+  });
+
+  it("renders 'No products yet' empty state when listProducts resolves with empty array", async () => {
+    mockListProducts.mockResolvedValue([]);
+
+    render(<Products />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("products-loading")).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("products-empty")).toBeInTheDocument();
+    expect(screen.getByText("No products yet")).toBeInTheDocument();
+  });
+
+  it("renders error message when listProducts promise is rejected", async () => {
+    mockListProducts.mockRejectedValue(new Error("Failed to load products from database"));
+
+    render(<Products />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("products-loading")).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Failed to load products from database")).toBeInTheDocument();
+    expect(screen.queryByTestId("products-empty")).not.toBeInTheDocument();
+  });
+
+  it("renders product cards grid when listProducts resolves with products", async () => {
+    const mockProducts = [
+      { id: "p1", name: "Alpha Running Shoe", price: 120, img: "/img1.jpg" },
+      { id: "p2", name: "Beta Trail Runner", price: 140, img: "/img2.jpg" },
+    ];
+    mockListProducts.mockResolvedValue(mockProducts);
+
+    render(<Products />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("products-loading")).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Alpha Running Shoe")).toBeInTheDocument();
+    expect(screen.getByText("$120")).toBeInTheDocument();
+    expect(screen.getByText("Beta Trail Runner")).toBeInTheDocument();
+    expect(screen.getByText("$140")).toBeInTheDocument();
+    expect(screen.queryByTestId("products-empty")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Summary of Changes

Resolves issue #105 by adding loading and empty states to the shop products grid in `app/shop/page.jsx`.

### Key Changes
1. **Loading State with Skeleton**:
   - Added `loading` state (defaults to `true`) during initial `listProducts` fetch.
   - Imported and rendered `ProductGridSkeleton` from `components/Skeleton.tsx` while `loading` is true.
2. **Explicit Empty State**:
   - When `loading` resolves and `products.length === 0` without error, displays an explicit "No products yet" empty message.
3. **Preserved Error State**:
   - Maintains the existing error alert if `listProducts` rejects.
4. **Comprehensive Unit Tests**:
   - Added `tests/app/shop/page.test.tsx` testing:
     1. `ProductGridSkeleton` is rendered while pending.
     2. "No products yet" empty message renders on empty array.
     3. Error alert renders on rejection.
     4. Product cards grid renders when products are loaded.

### Verification (2x Verified)
- `npx vitest run tests/app/shop/page.test.tsx` (4/4 tests pass)
- `npm run type-check` (0 errors)
- `npm run lint` (0 errors)
- `npx prettier --check` (100% formatted)

Closes #105
