### PR TITLE
fix(orders): preserve buyer and token on dispatch/refund merge in orders reducer (closes #73)

### DIFF
--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -9,6 +9,7 @@ import {
   OrderEvent,
   eventToOrder,
   OrderStatus,
+  mergeOrderEvents,
 } from "../../../lib/stellar/orders";
 import { NETWORK, CHECKOUT_CONTRACT_ID } from "../../../lib/stellar/config";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";
@@ -25,10 +26,7 @@ import Link from "next/link";
 
 // Status badge component
 const StatusBadge = ({ status }: { status: OrderStatus }) => {
-  const statusConfig: Record<
-    OrderStatus,
-    { bg: string; text: string; icon: React.ReactNode }
-  > = {
+  const statusConfig: Record<OrderStatus, { bg: string; text: string; icon: React.ReactNode }> = {
     Pending: {
       bg: "bg-yellow-100",
       text: "text-yellow-800",
@@ -103,14 +101,10 @@ const OrderRow = ({
   return (
     <tr className="border-b hover:bg-gray-50">
       <td className="py-4 px-4">
-        <div className="font-mono text-xs text-gray-600">
-          {truncateAddress(order.orderId)}
-        </div>
+        <div className="font-mono text-xs text-gray-600">{truncateAddress(order.orderId)}</div>
       </td>
       <td className="py-4 px-4">
-        <div className="font-mono text-xs text-gray-600">
-          {truncateAddress(order.buyer)}
-        </div>
+        <div className="font-mono text-xs text-gray-600">{truncateAddress(order.buyer)}</div>
       </td>
       <td className="py-4 px-4">
         <div className="font-semibold">
@@ -120,9 +114,7 @@ const OrderRow = ({
       <td className="py-4 px-4">
         <StatusBadge status={order.status} />
       </td>
-      <td className="py-4 px-4 text-sm text-gray-500">
-        {formatDate(order.timestamp)}
-      </td>
+      <td className="py-4 px-4 text-sm text-gray-500">{formatDate(order.timestamp)}</td>
       <td className="py-4 px-4 text-sm">
         <a
           href={`https://stellar.expert/explorer/${NETWORK}/tx/${order.txHash}`}
@@ -155,17 +147,11 @@ const OrderRow = ({
               disabled={isProcessing}
               className="px-3 py-1 text-sm bg-purple-600 text-white rounded hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
             >
-              {isProcessing ? (
-                <AiOutlineLoading3Quarters className="animate-spin" />
-              ) : (
-                <MdCancel />
-              )}
+              {isProcessing ? <AiOutlineLoading3Quarters className="animate-spin" /> : <MdCancel />}
               Refund
             </button>
           )}
-          {!canDispatch && !canRefund && (
-            <span className="text-gray-400 text-sm">-</span>
-          )}
+          {!canDispatch && !canRefund && <span className="text-gray-400 text-sm">-</span>}
         </div>
       </td>
     </tr>
@@ -176,9 +162,7 @@ const OrderRow = ({
 const OrdersManagementContent = () => {
   const [orders, setOrders] = useState<Map<string, OrderEvent>>(new Map());
   const [isLoading, setIsLoading] = useState(true);
-  const [processingOrderId, setProcessingOrderId] = useState<string | null>(
-    null
-  );
+  const [processingOrderId, setProcessingOrderId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [indexerStatus, setIndexerStatus] = useState<{
@@ -199,10 +183,7 @@ const OrdersManagementContent = () => {
             // Update existing order or add new one
             const existing = newMap.get(order.orderId);
             if (existing) {
-              // Update status if the new event is more recent
-              if (event.ledger > (existing.ledger || 0)) {
-                newMap.set(order.orderId, { ...existing, ...order });
-              }
+              newMap.set(order.orderId, mergeOrderEvents(existing, order));
             } else {
               newMap.set(order.orderId, order);
             }
@@ -244,9 +225,7 @@ const OrdersManagementContent = () => {
       const result = await dispatchOrder(orderId);
 
       if (result.success) {
-        setSuccessMessage(
-          `Order ${truncateAddress(orderId)} dispatched successfully!`
-        );
+        setSuccessMessage(`Order ${truncateAddress(orderId)} dispatched successfully!`);
         // Update local state
         setOrders((prev) => {
           const newMap = new Map(prev);
@@ -276,9 +255,7 @@ const OrdersManagementContent = () => {
       const result = await refundOrder(orderId);
 
       if (result.success) {
-        setSuccessMessage(
-          `Order ${truncateAddress(orderId)} refunded successfully!`
-        );
+        setSuccessMessage(`Order ${truncateAddress(orderId)} refunded successfully!`);
         // Update local state
         setOrders((prev) => {
           const newMap = new Map(prev);
@@ -299,9 +276,7 @@ const OrdersManagementContent = () => {
   }, []);
 
   // Sort orders by timestamp (newest first)
-  const sortedOrders = Array.from(orders.values()).sort(
-    (a, b) => b.timestamp - a.timestamp
-  );
+  const sortedOrders = Array.from(orders.values()).sort((a, b) => b.timestamp - a.timestamp);
 
   // Stats
   const stats = {
@@ -337,9 +312,7 @@ const OrdersManagementContent = () => {
       <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6 flex items-center gap-3">
         <SiStellar className="text-purple-600 text-xl" />
         <div>
-          <span className="font-medium text-purple-800">
-            Stellar {NETWORK.toUpperCase()}
-          </span>
+          <span className="font-medium text-purple-800">Stellar {NETWORK.toUpperCase()}</span>
           <span className="text-purple-600 ml-2 text-sm">
             Contract: {truncateAddress(CHECKOUT_CONTRACT_ID)}
           </span>
@@ -377,9 +350,7 @@ const OrdersManagementContent = () => {
           <div className="text-yellow-600 text-sm flex items-center gap-1">
             <MdPending /> Pending
           </div>
-          <div className="text-2xl font-bold text-yellow-800">
-            {stats.pending}
-          </div>
+          <div className="text-2xl font-bold text-yellow-800">{stats.pending}</div>
         </div>
         <div className="bg-blue-50 rounded-lg shadow p-4">
           <div className="text-blue-600 text-sm flex items-center gap-1">
@@ -391,17 +362,13 @@ const OrdersManagementContent = () => {
           <div className="text-green-600 text-sm flex items-center gap-1">
             <MdLocalShipping /> Shipped
           </div>
-          <div className="text-2xl font-bold text-green-800">
-            {stats.shipped}
-          </div>
+          <div className="text-2xl font-bold text-green-800">{stats.shipped}</div>
         </div>
         <div className="bg-red-50 rounded-lg shadow p-4">
           <div className="text-purple-600 text-sm flex items-center gap-1">
             <MdCancel /> Refunded
           </div>
-          <div className="text-2xl font-bold text-purple-800">
-            {stats.refunded}
-          </div>
+          <div className="text-2xl font-bold text-purple-800">{stats.refunded}</div>
         </div>
       </div>
 
@@ -481,29 +448,28 @@ const OrdersManagementContent = () => {
           <li className="flex items-start gap-2">
             <MdPayment className="text-blue-500 mt-0.5" />
             <span>
-              <strong>Paid (Escrow):</strong> Customer has paid and funds are
-              held in the smart contract escrow
+              <strong>Paid (Escrow):</strong> Customer has paid and funds are held in the smart
+              contract escrow
             </span>
           </li>
           <li className="flex items-start gap-2">
             <MdLocalShipping className="text-green-500 mt-0.5" />
             <span>
-              <strong>Ship:</strong> Release the escrowed funds to your merchant
-              wallet when you ship the order
+              <strong>Ship:</strong> Release the escrowed funds to your merchant wallet when you
+              ship the order
             </span>
           </li>
           <li className="flex items-start gap-2">
             <MdCancel className="text-purple-500 mt-0.5" />
             <span>
-              <strong>Refund:</strong> Return the escrowed funds to the
-              customer's wallet (e.g., if item is out of stock)
+              <strong>Refund:</strong> Return the escrowed funds to the customer's wallet (e.g., if
+              item is out of stock)
             </span>
           </li>
         </ul>
         <p className="mt-4 text-xs text-gray-500">
-          Note: Only the merchant wallet that deployed the contract can
-          dispatch/refund orders. Make sure you're connected with the correct
-          Freighter wallet.
+          Note: Only the merchant wallet that deployed the contract can dispatch/refund orders. Make
+          sure you're connected with the correct Freighter wallet.
         </p>
       </div>
     </div>

--- a/lib/stellar/orders.ts
+++ b/lib/stellar/orders.ts
@@ -88,9 +88,11 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
   const orderIdHashBytes = await hashOrderId(orderId);
   const orderIdHash = bytesToHex(orderIdHashBytes);
 
-  const account = await server.getAccount(
-    Keypair.random().publicKey() // dummy source for simulation
-  ).catch(() => null);
+  const account = await server
+    .getAccount(
+      Keypair.random().publicKey() // dummy source for simulation
+    )
+    .catch(() => null);
 
   if (!account) {
     // Fallback: just simulate without account
@@ -104,12 +106,7 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
         networkPassphrase: NETWORK_PASSPHRASE,
       }
     )
-      .addOperation(
-        contract.call(
-          "order",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHash, "hex"))
-        )
-      )
+      .addOperation(contract.call("order", xdr.ScVal.scvBytes(Buffer.from(orderIdHash, "hex"))))
       .setTimeout(30)
       .build();
 
@@ -147,25 +144,20 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
 
       for (const entry of orderMap) {
         const key =
-          entry.key().switch() === xdr.ScValType.scvSymbol()
-            ? entry.key().sym().toString()
-            : "";
+          entry.key().switch() === xdr.ScValType.scvSymbol() ? entry.key().sym().toString() : "";
         const val = entry.val();
 
         switch (key) {
           case "buyer":
             if (val.switch() === xdr.ScValType.scvAddress()) {
-              order.buyer = StrKey.encodeEd25519PublicKey(
-                val.address().accountId().ed25519()
-              );
+              order.buyer = StrKey.encodeEd25519PublicKey(val.address().accountId().ed25519());
             }
             break;
           case "amount":
             if (val.switch() === xdr.ScValType.scvI128()) {
               const parts = val.i128();
               order.amount =
-                (BigInt(parts.hi().toString()) << BigInt(64)) |
-                BigInt(parts.lo().toString());
+                (BigInt(parts.hi().toString()) << BigInt(64)) | BigInt(parts.lo().toString());
             }
             break;
           case "token":
@@ -187,9 +179,7 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
       }
 
       // Format display amount
-      const tokenConfig = order.token
-        ? tokenForContract(order.token.toUpperCase())
-        : undefined;
+      const tokenConfig = order.token ? tokenForContract(order.token.toUpperCase()) : undefined;
       const decimals = tokenConfig?.decimals ?? 7;
       order.tokenSymbol = tokenConfig?.symbol ?? "TOKEN";
       order.amountDisplay = order.amount
@@ -211,9 +201,7 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
  * Dispatches an order, releasing the escrowed funds to the merchant.
  * Requires the connected wallet to be the merchant.
  */
-export async function dispatchOrder(
-  orderId: string
-): Promise<OrderActionResult> {
+export async function dispatchOrder(orderId: string): Promise<OrderActionResult> {
   try {
     const publicKey = await connectWallet();
     const server = new rpc.Server(RPC_URL);
@@ -227,12 +215,7 @@ export async function dispatchOrder(
       fee: "100000",
       networkPassphrase: NETWORK_PASSPHRASE,
     })
-      .addOperation(
-        contract.call(
-          "dispatch",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHashBytes))
-        )
-      )
+      .addOperation(contract.call("dispatch", xdr.ScVal.scvBytes(Buffer.from(orderIdHashBytes))))
       .setTimeout(TX_TIMEOUT_SECONDS)
       .build();
 
@@ -258,10 +241,7 @@ export async function dispatchOrder(
 
     // Sign with Freighter
     const signedXdr = await signWithFreighter(preparedTx.toXDR(), publicKey);
-    const signedTx = TransactionBuilder.fromXDR(
-      signedXdr,
-      NETWORK_PASSPHRASE
-    );
+    const signedTx = TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
 
     // Submit
     const sendResult = await server.sendTransaction(signedTx);
@@ -308,12 +288,7 @@ export async function refundOrder(orderId: string): Promise<OrderActionResult> {
       fee: "100000",
       networkPassphrase: NETWORK_PASSPHRASE,
     })
-      .addOperation(
-        contract.call(
-          "refund",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHashBytes))
-        )
-      )
+      .addOperation(contract.call("refund", xdr.ScVal.scvBytes(Buffer.from(orderIdHashBytes))))
       .setTimeout(TX_TIMEOUT_SECONDS)
       .build();
 
@@ -337,10 +312,7 @@ export async function refundOrder(orderId: string): Promise<OrderActionResult> {
     // Prepare and sign
     const preparedTx = rpc.assembleTransaction(tx, simResult).build();
     const signedXdr = await signWithFreighter(preparedTx.toXDR(), publicKey);
-    const signedTx = TransactionBuilder.fromXDR(
-      signedXdr,
-      NETWORK_PASSPHRASE
-    );
+    const signedTx = TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
 
     // Submit
     const sendResult = await server.sendTransaction(signedTx);
@@ -369,10 +341,7 @@ export async function refundOrder(orderId: string): Promise<OrderActionResult> {
 // Transaction Polling
 // ---------------------------------------------------------------------------
 
-async function pollTransaction(
-  server: rpc.Server,
-  txHash: string
-): Promise<OrderActionResult> {
+async function pollTransaction(server: rpc.Server, txHash: string): Promise<OrderActionResult> {
   const startTime = Date.now();
   const timeoutMs = TX_TIMEOUT_SECONDS * 1000;
 
@@ -498,5 +467,31 @@ export function eventToOrder(
     timestamp,
     ledger,
     txHash,
+  };
+}
+
+/**
+ * Merges an incoming OrderEvent into an existing OrderEvent.
+ * When a newer lifecycle event (e.g. dispatch or refund) arrives for an existing order,
+ * it updates lifecycle fields (status, ledger, txHash, timestamp) while preserving
+ * the original payment and buyer fields (buyer, token, tokenSymbol, amount, amountRaw).
+ */
+export function mergeOrderEvents(existing: OrderEvent, incoming: OrderEvent): OrderEvent {
+  // Only update if the incoming event is from a newer or equal ledger
+  if (incoming.ledger < existing.ledger) {
+    return existing;
+  }
+
+  return {
+    ...existing,
+    status: incoming.status !== "Unknown" ? incoming.status : existing.status,
+    ledger: incoming.ledger,
+    txHash: incoming.txHash || existing.txHash,
+    timestamp: incoming.timestamp || existing.timestamp,
+    buyer: existing.buyer || incoming.buyer,
+    token: existing.token || incoming.token,
+    tokenSymbol: existing.tokenSymbol || incoming.tokenSymbol,
+    amount: existing.amount || incoming.amount,
+    amountRaw: existing.amountRaw || incoming.amountRaw,
   };
 }

--- a/tests/lib/stellar/orders-reducer.test.ts
+++ b/tests/lib/stellar/orders-reducer.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { mergeOrderEvents, OrderEvent } from "../../../lib/stellar/orders";
+
+describe("mergeOrderEvents reducer helper", () => {
+  const existingPaidOrder: OrderEvent = {
+    orderId: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    buyer: "GBUYER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    amount: "50.00",
+    amountRaw: 50000000n,
+    token: "CAS3J7GYLGXMF6TDJBBYYSE3VGSBRUCM5ZLGNELHM44H6P7TVDA22W27",
+    tokenSymbol: "USDC",
+    status: "Paid",
+    timestamp: 1700000000000,
+    ledger: 100,
+    txHash: "0xinitialpaidtx123",
+  };
+
+  it("keeps buyer, token, amount, and tokenSymbol when merging a dispatch event and updates status to Shipped", () => {
+    const dispatchEventOrder: OrderEvent = {
+      orderId: existingPaidOrder.orderId,
+      buyer: "GMERCHANT9876543210ZYXWVUTSRQPONMLKJIHGFEDCBA",
+      amount: "0",
+      amountRaw: 0n,
+      token: "",
+      tokenSymbol: "TOKEN",
+      status: "Shipped",
+      timestamp: 1700000060000,
+      ledger: 105,
+      txHash: "0xdispatchtx456",
+    };
+
+    const merged = mergeOrderEvents(existingPaidOrder, dispatchEventOrder);
+
+    expect(merged.status).toBe("Shipped");
+    expect(merged.ledger).toBe(105);
+    expect(merged.txHash).toBe("0xdispatchtx456");
+    expect(merged.timestamp).toBe(1700000060000);
+
+    expect(merged.buyer).toBe("GBUYER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+    expect(merged.token).toBe("CAS3J7GYLGXMF6TDJBBYYSE3VGSBRUCM5ZLGNELHM44H6P7TVDA22W27");
+    expect(merged.tokenSymbol).toBe("USDC");
+    expect(merged.amount).toBe("50.00");
+    expect(merged.amountRaw).toBe(50000000n);
+  });
+
+  it("keeps buyer and token details when merging a refund event and updates status to Refunded", () => {
+    const refundEventOrder: OrderEvent = {
+      orderId: existingPaidOrder.orderId,
+      buyer: "GMERCHANT9876543210ZYXWVUTSRQPONMLKJIHGFEDCBA",
+      amount: "0",
+      amountRaw: 0n,
+      token: "",
+      tokenSymbol: "TOKEN",
+      status: "Refunded",
+      timestamp: 1700000080000,
+      ledger: 110,
+      txHash: "0xrefundtx789",
+    };
+
+    const merged = mergeOrderEvents(existingPaidOrder, refundEventOrder);
+
+    expect(merged.status).toBe("Refunded");
+    expect(merged.ledger).toBe(110);
+    expect(merged.txHash).toBe("0xrefundtx789");
+    expect(merged.buyer).toBe(existingPaidOrder.buyer);
+    expect(merged.tokenSymbol).toBe("USDC");
+    expect(merged.amount).toBe("50.00");
+  });
+
+  it("ignores older events with lower ledger numbers", () => {
+    const staleEvent: OrderEvent = {
+      ...existingPaidOrder,
+      ledger: 95,
+      status: "Pending",
+      txHash: "0xoldtx000",
+    };
+
+    const merged = mergeOrderEvents(existingPaidOrder, staleEvent);
+
+    expect(merged).toEqual(existingPaidOrder);
+    expect(merged.status).toBe("Paid");
+    expect(merged.ledger).toBe(100);
+  });
+});


### PR DESCRIPTION
### Summary of Changes

Resolves issue #73 where the inline orders reducer in `app/admin/orders/page.tsx` merged incoming events via `{ ...existing, ...order }`. In Soroban checkout contracts, dispatch and refund event topics contain `[order_id, merchant]`, so `topic2` is the merchant address. Overwriting `existing` with the incoming event replaced the stored buyer address with the merchant and could clobber the token symbol with a fallback.

### Key Changes
1. **Extracted `mergeOrderEvents` Helper**:
   - Added pure, exported function `mergeOrderEvents` in `lib/stellar/orders.ts`.
   - Carries forward lifecycle fields (`status`, `ledger`, `txHash`, `timestamp`) when an event from an equal or newer ledger arrives.
   - Strictly preserves initial order details (`buyer`, `token`, `tokenSymbol`, `amount`, `amountRaw`) so they are never clobbered by dispatch or refund topics.
   - Ignores stale out-of-order events (`incoming.ledger < existing.ledger`).
2. **Updated Admin Orders Page**:
   - Refactored `app/admin/orders/page.tsx` to use `mergeOrderEvents(existing, order)`.
3. **Comprehensive Unit Tests**:
   - Created `tests/lib/stellar/orders-reducer.test.ts` verifying:
     1. Merging a dispatch event over an existing Paid row keeps buyer, token, amount, and tokenSymbol and updates status to Shipped.
     2. Merging a refund event over an existing Paid row keeps buyer and token details and updates status to Refunded.
     3. Stale events with lower ledger numbers are ignored.

### Verification (2x Verified)
- `npx vitest run tests/lib/stellar/orders-reducer.test.ts` (3/3 tests pass)
- `npm run type-check` (0 errors)
- `npm run lint` (0 errors)
- `npx prettier --check` (100% formatted)

Closes #73
