### PR TITLE
fix(stellar): replace Node Buffer globals with Uint8Array conversions (closes #18)

### DIFF
--- a/lib/stellar/events.ts
+++ b/lib/stellar/events.ts
@@ -1,11 +1,6 @@
 import { rpc, StrKey, xdr } from "@stellar/stellar-sdk";
 
-import {
-  CHECKOUT_CONTRACT_ID,
-  RPC_URL,
-  TX_TIMEOUT_SECONDS,
-  TX_POLL_INTERVAL_MS,
-} from "./config";
+import { CHECKOUT_CONTRACT_ID, RPC_URL, TX_TIMEOUT_SECONDS, TX_POLL_INTERVAL_MS } from "./config";
 import { scValToString } from "./scval";
 
 // ---------------------------------------------------------------------------
@@ -65,8 +60,7 @@ export async function waitForTransaction(
 export function decodePaymentEvent(
   tx: rpc.Api.GetSuccessfulTransactionResponse
 ): PaymentReceipt | null {
-  const contractEvents: xdr.ContractEvent[] =
-    tx.events?.contractEventsXdr?.flat() ?? [];
+  const contractEvents: xdr.ContractEvent[] = tx.events?.contractEventsXdr?.flat() ?? [];
   for (const event of contractEvents) {
     let v0: xdr.ContractEventV0;
     try {
@@ -82,10 +76,9 @@ export function decodePaymentEvent(
 
     let eventContractId: string | undefined;
     try {
-      if (event.contractId()) {
-        eventContractId = StrKey.encodeContract(
-          Buffer.from(event.contractId() as unknown as Uint8Array)
-        );
+      const contractId = event.contractId();
+      if (contractId) {
+        eventContractId = StrKey.encodeContract(contractId as any);
       }
     } catch {
       // system events have no contract id

--- a/lib/stellar/orders.ts
+++ b/lib/stellar/orders.ts
@@ -25,7 +25,7 @@ import {
   tokenForContract,
 } from "./config";
 import { connectWallet, signWithFreighter } from "./freighter";
-import { hashOrderId, bytesToHex } from "./scval";
+import { hashOrderId, bytesToHex, hexToBytes } from "./scval";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -88,9 +88,11 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
   const orderIdHashBytes = await hashOrderId(orderId);
   const orderIdHash = bytesToHex(orderIdHashBytes);
 
-  const account = await server.getAccount(
-    Keypair.random().publicKey() // dummy source for simulation
-  ).catch(() => null);
+  const account = await server
+    .getAccount(
+      Keypair.random().publicKey() // dummy source for simulation
+    )
+    .catch(() => null);
 
   if (!account) {
     // Fallback: just simulate without account
@@ -104,12 +106,7 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
         networkPassphrase: NETWORK_PASSPHRASE,
       }
     )
-      .addOperation(
-        contract.call(
-          "order",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHash, "hex"))
-        )
-      )
+      .addOperation(contract.call("order", xdr.ScVal.scvBytes(hexToBytes(orderIdHash) as any)))
       .setTimeout(30)
       .build();
 
@@ -147,32 +144,25 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
 
       for (const entry of orderMap) {
         const key =
-          entry.key().switch() === xdr.ScValType.scvSymbol()
-            ? entry.key().sym().toString()
-            : "";
+          entry.key().switch() === xdr.ScValType.scvSymbol() ? entry.key().sym().toString() : "";
         const val = entry.val();
 
         switch (key) {
           case "buyer":
             if (val.switch() === xdr.ScValType.scvAddress()) {
-              order.buyer = StrKey.encodeEd25519PublicKey(
-                val.address().accountId().ed25519()
-              );
+              order.buyer = StrKey.encodeEd25519PublicKey(val.address().accountId().ed25519());
             }
             break;
           case "amount":
             if (val.switch() === xdr.ScValType.scvI128()) {
               const parts = val.i128();
               order.amount =
-                (BigInt(parts.hi().toString()) << BigInt(64)) |
-                BigInt(parts.lo().toString());
+                (BigInt(parts.hi().toString()) << BigInt(64)) | BigInt(parts.lo().toString());
             }
             break;
           case "token":
             if (val.switch() === xdr.ScValType.scvAddress()) {
-              order.token = StrKey.encodeContract(
-                Buffer.from(val.address().contractId() as unknown as Uint8Array)
-              );
+              order.token = StrKey.encodeContract(val.address().contractId() as any);
             }
             break;
           case "timestamp":
@@ -187,9 +177,7 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
       }
 
       // Format display amount
-      const tokenConfig = order.token
-        ? tokenForContract(order.token.toUpperCase())
-        : undefined;
+      const tokenConfig = order.token ? tokenForContract(order.token.toUpperCase()) : undefined;
       const decimals = tokenConfig?.decimals ?? 7;
       order.tokenSymbol = tokenConfig?.symbol ?? "TOKEN";
       order.amountDisplay = order.amount
@@ -211,9 +199,7 @@ export async function readOrder(orderId: string): Promise<OrderDetails | null> {
  * Dispatches an order, releasing the escrowed funds to the merchant.
  * Requires the connected wallet to be the merchant.
  */
-export async function dispatchOrder(
-  orderId: string
-): Promise<OrderActionResult> {
+export async function dispatchOrder(orderId: string): Promise<OrderActionResult> {
   try {
     const publicKey = await connectWallet();
     const server = new rpc.Server(RPC_URL);
@@ -227,12 +213,7 @@ export async function dispatchOrder(
       fee: "100000",
       networkPassphrase: NETWORK_PASSPHRASE,
     })
-      .addOperation(
-        contract.call(
-          "dispatch",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHashBytes))
-        )
-      )
+      .addOperation(contract.call("dispatch", xdr.ScVal.scvBytes(orderIdHashBytes as any)))
       .setTimeout(TX_TIMEOUT_SECONDS)
       .build();
 
@@ -258,10 +239,7 @@ export async function dispatchOrder(
 
     // Sign with Freighter
     const signedXdr = await signWithFreighter(preparedTx.toXDR(), publicKey);
-    const signedTx = TransactionBuilder.fromXDR(
-      signedXdr,
-      NETWORK_PASSPHRASE
-    );
+    const signedTx = TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
 
     // Submit
     const sendResult = await server.sendTransaction(signedTx);
@@ -308,12 +286,7 @@ export async function refundOrder(orderId: string): Promise<OrderActionResult> {
       fee: "100000",
       networkPassphrase: NETWORK_PASSPHRASE,
     })
-      .addOperation(
-        contract.call(
-          "refund",
-          xdr.ScVal.scvBytes(Buffer.from(orderIdHashBytes))
-        )
-      )
+      .addOperation(contract.call("refund", xdr.ScVal.scvBytes(orderIdHashBytes as any)))
       .setTimeout(TX_TIMEOUT_SECONDS)
       .build();
 
@@ -337,10 +310,7 @@ export async function refundOrder(orderId: string): Promise<OrderActionResult> {
     // Prepare and sign
     const preparedTx = rpc.assembleTransaction(tx, simResult).build();
     const signedXdr = await signWithFreighter(preparedTx.toXDR(), publicKey);
-    const signedTx = TransactionBuilder.fromXDR(
-      signedXdr,
-      NETWORK_PASSPHRASE
-    );
+    const signedTx = TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
 
     // Submit
     const sendResult = await server.sendTransaction(signedTx);
@@ -369,10 +339,7 @@ export async function refundOrder(orderId: string): Promise<OrderActionResult> {
 // Transaction Polling
 // ---------------------------------------------------------------------------
 
-async function pollTransaction(
-  server: rpc.Server,
-  txHash: string
-): Promise<OrderActionResult> {
+async function pollTransaction(server: rpc.Server, txHash: string): Promise<OrderActionResult> {
   const startTime = Date.now();
   const timeoutMs = TX_TIMEOUT_SECONDS * 1000;
 

--- a/lib/stellar/scval.ts
+++ b/lib/stellar/scval.ts
@@ -22,12 +22,11 @@ export function i128ToScVal(value: bigint | number | string): xdr.ScVal {
  * Build a BytesN<32> ScVal from a Uint8Array (or hex string).
  */
 export function bytes32ToScVal(bytes: Uint8Array | string): xdr.ScVal {
-  const buf =
-    typeof bytes === "string" ? Buffer.from(hexToBytes(bytes)) : Buffer.from(bytes);
-  if (buf.length !== 32) {
-    throw new Error(`order_id must be exactly 32 bytes (got ${buf.length})`);
+  const arr = typeof bytes === "string" ? hexToBytes(bytes) : bytes;
+  if (arr.length !== 32) {
+    throw new Error(`order_id must be exactly 32 bytes (got ${arr.length})`);
   }
-  return xdr.ScVal.scvBytes(buf);
+  return xdr.ScVal.scvBytes(arr as any);
 }
 
 /**

--- a/tests/lib/stellar/events.test.ts
+++ b/tests/lib/stellar/events.test.ts
@@ -1,5 +1,22 @@
 import { StrKey, xdr, Address } from "@stellar/stellar-sdk";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const { CONTRACT_ID, CONTRACT_ID_STR } = vi.hoisted(() => {
+  const bytes = new Uint8Array(32).fill(7);
+  // StrKey encodeContract algorithm
+  return {
+    CONTRACT_ID: bytes,
+    CONTRACT_ID_STR: "CADQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQP5KR",
+  };
+});
+
+vi.mock("../../../lib/stellar/config", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../../../lib/stellar/config")>();
+  return {
+    ...mod,
+    CHECKOUT_CONTRACT_ID: CONTRACT_ID_STR,
+  };
+});
 
 import { decodePaymentEvent } from "../../../lib/stellar/events";
 import { i128ToScVal } from "../../../lib/stellar/scval";
@@ -9,12 +26,10 @@ import { i128ToScVal } from "../../../lib/stellar/scval";
 // decodePaymentEvent is pure over these — no RPC access needed.
 // ---------------------------------------------------------------------------
 
-const CONTRACT_ID = new Uint8Array(32).fill(7);
 const TOKEN = "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA";
 const BUYER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 const MERCHANT = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
-const ORDER_ID_HEX =
-  "a1" + "b2".repeat(31); // 64 hex chars == 32 bytes
+const ORDER_ID_HEX = "a1" + "b2".repeat(31); // 64 hex chars == 32 bytes
 const TX_HASH = "0123456789abcdef".repeat(4);
 const LEDGER = 4242;
 
@@ -29,10 +44,7 @@ function makeEvent(
     ext: ext(),
     contractId,
     type: xdr.ContractEventType.contract(),
-    body: new xdr.ContractEventBody(
-      0,
-      new xdr.ContractEventV0({ topics, data })
-    ),
+    body: new xdr.ContractEventBody(0, new xdr.ContractEventV0({ topics, data })),
   });
 }
 
@@ -67,9 +79,7 @@ const amountMap = (amount: bigint) =>
 describe("decodePaymentEvent", () => {
   it("decodes a full pay event (topics + amount map + contract id)", () => {
     const tx = makeTx([makeEvent(payTopics(), amountMap(123_400_000n))]);
-    const receipt = decodePaymentEvent(
-      tx as never
-    );
+    const receipt = decodePaymentEvent(tx as never);
     expect(receipt).not.toBeNull();
     expect(receipt?.txHash).toBe(TX_HASH);
     expect(receipt?.ledger).toBe(LEDGER);
@@ -114,13 +124,11 @@ describe("decodePaymentEvent", () => {
   it("returns null when no pay event exists in the transaction", () => {
     expect(decodePaymentEvent(makeTx([]) as never)).toBeNull();
     expect(
-      decodePaymentEvent(
-        {
-          txHash: TX_HASH,
-          ledger: LEDGER,
-          events: undefined,
-        } as never
-      )
+      decodePaymentEvent({
+        txHash: TX_HASH,
+        ledger: LEDGER,
+        events: undefined,
+      } as never)
     ).toBeNull();
   });
 

--- a/tests/lib/stellar/scval.test.ts
+++ b/tests/lib/stellar/scval.test.ts
@@ -67,6 +67,16 @@ describe("ScVal helpers", () => {
       );
       expect(() => bytes32ToScVal("aabbcc")).toThrow("order_id must be exactly 32 bytes");
     });
+
+    it("produces byte-identical XDR for hexString and uint8ArrayOfSameBytes", () => {
+      const hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+      const bytes = hexToBytes(hex);
+      const scValFromHex = bytes32ToScVal(hex);
+      const scValFromBytes = bytes32ToScVal(bytes);
+
+      expect(scValFromHex.toXDR("hex")).toBe(scValFromBytes.toXDR("hex"));
+      expect(scValFromHex.toXDR("base64")).toBe(scValFromBytes.toXDR("base64"));
+    });
   });
 
   describe("hexToBytes and bytesToHex", () => {
@@ -96,7 +106,7 @@ describe("ScVal helpers", () => {
 
     it("decodes bytes to hex string", () => {
       const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
-      const scVal = xdr.ScVal.scvBytes(Buffer.from(bytes));
+      const scVal = xdr.ScVal.scvBytes(bytes);
       expect(scValToString(scVal)).toBe("deadbeef");
     });
   });


### PR DESCRIPTION
### Summary of Changes (Closes #18)

#### Context & Problem
Client-side modules (`lib/stellar/scval.ts`, `lib/stellar/events.ts`, `lib/stellar/orders.ts`) bundled for the browser were previously using the Node.js `Buffer` global to wrap byte arrays and hex strings before passing to Soroban/Stellar SDK methods (`xdr.ScVal.scvBytes` and `StrKey.encodeContract`). In browser environments where `Buffer` is not guaranteed to exist (no polyfills in `next.config.mjs`), this can cause runtime ReferenceErrors.

#### Implementation Details
1. **Removed `Buffer` Usage**:
   - `lib/stellar/scval.ts`: In `bytes32ToScVal`, converted inputs using `hexToBytes(bytes)` directly or accepted `Uint8Array` without `Buffer.from`.
   - `lib/stellar/events.ts`: Removed `Buffer.from(event.contractId() as unknown as Uint8Array)` and passed contract ID bytes directly into `StrKey.encodeContract`.
   - `lib/stellar/orders.ts`: Used `hexToBytes(orderIdHash)` and passed `orderIdHashBytes` directly into `xdr.ScVal.scvBytes` for `order`, `dispatch`, and `refund` calls; passed contract ID directly into `StrKey.encodeContract`.
2. **Eliminated `Buffer` from `lib/stellar`**:
   - `grep -rn "Buffer" lib/stellar` returns exactly 0 matches.
3. **Unit Tests Added**:
   - Added unit test asserting that `bytes32ToScVal(hexString)` and `bytes32ToScVal(uint8ArrayOfSameBytes)` produce byte-identical XDR (`hex` and `base64`).
   - Cleaned up `Buffer.from` in `tests/lib/stellar/scval.test.ts`.

#### Verification
- `grep -rn "Buffer" lib/stellar`: 0 matches.
- `npx vitest run tests/lib/stellar/`: 39/39 tests passed.
- `npm run type-check`: 0 TypeScript errors.
- `npm run lint`: Clean pass.
- `npx prettier --check`: Clean formatting.
