### PR TITLE
test(cart): add unit tests for floating cart badge button (closes #99)

### DIFF
--- a/tests/components/Cart.test.jsx
+++ b/tests/components/Cart.test.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Cart from "../../components/Cart";
+
+describe("Cart floating button component", () => {
+  it("does not render the badge when itemCount is 0", () => {
+    const handleClick = vi.fn();
+    render(<Cart itemCount={0} onClick={handleClick} />);
+
+    expect(screen.queryByText("0")).toBeNull();
+    expect(screen.queryByText("3")).toBeNull();
+  });
+
+  it("renders the badge displaying '3' when itemCount is 3", () => {
+    const handleClick = vi.fn();
+    render(<Cart itemCount={3} onClick={handleClick} />);
+
+    const badge = screen.getByText("3");
+    expect(badge).toBeInTheDocument();
+    expect(badge.tagName).toBe("SPAN");
+  });
+
+  it("renders the badge for other positive counts", () => {
+    const handleClick = vi.fn();
+    render(<Cart itemCount={10} onClick={handleClick} />);
+
+    expect(screen.getByText("10")).toBeInTheDocument();
+  });
+
+  it("calls onClick exactly once when the button is clicked", () => {
+    const handleClick = vi.fn();
+    render(<Cart itemCount={3} onClick={handleClick} />);
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Summary of Changes

Resolves issue #99 by adding unit tests for the floating Cart badge button in `components/Cart.jsx`.

### Key Changes
- Created `tests/components/Cart.test.jsx` asserting:
  1. The badge is not rendered when `itemCount = 0`.
  2. The badge displays '3' when `itemCount = 3`.
  3. The badge correctly displays other positive numbers (e.g. 10).
  4. Clicking the floating button invokes `onClick` exactly once.

### Verification (2x Verified)
- `npx vitest run tests/components/Cart.test.jsx` (4/4 tests pass)
- `npm run type-check` (0 errors)
- `npm run lint` (0 errors)
- `npx prettier --check` (100% formatted)

Closes #99
