### PR TITLE
ci: add concurrency group with cancel-in-progress (closes #54)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, develop]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
### Summary of Changes (Closes #54)

#### Context & Problem
`.github/workflows/ci.yml` triggers on push and pull_request events but previously lacked a top-level concurrency group. When rapid consecutive commits were pushed, redundant workflow runs accumulated on GitHub Actions runners, consuming execution minutes and cluttering CI status checks.

#### Implementation Details
1. **Added Concurrency Block**:
   - Configured top-level `concurrency` in `.github/workflows/ci.yml`:
     ```yaml
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     ```
   - Automatically cancels superseded in-flight jobs for the same branch/ref while keeping the latest run active.
2. **Verification**:
   - Validated YAML syntax with `yaml.safe_load`.
   - Verified formatted output with `npx prettier --check .github/workflows/ci.yml`.
   - TypeScript and Next.js linting checks pass cleanly.
