### PR TITLE
test(env): add unit tests for loadEmailJSConfig, loadSupabaseConfig, loadAdminConfig and loadStellarConfig (closes #94)

### DIFF
--- a/tests/lib/env.test.ts
+++ b/tests/lib/env.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { isAdminEmail, isDevelopment, isProduction, validateEnv } from "../../lib/env";
+import {
+  isAdminEmail,
+  isDevelopment,
+  isProduction,
+  validateEnv,
+  loadEmailJSConfig,
+  loadSupabaseConfig,
+  loadAdminConfig,
+  loadStellarConfig,
+  ValidationError,
+} from "../../lib/env";
 
 describe("isAdminEmail", () => {
   beforeEach(() => {
@@ -98,5 +108,179 @@ describe("validateEnv", () => {
     expect(config.emailjs.templateId).toBe("template_xyz");
     expect(config.emailjs.publicKey).toBe("pubkey_789");
     expect(config.admin.adminEmails).toContain("admin@store.org");
+  });
+});
+
+describe("loadEmailJSConfig", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("loads valid EmailJS configuration without errors", () => {
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_SERVICE_ID", "service_test123");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_TEMPLATE_ID", "template_test456");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_PUBLIC_KEY", "pubkey_test789");
+    vi.stubEnv("NEXT_PUBLIC_DEFAULT_RECIPIENT_EMAIL", "orders@store.com");
+
+    const errors: ValidationError[] = [];
+    const config = loadEmailJSConfig(errors);
+
+    expect(errors).toHaveLength(0);
+    expect(config.serviceId).toBe("service_test123");
+    expect(config.templateId).toBe("template_test456");
+    expect(config.publicKey).toBe("pubkey_test789");
+    expect(config.defaultRecipientEmail).toBe("orders@store.com");
+  });
+
+  it("records validation errors when required EmailJS fields are missing", () => {
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_SERVICE_ID", "");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_TEMPLATE_ID", "");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_PUBLIC_KEY", "");
+    vi.stubEnv("NEXT_PUBLIC_DEFAULT_RECIPIENT_EMAIL", "");
+
+    const errors: ValidationError[] = [];
+    const config = loadEmailJSConfig(errors);
+
+    expect(errors).toHaveLength(3);
+    expect(errors).toEqual([
+      {
+        field: "NEXT_PUBLIC_EMAILJS_SERVICE_ID",
+        message: "NEXT_PUBLIC_EMAILJS_SERVICE_ID is required for email notifications",
+      },
+      {
+        field: "NEXT_PUBLIC_EMAILJS_TEMPLATE_ID",
+        message: "NEXT_PUBLIC_EMAILJS_TEMPLATE_ID is required for email notifications",
+      },
+      {
+        field: "NEXT_PUBLIC_EMAILJS_PUBLIC_KEY",
+        message: "NEXT_PUBLIC_EMAILJS_PUBLIC_KEY is required for email notifications",
+      },
+    ]);
+    expect(config.defaultRecipientEmail).toBe("");
+  });
+
+  it("treats whitespace-only values as missing and trims non-empty values", () => {
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_SERVICE_ID", "   ");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_TEMPLATE_ID", "  template_trimmed  ");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_PUBLIC_KEY", "\t\n  ");
+
+    const errors: ValidationError[] = [];
+    const config = loadEmailJSConfig(errors);
+
+    expect(errors).toHaveLength(2);
+    expect(errors[0].field).toBe("NEXT_PUBLIC_EMAILJS_SERVICE_ID");
+    expect(errors[1].field).toBe("NEXT_PUBLIC_EMAILJS_PUBLIC_KEY");
+    expect(config.templateId).toBe("template_trimmed");
+  });
+});
+
+describe("loadSupabaseConfig", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("loads valid Supabase configuration without errors", () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://xyz.supabase.co");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "anon-key-xyz");
+
+    const errors: ValidationError[] = [];
+    const config = loadSupabaseConfig(errors);
+
+    expect(errors).toHaveLength(0);
+    expect(config.url).toBe("https://xyz.supabase.co");
+    expect(config.anonKey).toBe("anon-key-xyz");
+  });
+
+  it("records validation errors when required Supabase fields are missing", () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "");
+
+    const errors: ValidationError[] = [];
+    loadSupabaseConfig(errors);
+
+    expect(errors).toHaveLength(2);
+    expect(errors).toEqual([
+      {
+        field: "NEXT_PUBLIC_SUPABASE_URL",
+        message: "NEXT_PUBLIC_SUPABASE_URL is required for Supabase",
+      },
+      {
+        field: "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+        message: "NEXT_PUBLIC_SUPABASE_ANON_KEY is required for Supabase",
+      },
+    ]);
+  });
+
+  it("treats whitespace-only values as missing", () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "   ");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "  \n\t ");
+
+    const errors: ValidationError[] = [];
+    loadSupabaseConfig(errors);
+
+    expect(errors).toHaveLength(2);
+  });
+});
+
+describe("loadAdminConfig", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("trims and lowercases email entries and removes empty items", () => {
+    vi.stubEnv(
+      "NEXT_PUBLIC_ADMIN_EMAILS",
+      "  Admin1@Store.com , ADMIN2@STORE.COM, , superadmin@mova.org "
+    );
+
+    const config = loadAdminConfig();
+    expect(config.adminEmails).toEqual([
+      "admin1@store.com",
+      "admin2@store.com",
+      "superadmin@mova.org",
+    ]);
+  });
+
+  it("returns empty array for empty, whitespace, or comma-only strings", () => {
+    vi.stubEnv("NEXT_PUBLIC_ADMIN_EMAILS", "");
+    expect(loadAdminConfig().adminEmails).toEqual([]);
+
+    vi.stubEnv("NEXT_PUBLIC_ADMIN_EMAILS", "   ");
+    expect(loadAdminConfig().adminEmails).toEqual([]);
+
+    vi.stubEnv("NEXT_PUBLIC_ADMIN_EMAILS", ",,,  , , ");
+    expect(loadAdminConfig().adminEmails).toEqual([]);
+  });
+});
+
+describe("loadStellarConfig", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("loads valid testnet defaults and requires checkoutContractId", () => {
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_NETWORK", "testnet");
+    vi.stubEnv("NEXT_PUBLIC_CHECKOUT_CONTRACT_ID", "CA12345");
+
+    const errors: ValidationError[] = [];
+    const config = loadStellarConfig(errors);
+
+    expect(errors).toHaveLength(0);
+    expect(config.network).toBe("testnet");
+    expect(config.checkoutContractId).toBe("CA12345");
+    expect(config.rpcUrl).toBe("https://soroban-testnet.stellar.org");
+  });
+
+  it("records an error when checkoutContractId is missing or whitespace", () => {
+    vi.stubEnv("NEXT_PUBLIC_CHECKOUT_CONTRACT_ID", "   ");
+
+    const errors: ValidationError[] = [];
+    loadStellarConfig(errors);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toEqual({
+      field: "NEXT_PUBLIC_CHECKOUT_CONTRACT_ID",
+      message: "NEXT_PUBLIC_CHECKOUT_CONTRACT_ID is required for Stellar payments",
+    });
   });
 });


