### PR TITLE
fix(errors): match exact AUTH_ERRORS before broad Stellar heuristics (closes #35)

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -104,7 +104,8 @@ export const STELLAR_ERRORS: Record<string, AppError> = {
   INSUFFICIENT_BALANCE: {
     code: "ACCOUNT_INSUFFICIENT_BALANCE",
     message: "Insufficient balance",
-    userMessage: "You don't have enough funds to complete this payment. Please add more to your wallet.",
+    userMessage:
+      "You don't have enough funds to complete this payment. Please add more to your wallet.",
     severity: "error",
     recoverable: true,
     action: "Add funds",
@@ -112,7 +113,8 @@ export const STELLAR_ERRORS: Record<string, AppError> = {
   NO_TRUSTLINE: {
     code: "ACCOUNT_NO_TRUSTLINE",
     message: "No trustline for token",
-    userMessage: "Your wallet needs to trust USDC before receiving payments. We'll set this up for you.",
+    userMessage:
+      "Your wallet needs to trust USDC before receiving payments. We'll set this up for you.",
     severity: "info",
     recoverable: true,
   },
@@ -151,7 +153,8 @@ export const STELLAR_ERRORS: Record<string, AppError> = {
   TX_TIMEOUT: {
     code: "TX_TIMEOUT",
     message: "Transaction timed out",
-    userMessage: "The transaction is taking longer than expected. Please check your wallet for the status.",
+    userMessage:
+      "The transaction is taking longer than expected. Please check your wallet for the status.",
     severity: "warning",
     recoverable: true,
     action: "Check wallet",
@@ -171,7 +174,7 @@ const SUPABASE_AUTH_CODE_MAP: Record<string, string> = {
   validation_failed: "Unable to validate email address: invalid format",
 };
 
-const AUTH_ERRORS: Record<string, AppError> = {
+export const AUTH_ERRORS: Record<string, AppError> = {
   "User already registered": {
     code: "AUTH_EMAIL_EXISTS",
     message: "Email already in use",
@@ -325,6 +328,16 @@ export function parseError(error: unknown): AppError {
 function parseErrorMessage(message: string): AppError {
   const lowerMessage = message.toLowerCase();
 
+  // Check auth errors by message key or code first
+  for (const [key, appError] of Object.entries(AUTH_ERRORS)) {
+    if (
+      lowerMessage.includes(key.toLowerCase()) ||
+      lowerMessage.includes(appError.code.toLowerCase())
+    ) {
+      return appError;
+    }
+  }
+
   // Check Stellar errors by key or code
   for (const [key, appError] of Object.entries(STELLAR_ERRORS)) {
     if (
@@ -345,15 +358,11 @@ function parseErrorMessage(message: string): AppError {
   if (lowerMessage.includes("timeout") || lowerMessage.includes("timed out")) {
     return STELLAR_ERRORS.TX_TIMEOUT;
   }
-  if (lowerMessage.includes("freighter") && (lowerMessage.includes("install") || lowerMessage.includes("not installed"))) {
+  if (
+    lowerMessage.includes("freighter") &&
+    (lowerMessage.includes("install") || lowerMessage.includes("not installed"))
+  ) {
     return STELLAR_ERRORS.FREIGHTER_NOT_FOUND;
-  }
-
-  // Check auth errors by message
-  for (const [key, appError] of Object.entries(AUTH_ERRORS)) {
-    if (lowerMessage.includes(key.toLowerCase()) || lowerMessage.includes(appError.code.toLowerCase())) {
-      return appError;
-    }
   }
 
   // Return generic error with original message

--- a/tests/lib/errors.test.ts
+++ b/tests/lib/errors.test.ts
@@ -78,4 +78,28 @@ describe("Error Handling & Stellar Error Reconciliation Tests", () => {
     );
     expect(isRecoverable(new WalletError("Wrong net", "WRONG_NETWORK"))).toBe(true);
   });
+
+  describe("AUTH_ERRORS vs broad Stellar keyword heuristics precedence", () => {
+    it("matches exact auth message when it contains broad keyword like 'cancelled'", () => {
+      const err = parseError("Email not confirmed: you cancelled the verification request");
+      expect(err.code).toBe("AUTH_EMAIL_NOT_CONFIRMED");
+      expect(err.message).toBe("Email not confirmed");
+      expect(err.userMessage).toBe("Please confirm your email before signing in.");
+      expect(err.code).not.toBe(STELLAR_ERRORS.USER_REJECTED.code);
+    });
+
+    it("matches pure Stellar message 'Transaction cancelled by user' to USER_REJECTED", () => {
+      const err = parseError("Transaction cancelled by user");
+      expect(err.code).toBe(STELLAR_ERRORS.USER_REJECTED.code);
+      expect(err.userMessage).toContain("cancelled the transaction");
+    });
+
+    it("prioritizes auth errors over other common keywords like 'insufficient' or 'timeout'", () => {
+      const authWithBalance = parseError("User already registered with insufficient permissions");
+      expect(authWithBalance.code).toBe("AUTH_EMAIL_EXISTS");
+
+      const authWithTimeout = parseError("Invalid login credentials timed out");
+      expect(authWithTimeout.code).toBe("AUTH_INVALID_CREDENTIALS");
+    });
+  });
 });


### PR DESCRIPTION
### Summary of Changes (Closes #35)

#### Context & Problem
`parseErrorMessage` in `lib/errors.ts` was evaluating broad single-word Stellar heuristics (e.g. `rejected/cancelled`, `insufficient/balance`, `timeout`, `freighter`) before iterating through `AUTH_ERRORS`. When an authentication error message contained any of those common words (such as `"Email not confirmed: you cancelled the verification request"`), it was prematurely misclassified as `STELLAR_ERRORS.USER_REJECTED` instead of matching `AUTH_ERRORS["Email not confirmed"]`.

#### Implementation Details
1. **Reordered Error Matching Precedence**:
   - In `lib/errors.ts`, shifted the `AUTH_ERRORS` match loop before the broad keyword checks.
   - Evaluates exact `AUTH_ERRORS` and `STELLAR_ERRORS` keys and codes prior to falling back to generic token substring patterns (`cancelled`, `insufficient`, `timeout`, etc.).
   - Exported `AUTH_ERRORS` so consumers and tests can reference defined auth error mappings directly.
2. **Comprehensive Precedence Unit Tests**:
   - In `tests/lib/errors.test.ts`, added test suite asserting:
     - `"Email not confirmed: you cancelled the verification request"` returns `AUTH_EMAIL_NOT_CONFIRMED` rather than `USER_REJECTED`.
     - Pure Stellar cancellation `"Transaction cancelled by user"` still correctly maps to `STELLAR_ERRORS.USER_REJECTED`.
     - Auth errors containing other common words (`insufficient`, `timeout`) maintain precedence over Stellar fallback heuristics.

#### Verification
- `npx vitest run tests/lib/errors.test.ts`: 6/6 tests passing.
- `npm run type-check`: 0 TypeScript errors.
- `npm run lint`: Clean pass.
- `npx prettier --check`: Clean formatting.
