### PR TITLE
fix(cart): give duplicate cart line items unique keys and remove by instance (closes #24)

### DIFF
--- a/app/shop/[id]/page.jsx
+++ b/app/shop/[id]/page.jsx
@@ -10,8 +10,7 @@ import { getProductById } from "../../../lib/products";
 import LoadingSpinner from "../../../components/LoadingSpinner";
 
 const ProductPage = ({ params }) => {
-  const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } =
-    useCart();
+  const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } = useCart();
   const [product, setProduct] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -70,12 +69,7 @@ const ProductPage = ({ params }) => {
         {!loading && !error && product && (
           <>
             <h1 className="text-4xl font-bold mb-4">{product.name}</h1>
-            <Image
-              src={product.img}
-              alt={product.name}
-              width={400}
-              height={400}
-            />
+            <Image src={product.img} alt={product.name} width={400} height={400} />
             <div className="flex space-x-4 items-center my-4">
               <h2 className="text-4xl">${product.price}</h2>
               <button
@@ -105,7 +99,7 @@ const ProductPage = ({ params }) => {
           <div>
             {cartItems.map((item) => (
               <div
-                key={item.id}
+                key={item.cartItemId || item.lineId || item.id}
                 className="flex justify-between items-center mb-2"
               >
                 <div className="w-16 h-16 flex-shrink-0">
@@ -132,11 +126,7 @@ const ProductPage = ({ params }) => {
         <div className="flex justify-between items-center mt-4 mx-5 sm:mx-10">
           <div>
             {cartItems.length > 0 && <strong>Total:</strong>}
-            {totalPrice ? (
-              <span className="ml-2 font-bold ">${totalPrice.toFixed(2)}</span>
-            ) : (
-              ""
-            )}
+            {totalPrice ? <span className="ml-2 font-bold ">${totalPrice.toFixed(2)}</span> : ""}
           </div>
           {cartItems.length > 0 && (
             <button

--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -10,8 +10,7 @@ import Toast from "../../components/Toast";
 import { listProducts } from "../../lib/products";
 
 export default function Products() {
-  const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } =
-    useCart();
+  const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } = useCart();
   const [showModal, setShowModal] = useState(false);
   const [toast, setToast] = useState({ show: false, message: "" });
   const [isCheckingOut, setIsCheckingOut] = useState(false);
@@ -102,7 +101,7 @@ export default function Products() {
           <div>
             {cartItems.map((item) => (
               <div
-                key={item.id}
+                key={item.cartItemId || item.lineId || item.id}
                 className="flex justify-between items-center mb-2"
               >
                 <div className="w-16 h-16 flex-shrink-0">
@@ -129,11 +128,7 @@ export default function Products() {
         <div className="flex justify-between items-center mt-4 mx-5 sm:mx-10">
           <div>
             {cartItems.length > 0 && <strong>Total:</strong>}
-            {totalPrice ? (
-              <span className="ml-2 font-bold ">${totalPrice.toFixed(2)}</span>
-            ) : (
-              ""
-            )}
+            {totalPrice ? <span className="ml-2 font-bold ">${totalPrice.toFixed(2)}</span> : ""}
           </div>
           {cartItems.length > 0 && (
             <button

--- a/context/CartContext.jsx
+++ b/context/CartContext.jsx
@@ -1,9 +1,27 @@
-"use client"
+"use client";
 import { createContext, useContext, useEffect, useState } from "react";
 
 const CartContext = createContext();
 
 export const useCart = () => useContext(CartContext);
+
+// Unique per-cart-line identifier helper. Adding the same product twice creates
+// independent rows (each removable on its own with unique React keys).
+let lineItemCounter = 0;
+export const generateCartItemId = (productId) => {
+  lineItemCounter += 1;
+  const rand = Math.random().toString(36).slice(2, 9);
+  return `${productId ?? "item"}-${Date.now().toString(36)}-${lineItemCounter}-${rand}`;
+};
+
+export const ensureCartItemId = (item) => {
+  if (!item || typeof item !== "object") return item;
+  if (item.cartItemId || item.lineId) return item;
+  return {
+    ...item,
+    cartItemId: generateCartItemId(item.id),
+  };
+};
 
 export const CartProvider = ({ children }) => {
   const [cartItems, setCartItems] = useState([]);
@@ -20,7 +38,7 @@ export const CartProvider = ({ children }) => {
       if (rawItems) {
         const parsed = JSON.parse(rawItems);
         if (Array.isArray(parsed)) {
-          storedCartItems = parsed;
+          storedCartItems = parsed.map(ensureCartItemId);
         }
       }
     } catch {
@@ -57,8 +75,13 @@ export const CartProvider = ({ children }) => {
   }, []);
 
   const addToCart = (product) => {
+    const lineItem = {
+      ...product,
+      cartItemId: generateCartItemId(product?.id),
+    };
+
     setCartItems((prevCartItems) => {
-      const updatedCartItems = [...prevCartItems, product];
+      const updatedCartItems = [...prevCartItems, lineItem];
       localStorage.setItem("cartItems", JSON.stringify(updatedCartItems));
       return updatedCartItems;
     });
@@ -68,7 +91,7 @@ export const CartProvider = ({ children }) => {
       return newItemCount;
     });
     setTotalPrice((prevTotalPrice) => {
-      const newTotalPrice = prevTotalPrice + product.price;
+      const newTotalPrice = prevTotalPrice + (product?.price || 0);
       localStorage.setItem("totalPrice", newTotalPrice.toString());
       return newTotalPrice;
     });
@@ -76,7 +99,29 @@ export const CartProvider = ({ children }) => {
 
   const removeFromCart = (product) => {
     setCartItems((prevCartItems) => {
-      const index = prevCartItems.findIndex((item) => item.id === product.id);
+      // Find by unique instance id if present (cartItemId or lineId),
+      // otherwise fall back to product id for legacy callers.
+      const targetInstanceId =
+        product?.cartItemId ||
+        product?.lineId ||
+        (typeof product === "string" &&
+        prevCartItems.some((i) => i.cartItemId === product || i.lineId === product)
+          ? product
+          : null);
+
+      let index = -1;
+      if (targetInstanceId) {
+        index = prevCartItems.findIndex(
+          (item) => item.cartItemId === targetInstanceId || item.lineId === targetInstanceId
+        );
+      }
+
+      if (index === -1) {
+        const targetProductId =
+          product && typeof product === "object" && product.id !== undefined ? product.id : product;
+        index = prevCartItems.findIndex((item) => item.id === targetProductId);
+      }
+
       if (index === -1) return prevCartItems;
 
       const removedItem = prevCartItems[index];

--- a/tests/context/CartContext.test.tsx
+++ b/tests/context/CartContext.test.tsx
@@ -8,9 +8,8 @@ describe("CartContext removeFromCart", () => {
     localStorage.clear();
   });
 
-  const wrapper = ({ children }: { children: React.ReactNode }) => (
-    React.createElement(CartProvider, null, children)
-  );
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(CartProvider, null, children);
 
   it("adds and removes items correctly", () => {
     const { result } = renderHook(() => useCart(), { wrapper });
@@ -80,5 +79,105 @@ describe("CartContext removeFromCart", () => {
     expect(result.current.itemCount).toBe(0);
     expect(result.current.totalPrice).toBe(0);
     expect(result.current.cartItems).toEqual([]);
+  });
+
+  it("assigns unique cartItemId to duplicate items and removes specific instance (lower row)", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    const product = { id: "p1", name: "Shoe 1", price: 50 };
+
+    act(() => {
+      result.current.addToCart(product);
+      result.current.addToCart(product);
+    });
+
+    expect(result.current.itemCount).toBe(2);
+    expect(result.current.totalPrice).toBe(100);
+    expect(result.current.cartItems).toHaveLength(2);
+
+    const [firstInstance, secondInstance] = result.current.cartItems;
+    expect(firstInstance.cartItemId).toBeDefined();
+    expect(secondInstance.cartItemId).toBeDefined();
+    expect(firstInstance.cartItemId).not.toBe(secondInstance.cartItemId);
+
+    // Remove the lower/second instance
+    act(() => {
+      result.current.removeFromCart(secondInstance);
+    });
+
+    expect(result.current.itemCount).toBe(1);
+    expect(result.current.totalPrice).toBe(50);
+    expect(result.current.cartItems).toHaveLength(1);
+    expect(result.current.cartItems[0].cartItemId).toBe(firstInstance.cartItemId);
+  });
+
+  it("removes upper duplicate row and leaves lower row intact", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    const product = { id: "p1", name: "Shoe 1", price: 50 };
+
+    act(() => {
+      result.current.addToCart(product);
+      result.current.addToCart(product);
+    });
+
+    const [firstInstance, secondInstance] = result.current.cartItems;
+
+    // Remove the upper/first instance
+    act(() => {
+      result.current.removeFromCart(firstInstance);
+    });
+
+    expect(result.current.itemCount).toBe(1);
+    expect(result.current.totalPrice).toBe(50);
+    expect(result.current.cartItems).toHaveLength(1);
+    expect(result.current.cartItems[0].cartItemId).toBe(secondInstance.cartItemId);
+  });
+
+  it("supports removal by cartItemId string directly", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    const product = { id: "p1", name: "Shoe 1", price: 50 };
+
+    act(() => {
+      result.current.addToCart(product);
+      result.current.addToCart(product);
+    });
+
+    const secondInstanceId = result.current.cartItems[1].cartItemId;
+
+    act(() => {
+      result.current.removeFromCart(secondInstanceId);
+    });
+
+    expect(result.current.itemCount).toBe(1);
+    expect(result.current.totalPrice).toBe(50);
+    expect(result.current.cartItems[0].cartItemId).not.toBe(secondInstanceId);
+  });
+
+  it("ensures legacy items loaded from localStorage without cartItemId are assigned unique cartItemIds", () => {
+    const legacyItems = [
+      { id: "legacy1", name: "Legacy A", price: 30 },
+      { id: "legacy1", name: "Legacy A (Duplicate)", price: 30 },
+    ];
+    localStorage.setItem("cartItems", JSON.stringify(legacyItems));
+    localStorage.setItem("itemCount", "2");
+    localStorage.setItem("totalPrice", "60");
+
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    expect(result.current.cartItems).toHaveLength(2);
+    expect(result.current.cartItems[0].cartItemId).toBeDefined();
+    expect(result.current.cartItems[1].cartItemId).toBeDefined();
+    expect(result.current.cartItems[0].cartItemId).not.toBe(result.current.cartItems[1].cartItemId);
+
+    // Can remove second instance independently
+    act(() => {
+      result.current.removeFromCart(result.current.cartItems[1]);
+    });
+
+    expect(result.current.cartItems).toHaveLength(1);
+    expect(result.current.itemCount).toBe(1);
+    expect(result.current.totalPrice).toBe(30);
   });
 });

--- a/tests/context/CartModalDuplicateRows.test.jsx
+++ b/tests/context/CartModalDuplicateRows.test.jsx
@@ -1,0 +1,146 @@
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { CartProvider, useCart } from "../../context/CartContext";
+
+const SAMPLE_PRODUCT = {
+  id: "prod-42",
+  name: "Soroban Runner Sneaker",
+  price: 75,
+  img: "/shoes/shoe1.png",
+};
+
+function CartModalConsumer() {
+  const { cartItems, itemCount, totalPrice, addToCart, removeFromCart } = useCart();
+
+  return (
+    <div>
+      <button onClick={() => addToCart(SAMPLE_PRODUCT)}>Add Product</button>
+      <span data-testid="count">{itemCount}</span>
+      <span data-testid="total">{totalPrice}</span>
+      <div data-testid="cart-modal">
+        {cartItems.map((item, idx) => (
+          <div
+            key={item.cartItemId || item.lineId || item.id}
+            data-testid={`cart-row-${idx}`}
+            data-cart-item-id={item.cartItemId}
+          >
+            <span>{item.name}</span>
+            <span>${item.price}</span>
+            <button data-testid={`remove-btn-${idx}`} onClick={() => removeFromCart(item)}>
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+describe("Cart duplicate rows UI & keys", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders duplicate line items with unique keys without console duplicate-key warnings", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <CartProvider>
+        <CartModalConsumer />
+      </CartProvider>
+    );
+
+    const addBtn = screen.getByRole("button", { name: "Add Product" });
+    act(() => {
+      fireEvent.click(addBtn);
+      fireEvent.click(addBtn);
+    });
+
+    expect(screen.getByTestId("count").textContent).toBe("2");
+    expect(screen.getByTestId("total").textContent).toBe("150");
+
+    const row0 = screen.getByTestId("cart-row-0");
+    const row1 = screen.getByTestId("cart-row-1");
+    expect(row0).toBeInTheDocument();
+    expect(row1).toBeInTheDocument();
+
+    const id0 = row0.getAttribute("data-cart-item-id");
+    const id1 = row1.getAttribute("data-cart-item-id");
+    expect(id0).toBeTruthy();
+    expect(id1).toBeTruthy();
+    expect(id0).not.toBe(id1);
+
+    // Verify no React duplicate key error was logged
+    const duplicateKeyWarnings = errorSpy.mock.calls.filter((call) =>
+      call.some(
+        (arg) =>
+          typeof arg === "string" && arg.includes("Encountered two children with the same key")
+      )
+    );
+    expect(duplicateKeyWarnings).toHaveLength(0);
+
+    errorSpy.mockRestore();
+  });
+
+  it("removes lower duplicate row leaving upper row intact", () => {
+    render(
+      <CartProvider>
+        <CartModalConsumer />
+      </CartProvider>
+    );
+
+    const addBtn = screen.getByRole("button", { name: "Add Product" });
+    act(() => {
+      fireEvent.click(addBtn);
+      fireEvent.click(addBtn);
+    });
+
+    const id0 = screen.getByTestId("cart-row-0").getAttribute("data-cart-item-id");
+    const id1 = screen.getByTestId("cart-row-1").getAttribute("data-cart-item-id");
+
+    // Click remove on lower/second row
+    const removeBtn1 = screen.getByTestId("remove-btn-1");
+    act(() => {
+      fireEvent.click(removeBtn1);
+    });
+
+    expect(screen.getByTestId("count").textContent).toBe("1");
+    expect(screen.getByTestId("total").textContent).toBe("75");
+
+    // Only 1 row remains and it corresponds to the first item (id0)
+    const remainingRow = screen.getByTestId("cart-row-0");
+    expect(remainingRow.getAttribute("data-cart-item-id")).toBe(id0);
+    expect(screen.queryByTestId("cart-row-1")).not.toBeInTheDocument();
+  });
+
+  it("removes upper duplicate row leaving lower row intact", () => {
+    render(
+      <CartProvider>
+        <CartModalConsumer />
+      </CartProvider>
+    );
+
+    const addBtn = screen.getByRole("button", { name: "Add Product" });
+    act(() => {
+      fireEvent.click(addBtn);
+      fireEvent.click(addBtn);
+    });
+
+    const id1 = screen.getByTestId("cart-row-1").getAttribute("data-cart-item-id");
+
+    // Click remove on upper/first row
+    const removeBtn0 = screen.getByTestId("remove-btn-0");
+    act(() => {
+      fireEvent.click(removeBtn0);
+    });
+
+    expect(screen.getByTestId("count").textContent).toBe("1");
+    expect(screen.getByTestId("total").textContent).toBe("75");
+
+    // Only 1 row remains and its id corresponds to the second item (id1)
+    const remainingRow = screen.getByTestId("cart-row-0");
+    expect(remainingRow.getAttribute("data-cart-item-id")).toBe(id1);
+    expect(screen.queryByTestId("cart-row-1")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Overview
Closes #24

### Problem
Previously, `addToCart` pushed bare product entries with no unique instance identifier. When identical products were added to the cart:
1. Both cart modals (`app/shop/page.jsx:105` and `app/shop/[id]/page.jsx:108`) mapped with `key={item.id}`, causing React duplicate key console warnings.
2. `removeFromCart` matched by `item.id === product.id` and spliced the first matching index, meaning clicking "Remove" on the second duplicate item mistakenly removed the first item.

### Changes
1. **Unique Instance Keying (`context/CartContext.jsx`)**:
   - Added `generateCartItemId(productId)` helper to assign each cart line a collision-free identifier (`{productId}-{timestamp}-{counter}-{rand}`).
   - Added `ensureCartItemId(item)` to gracefully normalize legacy carts restored from `localStorage` that lack unique line identifiers.
   - Updated `addToCart` to assign a fresh unique `cartItemId` to every added line item instance.
2. **Instance-Based Removal (`context/CartContext.jsx`)**:
   - Updated `removeFromCart` to prioritize removal by unique line instance (`cartItemId` / `lineId` or instance id string), while maintaining backwards-compatible fallback to `item.id` for legacy callers.
3. **Cart Modals Updated (`app/shop/page.jsx` & `app/shop/[id]/page.jsx`)**:
   - Updated modal list row keys to `key={item.cartItemId || item.lineId || item.id}`.
4. **Comprehensive Test Suite**:
   - Extended `tests/context/CartContext.test.tsx` with 4 new test cases verifying unique `cartItemId` generation, removal of lower vs upper duplicate rows, string id removal, and legacy localStorage hydration.
   - Created `tests/context/CartModalDuplicateRows.test.jsx` verifying duplicate item DOM rendering without console duplicate-key warnings and independent removal of duplicate rows.

### Acceptance Criteria Verification
- [x] Adding the same product twice renders two rows with no duplicate-key console warning.
- [x] Removing the lower duplicate row leaves the upper one intact and vice versa.
- [x] `itemCount` and `totalPrice` stay accurate across duplicate add/remove.
- [x] Passes type-check, lint, and vitest unit tests (verified 2x).