### PR DESCRIPTION
### Summary of Changes

Resolves issue #94 by adding comprehensive unit tests for the environment configuration loaders in `lib/env.ts` (`loadEmailJSConfig`, `loadSupabaseConfig`, `loadAdminConfig`, and `loadStellarConfig`).

### Key Changes
- Extended `tests/lib/env.test.ts` with tests verifying:
  1. `loadEmailJSConfig`:
     - Loads valid serviceId, templateId, publicKey, and defaultRecipientEmail.
     - Pushes descriptive validation errors when required variables are unset.
     - Treats whitespace-only values as missing and trims non-empty values.
  2. `loadSupabaseConfig`:
     - Loads valid url and anonKey.
     - Pushes validation errors when required variables are missing or whitespace-only.
  3. `loadAdminConfig`:
     - Trims and lowercases comma-separated email addresses, ignoring empty entries.
     - Returns `[]` for empty string, whitespace, or comma-only values.
  4. `loadStellarConfig`:
     - Loads network and rpcUrl defaults and requires `NEXT_PUBLIC_CHECKOUT_CONTRACT_ID`.
     - Validates missing or whitespace checkout contract id.

### Verification (2x Verified)
- `npx vitest run tests/lib/env.test.ts` (21/21 tests pass)
- `npm run type-check` (0 errors)
- `npm run lint` (0 errors)
- `npx prettier --check` (100% formatted)

Closes #94
