### PR TITLE
fix(ci): gate ci-success on security and rust-security checks (closes #55)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
   # Summary job that requires all checks to pass
   ci-success:
     name: CI Success
-    needs: [frontend, contracts, security]
+    needs: [frontend, contracts, security, rust-security]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
@@ -159,6 +159,14 @@ jobs:
           fi
           if [[ "${{ needs.contracts.result }}" != "success" ]]; then
             echo "Contracts job failed"
+            exit 1
+          fi
+          if [[ "${{ needs.security.result }}" != "success" ]]; then
+            echo "Security job failed"
+            exit 1
+          fi
+          if [[ "${{ needs['rust-security'].result }}" != "success" ]]; then
+            echo "Rust-security job failed"
             exit 1
           fi
           echo "All required checks passed!"


### PR DESCRIPTION
### Summary of Changes (Closes #55)

#### Context & Problem
The `ci-success` summary gate job in `.github/workflows/ci.yml` previously only listed `[frontend, contracts, security]` in its `needs` clause, leaving out `rust-security`. Furthermore, the step script only evaluated `needs.frontend.result` and `needs.contracts.result`, while completely omitting failure branches for `security` and `rust-security`. Consequently, the workflow reported "All required checks passed!" even when security audits failed.

#### Implementation Details
1. **Added `rust-security` to `needs` list**:
   - Updated `needs: [frontend, contracts, security, rust-security]` in `.github/workflows/ci.yml:148`.
2. **Added Explicit Failure Branches**:
   - Added checks for `${{ needs.security.result }}` and `${{ needs[rust-security].result }}` (utilizing standard bracket index syntax for hyphenated job identifier safety).
   - If any of the four jobs fails, the gate script logs the specific failing job name and exits with code 1.

#### Verification
- Parsed YAML with `yaml.safe_load` - 100% valid syntax.
- Formatted and verified with `npx prettier --check .github/workflows/ci.yml`.
- Simulated all combinations of job statuses (frontend, contracts, security, rust-security failures as well as all passing) against the bash gate script - all test scenarios exited with expected non-zero/zero codes and log messages.
