### PR TITLE
fix(stellar): differentiate RPC outages from missing accounts in loadAccount and getNativeBalance (closes #19)

### DIFF
--- a/lib/stellar/account.ts
+++ b/lib/stellar/account.ts
@@ -43,6 +43,44 @@ export interface PaymentReadiness {
 }
 
 /**
+ * Detect if an error from the RPC indicates that the account does not exist
+ * on the ledger (e.g. 404 / not found), as opposed to an RPC or network outage.
+ */
+export function isAccountMissingError(err: unknown): boolean {
+  if (!err) return false;
+  const status =
+    (err as { status?: number })?.status ??
+    (err as { response?: { status?: number } })?.response?.status ??
+    (err as { code?: number })?.code;
+
+  if (status === 404) return true;
+
+  const msg = err instanceof Error ? err.message : String(err);
+  const lower = msg.toLowerCase();
+
+  if (
+    lower.includes("network") ||
+    lower.includes("fetch failed") ||
+    lower.includes("econnrefused") ||
+    lower.includes("etimedout") ||
+    lower.includes("timeout") ||
+    lower.includes("500") ||
+    lower.includes("502") ||
+    lower.includes("503") ||
+    lower.includes("504")
+  ) {
+    return false;
+  }
+
+  return (
+    lower.includes("account not found") ||
+    lower.includes("not found") ||
+    lower.includes("does not exist") ||
+    lower.includes("404")
+  );
+}
+
+/**
  * Load a buyer account, funding it on testnet when it does not exist yet.
  * On mainnet a missing account is a hard error.
  */
@@ -55,7 +93,17 @@ export async function loadAccount(
   try {
     const account = await server.getAccount(publicKey);
     return { account, funded: false };
-  } catch {
+  } catch (err) {
+    if (!isAccountMissingError(err)) {
+      if (err instanceof WalletError) {
+        throw err;
+      }
+      throw new WalletError(
+        `RPC error loading account: ${err instanceof Error ? err.message : String(err)}`,
+        "RPC_ERROR"
+      );
+    }
+
     if (!IS_MAINNET && fund) {
       await fundTestnetAccount(publicKey);
       const account = await server.getAccount(publicKey);
@@ -80,15 +128,21 @@ export async function fundTestnetAccount(publicKey: string): Promise<void> {
 }
 
 /** Native XLM balance of an account (0 when the account does not exist). */
-export async function getNativeBalance(
-  server: rpc.Server,
-  publicKey: string
-): Promise<bigint> {
+export async function getNativeBalance(server: rpc.Server, publicKey: string): Promise<bigint> {
   try {
     const entry = await server.getAccountEntry(publicKey);
     return BigInt(entry.balance().toString());
-  } catch {
-    return BigInt(0);
+  } catch (err) {
+    if (isAccountMissingError(err)) {
+      return BigInt(0);
+    }
+    if (err instanceof WalletError) {
+      throw err;
+    }
+    throw new WalletError(
+      `RPC error retrieving native balance: ${err instanceof Error ? err.message : String(err)}`,
+      "RPC_ERROR"
+    );
   }
 }
 

--- a/tests/lib/stellar/account.test.ts
+++ b/tests/lib/stellar/account.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from "vitest";
-import { formatAmount, MIN_NATIVE_RESERVE } from "../../../lib/stellar/account";
+import { describe, it, expect, vi } from "vitest";
+import {
+  formatAmount,
+  MIN_NATIVE_RESERVE,
+  loadAccount,
+  getNativeBalance,
+  isAccountMissingError,
+} from "../../../lib/stellar/account";
 
 describe("formatAmount", () => {
   it("formats MIN_NATIVE_RESERVE with 7 decimals correctly", () => {
@@ -41,5 +47,101 @@ describe("formatAmount", () => {
     const expectedFrac = (huge % 10000000n).toString().padStart(7, "0").replace(/0+$/, "");
     const expected = expectedFrac ? `${expectedInt}.${expectedFrac}` : expectedInt;
     expect(formatted).toBe(expected);
+  });
+});
+
+describe("isAccountMissingError", () => {
+  it("identifies 404 status and account not found messages", () => {
+    expect(isAccountMissingError({ status: 404 })).toBe(true);
+    expect(isAccountMissingError({ response: { status: 404 } })).toBe(true);
+    expect(isAccountMissingError(new Error("Account not found"))).toBe(true);
+    expect(isAccountMissingError(new Error("Resource not found"))).toBe(true);
+    expect(isAccountMissingError(new Error("Account does not exist"))).toBe(true);
+    expect(isAccountMissingError(new Error("Error code: 404"))).toBe(true);
+  });
+
+  it("identifies network and RPC outages as NOT account-missing", () => {
+    expect(isAccountMissingError(new Error("Network error"))).toBe(false);
+    expect(isAccountMissingError(new Error("fetch failed"))).toBe(false);
+    expect(isAccountMissingError(new Error("connect ECONNREFUSED"))).toBe(false);
+    expect(isAccountMissingError(new Error("request timeout"))).toBe(false);
+    expect(isAccountMissingError(new Error("500 Internal Server Error"))).toBe(false);
+    expect(isAccountMissingError(new Error("503 Service Unavailable"))).toBe(false);
+    expect(isAccountMissingError(null)).toBe(false);
+  });
+});
+
+describe("loadAccount", () => {
+  const dummyPublicKey = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
+  it("never calls friendbot and rejects when getAccount fails with a network error", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const stubServer = {
+      getAccount: vi.fn().mockRejectedValue(new Error("fetch failed: connection refused")),
+    };
+
+    await expect(loadAccount(stubServer as never, dummyPublicKey, { fund: true })).rejects.toThrow(
+      /RPC error loading account/
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("triggers friendbot funding and re-loads account when getAccount fails with account-missing error", async () => {
+    const dummyAccount = { id: dummyPublicKey, sequence: "1" };
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+    } as Response);
+
+    const stubServer = {
+      getAccount: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Account not found (404)"))
+        .mockResolvedValueOnce(dummyAccount),
+    };
+
+    const result = await loadAccount(stubServer as never, dummyPublicKey, { fund: true });
+    expect(result.funded).toBe(true);
+    expect(result.account).toBe(dummyAccount);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    fetchSpy.mockRestore();
+  });
+});
+
+describe("getNativeBalance", () => {
+  const dummyPublicKey = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
+  it("returns balance when getAccountEntry succeeds", async () => {
+    const stubServer = {
+      getAccountEntry: vi.fn().mockResolvedValue({
+        balance: () => "50000000",
+      }),
+    };
+
+    const balance = await getNativeBalance(stubServer as never, dummyPublicKey);
+    expect(balance).toBe(50000000n);
+  });
+
+  it("surfaces RPC / network rejections rather than returning 0n", async () => {
+    const stubServer = {
+      getAccountEntry: vi.fn().mockRejectedValue(new Error("503 Service Unavailable: RPC timeout")),
+    };
+
+    await expect(getNativeBalance(stubServer as never, dummyPublicKey)).rejects.toThrow(
+      /RPC error retrieving native balance/
+    );
+  });
+
+  it("returns 0n when getAccountEntry indicates account does not exist (not found)", async () => {
+    const stubServer = {
+      getAccountEntry: vi.fn().mockRejectedValue(new Error("Account not found")),
+    };
+
+    const balance = await getNativeBalance(stubServer as never, dummyPublicKey);
+    expect(balance).toBe(0n);
   });
 });


### PR DESCRIPTION
### Summary
Closes #19 ($75 Bounty)

This PR fixes untyped error suppression in loadAccount and getNativeBalance (lib/stellar/account.ts):
- Added isAccountMissingError to identify true account-missing status (HTTP 404 / account not found / does not exist) while excluding network/RPC timeouts, 500/502/503/504 errors, and connection failures.
- In loadAccount: when getAccount encounters network/RPC failures, friendbot is bypassed and a WalletError with code RPC_ERROR is thrown instead of presenting generic unfunded messages or wasting friendbot requests. True account-missing errors continue to trigger the testnet friendbot funding path.
- In getNativeBalance: surfaces RPC/network rejections rather than catching all errors and returning BigInt(0).
- Added comprehensive unit tests in tests/lib/stellar/account.test.ts asserting all failure and success branches.

### Verification
- [x] All 14 tests in tests/lib/stellar/account.test.ts pass cleanly.
- [x] npx prettier --check lib/stellar/account.ts tests/lib/stellar/account.test.ts passes.
- [x] npm run type-check passes cleanly.
