### PR TITLE
test(errors): add unit tests for error-classification helpers (closes #33)

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -104,7 +104,8 @@ export const STELLAR_ERRORS: Record<string, AppError> = {
   INSUFFICIENT_BALANCE: {
     code: "ACCOUNT_INSUFFICIENT_BALANCE",
     message: "Insufficient balance",
-    userMessage: "You don't have enough funds to complete this payment. Please add more to your wallet.",
+    userMessage:
+      "You don't have enough funds to complete this payment. Please add more to your wallet.",
     severity: "error",
     recoverable: true,
     action: "Add funds",
@@ -112,7 +113,8 @@ export const STELLAR_ERRORS: Record<string, AppError> = {
   NO_TRUSTLINE: {
     code: "ACCOUNT_NO_TRUSTLINE",
     message: "No trustline for token",
-    userMessage: "Your wallet needs to trust USDC before receiving payments. We'll set this up for you.",
+    userMessage:
+      "Your wallet needs to trust USDC before receiving payments. We'll set this up for you.",
     severity: "info",
     recoverable: true,
   },
@@ -151,10 +153,18 @@ export const STELLAR_ERRORS: Record<string, AppError> = {
   TX_TIMEOUT: {
     code: "TX_TIMEOUT",
     message: "Transaction timed out",
-    userMessage: "The transaction is taking longer than expected. Please check your wallet for the status.",
+    userMessage:
+      "The transaction is taking longer than expected. Please check your wallet for the status.",
     severity: "warning",
     recoverable: true,
     action: "Check wallet",
+  },
+  ORDER_ALREADY_PAID: {
+    code: "STELLAR_ORDER_ALREADY_PAID",
+    message: "Order already paid",
+    userMessage: "This order has already been paid for.",
+    severity: "error",
+    recoverable: false,
   },
 };
 
@@ -171,7 +181,7 @@ const SUPABASE_AUTH_CODE_MAP: Record<string, string> = {
   validation_failed: "Unable to validate email address: invalid format",
 };
 
-const AUTH_ERRORS: Record<string, AppError> = {
+export const AUTH_ERRORS: Record<string, AppError> = {
   "User already registered": {
     code: "AUTH_EMAIL_EXISTS",
     message: "Email already in use",
@@ -214,7 +224,7 @@ const AUTH_ERRORS: Record<string, AppError> = {
 // General Error Messages
 // =============================================================================
 
-const GENERAL_ERRORS: Record<string, AppError> = {
+export const GENERAL_ERRORS: Record<string, AppError> = {
   ValidationError: {
     code: "VALIDATION_ERROR",
     message: "Validation error",
@@ -325,17 +335,24 @@ export function parseError(error: unknown): AppError {
 function parseErrorMessage(message: string): AppError {
   const lowerMessage = message.toLowerCase();
 
-  // Check Stellar errors by key or code
+  // Check Stellar errors by key, code, message or normalized key
   for (const [key, appError] of Object.entries(STELLAR_ERRORS)) {
+    const normalizedKey = key.toLowerCase().replace(/_/g, "");
+    const normalizedMsg = lowerMessage.replace(/[\s_]/g, "");
     if (
       lowerMessage.includes(key.toLowerCase()) ||
-      lowerMessage.includes(appError.code.toLowerCase())
+      lowerMessage.includes(appError.code.toLowerCase()) ||
+      lowerMessage.includes(appError.message.toLowerCase()) ||
+      normalizedMsg.includes(normalizedKey)
     ) {
       return appError;
     }
   }
 
   // Check for common error patterns
+  if (lowerMessage.includes("order already paid") || lowerMessage.includes("orderalreadypaid")) {
+    return STELLAR_ERRORS.ORDER_ALREADY_PAID;
+  }
   if (lowerMessage.includes("insufficient") || lowerMessage.includes("balance")) {
     return STELLAR_ERRORS.INSUFFICIENT_BALANCE;
   }
@@ -345,13 +362,19 @@ function parseErrorMessage(message: string): AppError {
   if (lowerMessage.includes("timeout") || lowerMessage.includes("timed out")) {
     return STELLAR_ERRORS.TX_TIMEOUT;
   }
-  if (lowerMessage.includes("freighter") && (lowerMessage.includes("install") || lowerMessage.includes("not installed"))) {
+  if (
+    lowerMessage.includes("freighter") &&
+    (lowerMessage.includes("install") || lowerMessage.includes("not installed"))
+  ) {
     return STELLAR_ERRORS.FREIGHTER_NOT_FOUND;
   }
 
   // Check auth errors by message
   for (const [key, appError] of Object.entries(AUTH_ERRORS)) {
-    if (lowerMessage.includes(key.toLowerCase()) || lowerMessage.includes(appError.code.toLowerCase())) {
+    if (
+      lowerMessage.includes(key.toLowerCase()) ||
+      lowerMessage.includes(appError.code.toLowerCase())
+    ) {
       return appError;
     }
   }

--- a/tests/lib/errors.test.ts
+++ b/tests/lib/errors.test.ts
@@ -3,79 +3,156 @@ import { describe, it, expect } from "vitest";
 import {
   parseError,
   STELLAR_ERRORS,
+  AUTH_ERRORS,
+  GENERAL_ERRORS,
   createError,
   getUserMessage,
   isRecoverable,
 } from "../../lib/errors";
 import { WalletError } from "../../lib/stellar/freighter";
 
-describe("Error Handling & Stellar Error Reconciliation Tests", () => {
-  it("classifies WalletError instances by their .code property", () => {
-    const errFreighterNotFound = new WalletError("Extension missing", "FREIGHTER_NOT_FOUND");
-    const parsedFreighterNotFound = parseError(errFreighterNotFound);
-    expect(parsedFreighterNotFound.code).toBe("WALLET_NOT_INSTALLED");
-    expect(parsedFreighterNotFound.userMessage).toContain("Freighter wallet extension");
-
-    const errWrongNetwork = new WalletError("Wrong net detected", "WRONG_NETWORK");
-    const parsedWrongNetwork = parseError(errWrongNetwork);
-    expect(parsedWrongNetwork.code).toBe("WALLET_WRONG_NETWORK");
-
-    const errTxSend = new WalletError("Tx failed", "TX_SEND_ERROR");
-    const parsedTxSend = parseError(errTxSend);
-    expect(parsedTxSend.code).toBe("TX_FAILED");
-
-    const errSim = new WalletError("Sim failed", "TX_SIMULATION_ERROR");
-    const parsedSim = parseError(errSim);
-    expect(parsedSim.code).toBe("TX_SIMULATION_FAILED");
-
-    const errContract = new WalletError("No contract ID", "CONTRACT_NOT_CONFIGURED");
-    const parsedContract = parseError(errContract);
-    expect(parsedContract.code).toBe("STELLAR_CONTRACT_NOT_CONFIGURED");
-  });
-
-  it("ensures every STELLAR_ERRORS code maps to a defined and emitted code key", () => {
-    const expectedKeys = [
-      "FREIGHTER_NOT_FOUND",
-      "FREIGHTER_REQUEST_DENIED",
-      "FREIGHTER_NETWORK_ERROR",
-      "WRONG_NETWORK",
-      "FREIGHTER_SIGN_ERROR",
-      "USER_REJECTED",
-      "ACCOUNT_NOT_FOUND",
-      "FRIENDBOT_ERROR",
-      "PAYMENT_NOT_READY",
-      "INSUFFICIENT_BALANCE",
-      "NO_TRUSTLINE",
-      "CONTRACT_NOT_CONFIGURED",
-      "INVALID_AMOUNT",
-      "TX_SIMULATION_ERROR",
-      "TX_SEND_ERROR",
-      "TX_TIMEOUT",
-    ];
-
-    for (const key of expectedKeys) {
-      expect(STELLAR_ERRORS[key]).toBeDefined();
-      expect(STELLAR_ERRORS[key].code).toBeTruthy();
-      expect(STELLAR_ERRORS[key].userMessage).toBeTruthy();
-    }
-  });
-
-  it("handles string messages, null/undefined, and custom AppErrors properly", () => {
-    expect(parseError(null).code).toBe("UNKNOWN_ERROR");
-    expect(parseError(undefined).code).toBe("UNKNOWN_ERROR");
-
-    const custom = createError("CUSTOM_CODE", "Internal msg", "Friendly msg", {
-      severity: "warning",
-      recoverable: false,
+describe("Error Classification & Handling Tests (lib/errors.ts)", () => {
+  describe("null and undefined handling", () => {
+    it("returns GENERAL_ERRORS.Unknown for null and undefined", () => {
+      expect(parseError(null)).toEqual(GENERAL_ERRORS.Unknown);
+      expect(parseError(undefined)).toEqual(GENERAL_ERRORS.Unknown);
+      expect(parseError("")).toEqual(GENERAL_ERRORS.Unknown);
     });
-    expect(custom.code).toBe("CUSTOM_CODE");
-    expect(custom.userMessage).toBe("Friendly msg");
-    expect(custom.severity).toBe("warning");
-    expect(custom.recoverable).toBe(false);
+  });
 
-    expect(getUserMessage(new WalletError("Funds low", "INSUFFICIENT_BALANCE"))).toContain(
-      "don't have enough funds"
-    );
-    expect(isRecoverable(new WalletError("Wrong net", "WRONG_NETWORK"))).toBe(true);
+  describe("OrderAlreadyPaid classification", () => {
+    it("resolves Error('OrderAlreadyPaid') and string 'order already paid' to STELLAR_ORDER_ALREADY_PAID", () => {
+      const errorFromInstance = parseError(new Error("OrderAlreadyPaid"));
+      expect(errorFromInstance.code).toBe("STELLAR_ORDER_ALREADY_PAID");
+      expect(errorFromInstance.userMessage).toBe(STELLAR_ERRORS.ORDER_ALREADY_PAID.userMessage);
+      expect(errorFromInstance.recoverable).toBe(false);
+
+      const errorFromString = parseError("order already paid");
+      expect(errorFromString.code).toBe("STELLAR_ORDER_ALREADY_PAID");
+      expect(errorFromString.userMessage).toBe(STELLAR_ERRORS.ORDER_ALREADY_PAID.userMessage);
+      expect(errorFromString.recoverable).toBe(false);
+    });
+  });
+
+  describe("balance checks and message length fallback", () => {
+    it("maps 'Insufficient USDC balance' to ACCOUNT_INSUFFICIENT_BALANCE", () => {
+      const parsed = parseError("Insufficient USDC balance");
+      expect(parsed.code).toBe("ACCOUNT_INSUFFICIENT_BALANCE");
+      expect(parsed.userMessage).toBe(STELLAR_ERRORS.INSUFFICIENT_BALANCE.userMessage);
+      expect(parsed.recoverable).toBe(true);
+    });
+
+    it("falls back to generic userMessage for unknown errors over 100 characters", () => {
+      const longMessage =
+        "This is an unclassified low-level database socket failure that contains far too many technical details ".repeat(
+          2
+        );
+      expect(longMessage.length).toBeGreaterThan(100);
+
+      const parsed = parseError(longMessage);
+      expect(parsed.code).toBe("UNKNOWN_ERROR");
+      expect(parsed.message).toBe(longMessage);
+      expect(parsed.userMessage).toBe("An error occurred. Please try again.");
+    });
+
+    it("preserves original message for unknown errors under or equal to 100 characters", () => {
+      const shortMessage = "A short custom failure occurred";
+      expect(shortMessage.length).toBeLessThanOrEqual(100);
+
+      const parsed = parseError(shortMessage);
+      expect(parsed.code).toBe("UNKNOWN_ERROR");
+      expect(parsed.message).toBe(shortMessage);
+      expect(parsed.userMessage).toBe(shortMessage);
+    });
+  });
+
+  describe("getUserMessage and isRecoverable helpers", () => {
+    it("returns userMessage matching parseError result", () => {
+      expect(getUserMessage(new Error("OrderAlreadyPaid"))).toBe(
+        STELLAR_ERRORS.ORDER_ALREADY_PAID.userMessage
+      );
+      expect(getUserMessage("Insufficient USDC balance")).toBe(
+        STELLAR_ERRORS.INSUFFICIENT_BALANCE.userMessage
+      );
+      expect(getUserMessage(new WalletError("User declined", "USER_REJECTED"))).toBe(
+        STELLAR_ERRORS.USER_REJECTED.userMessage
+      );
+    });
+
+    it("reflects the recoverable flag from AppError", () => {
+      expect(isRecoverable(new Error("OrderAlreadyPaid"))).toBe(false);
+      expect(isRecoverable("Insufficient USDC balance")).toBe(true);
+      expect(isRecoverable(new WalletError("Contract missing", "CONTRACT_NOT_CONFIGURED"))).toBe(
+        false
+      );
+      expect(isRecoverable(new WalletError("Wrong net", "WRONG_NETWORK"))).toBe(true);
+      expect(isRecoverable(null)).toBe(true);
+    });
+  });
+
+  describe("WalletError classification by .code property", () => {
+    it("classifies WalletError instances by their .code property", () => {
+      const errFreighterNotFound = new WalletError("Extension missing", "FREIGHTER_NOT_FOUND");
+      const parsedFreighterNotFound = parseError(errFreighterNotFound);
+      expect(parsedFreighterNotFound.code).toBe("WALLET_NOT_INSTALLED");
+      expect(parsedFreighterNotFound.userMessage).toContain("Freighter wallet extension");
+
+      const errWrongNetwork = new WalletError("Wrong net detected", "WRONG_NETWORK");
+      const parsedWrongNetwork = parseError(errWrongNetwork);
+      expect(parsedWrongNetwork.code).toBe("WALLET_WRONG_NETWORK");
+
+      const errTxSend = new WalletError("Tx failed", "TX_SEND_ERROR");
+      const parsedTxSend = parseError(errTxSend);
+      expect(parsedTxSend.code).toBe("TX_FAILED");
+
+      const errSim = new WalletError("Sim failed", "TX_SIMULATION_ERROR");
+      const parsedSim = parseError(errSim);
+      expect(parsedSim.code).toBe("TX_SIMULATION_FAILED");
+
+      const errContract = new WalletError("No contract ID", "CONTRACT_NOT_CONFIGURED");
+      const parsedContract = parseError(errContract);
+      expect(parsedContract.code).toBe("STELLAR_CONTRACT_NOT_CONFIGURED");
+    });
+  });
+
+  describe("Table schema integrity", () => {
+    it("ensures every STELLAR_ERRORS entry maps to defined code and userMessage", () => {
+      const expectedKeys = [
+        "FREIGHTER_NOT_FOUND",
+        "FREIGHTER_REQUEST_DENIED",
+        "FREIGHTER_NETWORK_ERROR",
+        "WRONG_NETWORK",
+        "FREIGHTER_SIGN_ERROR",
+        "USER_REJECTED",
+        "ACCOUNT_NOT_FOUND",
+        "FRIENDBOT_ERROR",
+        "PAYMENT_NOT_READY",
+        "INSUFFICIENT_BALANCE",
+        "NO_TRUSTLINE",
+        "CONTRACT_NOT_CONFIGURED",
+        "INVALID_AMOUNT",
+        "TX_SIMULATION_ERROR",
+        "TX_SEND_ERROR",
+        "TX_TIMEOUT",
+        "ORDER_ALREADY_PAID",
+      ];
+
+      for (const key of expectedKeys) {
+        expect(STELLAR_ERRORS[key]).toBeDefined();
+        expect(STELLAR_ERRORS[key].code).toBeTruthy();
+        expect(STELLAR_ERRORS[key].userMessage).toBeTruthy();
+      }
+    });
+
+    it("creates custom AppError objects accurately with createError", () => {
+      const custom = createError("CUSTOM_CODE", "Internal msg", "Friendly msg", {
+        severity: "warning",
+        recoverable: false,
+      });
+      expect(custom.code).toBe("CUSTOM_CODE");
+      expect(custom.userMessage).toBe("Friendly msg");
+      expect(custom.severity).toBe("warning");
+      expect(custom.recoverable).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
### Summary
Closes #33 ($60 Bounty)

This PR adds comprehensive unit tests in `tests/lib/errors.test.ts` for the error-classification helpers (`parseError`, `parseErrorMessage`, `getUserMessage`, and `isRecoverable`):
- Exports `AUTH_ERRORS` and `GENERAL_ERRORS` tables.
- Adds `ORDER_ALREADY_PAID` (`STELLAR_ORDER_ALREADY_PAID`) to `STELLAR_ERRORS` matching contract error 4 (`OrderAlreadyPaid`).
- Supports matching both camelCase / PascalCase and natural spaced error strings (`Error("OrderAlreadyPaid")` and `"order already paid"`).
- Tests `null`/`undefined` fallback to `GENERAL_ERRORS.Unknown`.
- Tests balance error pattern mapping to `ACCOUNT_INSUFFICIENT_BALANCE`.
- Tests message length fallback: messages over 100 characters fall back to generic userMessage, while messages <= 100 characters preserve their original text.
- Tests `getUserMessage` and `isRecoverable` delegation and accuracy.

### Verification
- [x] `parseError(null)` and `parseError(undefined)` return `GENERAL_ERRORS.Unknown`.
- [x] `parseError(new Error("OrderAlreadyPaid"))` and `parseError("order already paid")` resolve to `STELLAR_ORDER_ALREADY_PAID`.
- [x] `"Insufficient USDC balance"` maps to `ACCOUNT_INSUFFICIENT_BALANCE`.
- [x] Messages > 100 chars fall back to generic user message.
- [x] `getUserMessage` returns correct user message; `isRecoverable` reflects the recoverable flag.
- [x] `npx vitest run tests/lib/errors.test.ts` passes (10/10 tests).
- [x] `npx prettier --check lib/errors.ts tests/lib/errors.test.ts` passes.
- [x] `npm run type-check` passes cleanly.
