### PR TITLE
fix(toast): cancel exit timer on show change or unmount to prevent stale onClose (closes #23)

### DIFF
--- a/components/Notification.tsx
+++ b/components/Notification.tsx
@@ -79,8 +79,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   );
 
   const success = useCallback(
-    (message: string, title?: string) =>
-      addNotification({ type: "success", message, title }),
+    (message: string, title?: string) => addNotification({ type: "success", message, title }),
     [addNotification]
   );
 
@@ -97,8 +96,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   );
 
   const info = useCallback(
-    (message: string, title?: string) =>
-      addNotification({ type: "info", message, title }),
+    (message: string, title?: string) => addNotification({ type: "info", message, title }),
     [addNotification]
   );
 
@@ -115,10 +113,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
       }}
     >
       {children}
-      <NotificationContainer
-        notifications={notifications}
-        onClose={removeNotification}
-      />
+      <NotificationContainer notifications={notifications} onClose={removeNotification} />
     </NotificationContext.Provider>
   );
 }
@@ -272,17 +267,23 @@ export function Toast({ message, show, onClose, type = "info", time = 3000 }: To
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
+    let timer: NodeJS.Timeout | null = null;
+    let exitTimer: NodeJS.Timeout | null = null;
+
     if (show) {
       setVisible(true);
-      const timer = setTimeout(() => {
+      timer = setTimeout(() => {
         setVisible(false);
-        const exitTimer = setTimeout(onClose, 300);
-        return () => clearTimeout(exitTimer);
+        exitTimer = setTimeout(onClose, 300);
       }, time);
-      return () => clearTimeout(timer);
     } else {
       setVisible(false);
     }
+
+    return () => {
+      if (timer) clearTimeout(timer);
+      if (exitTimer) clearTimeout(exitTimer);
+    };
   }, [show, onClose, time]);
 
   if (!show && !visible) return null;
@@ -303,11 +304,7 @@ export function Toast({ message, show, onClose, type = "info", time = 3000 }: To
     >
       <Icon className={`w-5 h-5 ${config.iconColor}`} />
       <span className="text-gray-800">{message}</span>
-      <button
-        onClick={onClose}
-        className="ml-2 p-1 rounded hover:bg-black/5"
-        aria-label="Close"
-      >
+      <button onClick={onClose} className="ml-2 p-1 rounded hover:bg-black/5" aria-label="Close">
         <MdClose className="w-4 h-4 text-gray-500" />
       </button>
     </div>

--- a/components/Toast.jsx
+++ b/components/Toast.jsx
@@ -1,24 +1,30 @@
 import { useEffect, useState } from "react";
 
-const Toast = ({ message, show, onClose , time=3000}) => {
+const Toast = ({ message, show, onClose, time = 3000 }) => {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
+    let timer = null;
+    let exitTimer = null;
+
     if (show) {
       setVisible(true);
-    
-      const timer = setTimeout(() => {
+
+      timer = setTimeout(() => {
         setVisible(false);
-        const exitTimer = setTimeout(() => {
+        exitTimer = setTimeout(() => {
           onClose();
         }, 300);
-        return () => clearTimeout(exitTimer);
       }, time);
-      return () => clearTimeout(timer);
     } else {
       setVisible(false);
     }
-  }, [show, onClose]);
+
+    return () => {
+      if (timer) clearTimeout(timer);
+      if (exitTimer) clearTimeout(exitTimer);
+    };
+  }, [show, onClose, time]);
 
   return (
     <div

--- a/tests/components/Toast.test.tsx
+++ b/tests/components/Toast.test.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import Toast from "../../components/Toast";
+import { Toast as NotificationToast } from "../../components/Notification";
+
+describe("Toast component exit timer cleanup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("Toast.jsx", () => {
+    it("re-showing a new toast within the exit window (300ms) cancels stale onClose callback", () => {
+      const onCloseA = vi.fn();
+      const onCloseB = vi.fn();
+
+      const { rerender } = render(
+        <Toast message="Message A" show={true} onClose={onCloseA} time={1000} />
+      );
+
+      // Fast-forward past time (1000ms), now inside 300ms exit transition
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      // Re-show Toast B with onCloseB at 1100ms (100ms into the 300ms exit window)
+      rerender(<Toast message="Message B" show={true} onClose={onCloseB} time={1000} />);
+
+      // Advance by another 250ms (reaching 1350ms total, which would have fired old exitTimer at 1300ms)
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      // Old onCloseA was cancelled by cleanup so it shouldn't fire
+      expect(onCloseA).not.toHaveBeenCalled();
+      // And fresh onCloseB shouldn't be prematurely fired
+      expect(onCloseB).not.toHaveBeenCalled();
+    });
+
+    it("unmounting mid-exit does not call onClose afterwards", () => {
+      const onClose = vi.fn();
+      const { unmount } = render(
+        <Toast message="Closing Soon" show={true} onClose={onClose} time={1000} />
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+        unmount();
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Notification.tsx Toast", () => {
+    it("re-showing within exit window cancels stale onClose callback", () => {
+      const onCloseA = vi.fn();
+      const onCloseB = vi.fn();
+
+      const { rerender } = render(
+        <NotificationToast message="Notification A" show={true} onClose={onCloseA} time={1000} />
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      rerender(
+        <NotificationToast message="Notification B" show={true} onClose={onCloseB} time={1000} />
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      expect(onCloseA).not.toHaveBeenCalled();
+      expect(onCloseB).not.toHaveBeenCalled();
+    });
+
+    it("unmounting mid-exit does not call onClose afterwards", () => {
+      const onClose = vi.fn();
+      const { unmount } = render(
+        <NotificationToast
+          message="Notification Closing"
+          show={true}
+          onClose={onClose}
+          time={1000}
+        />
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+        unmount();
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
### Summary of Changes

Resolves issue #23 where the 300ms exit timer cleanup in `components/Toast.jsx` and `components/Notification.tsx` was returned from inside the outer `setTimeout` callback where it was never executed. When a new toast was shown within that 300ms window or the component was unmounted mid-exit, the stale `onClose` fired and hid the new toast prematurely.

### Key Changes
1. **Restructured Timer Cleanup**:
   - In `components/Toast.jsx`, tracked `timer` and `exitTimer` in the `useEffect` body.
   - Returned a proper cleanup function that clears both `timer` and `exitTimer` whenever `show`, `onClose`, or `time` changes or on unmount.
   - Applied the exact same corrected cleanup pattern to `components/Notification.tsx` (Toast component).
2. **Comprehensive Unit Tests**:
   - Created `tests/components/Toast.test.tsx` using Vitest fake timers verifying for both components:
     1. Showing toast A, then re-showing toast B within 300ms cancels stale `onClose` for A without prematurely invoking `onClose` for B.
     2. Unmounting mid-exit transition cancels the exit timer and does not fire `onClose`.

### Verification (2x Verified)
- `npx vitest run tests/components/Toast.test.tsx` (4/4 tests pass)
- `npm run type-check` (0 errors)
- `npm run lint` (0 errors)
- `npx prettier --check` (100% formatted)

Closes #23
