### PR TITLE
fix(stellar): retry getLatestLedger on startup outage and defer polling (closes #68)

### DIFF
--- a/lib/stellar/indexer.ts
+++ b/lib/stellar/indexer.ts
@@ -38,6 +38,7 @@ export interface IndexerStatus {
   lastCursor?: string;
   eventsSeen: number;
   lastError?: string;
+  retrying?: boolean;
 }
 
 export interface IndexerCallbacks {
@@ -64,6 +65,8 @@ export class PaymentEventIndexer {
   private timer: ReturnType<typeof setInterval> | null = null;
   private running = false;
   private started = false;
+  private initializing = false;
+  private initialized = false;
 
   constructor(
     opts: {
@@ -76,8 +79,7 @@ export class PaymentEventIndexer {
     this.server = new rpc.Server(opts.rpcUrl ?? RPC_URL);
     this.contractId = opts.contractId ?? CHECKOUT_CONTRACT_ID;
     this.pollMs = opts.pollMs ?? EVENT_POLL_INTERVAL_MS;
-    this.watchedSymbols =
-      opts.watchedSymbols ?? ["pay", "create_order", "dispatch", "refund"];
+    this.watchedSymbols = opts.watchedSymbols ?? ["pay", "create_order", "dispatch", "refund"];
   }
 
   get status(): IndexerStatus {
@@ -87,6 +89,7 @@ export class PaymentEventIndexer {
       lastCursor: this.cursor,
       eventsSeen: this.eventsSeen,
       lastError: this.lastError,
+      retrying: this.running && !this.initialized,
     };
   }
 
@@ -96,7 +99,8 @@ export class PaymentEventIndexer {
     this.running = true;
     this.started = true;
 
-    void this.initialize(callbacks);
+    this.timer = setInterval(() => void this.tick(callbacks), this.pollMs);
+    void this.tick(callbacks);
   }
 
   stop(): void {
@@ -107,26 +111,43 @@ export class PaymentEventIndexer {
     }
   }
 
-  private async initialize(callbacks: IndexerCallbacks): Promise<void> {
+  private async tick(callbacks: IndexerCallbacks): Promise<void> {
+    if (!this.running) return;
+
+    if (!this.initialized) {
+      await this.ensureInitialized(callbacks);
+      if (!this.initialized) {
+        return;
+      }
+    }
+
+    await this.poll(callbacks);
+  }
+
+  private async ensureInitialized(callbacks: IndexerCallbacks): Promise<void> {
+    if (this.initializing) return;
+    this.initializing = true;
+
     try {
       const latest = await this.server.getLatestLedger();
       this.latestLedger = latest.sequence;
-      this.startLedger = Math.max(
-        1,
-        this.latestLedger - EVENT_START_LEDGER_BACKFILL
-      );
+      this.startLedger = Math.max(1, this.latestLedger - EVENT_START_LEDGER_BACKFILL);
+      this.initialized = true;
+      this.lastError = undefined;
       callbacks.onStatus?.(this.status);
     } catch (err) {
       this.lastError = String(err instanceof Error ? err.message : err);
-      callbacks.onError?.(new Error(`Could not reach the Stellar RPC: ${this.lastError}`));
+      callbacks.onError?.(
+        new Error(`Could not reach the Stellar RPC (retrying): ${this.lastError}`)
+      );
+      callbacks.onStatus?.(this.status);
+    } finally {
+      this.initializing = false;
     }
-
-    this.timer = setInterval(() => void this.poll(callbacks), this.pollMs);
-    void this.poll(callbacks);
   }
 
   private async poll(callbacks: IndexerCallbacks): Promise<void> {
-    if (!this.running) return;
+    if (!this.running || !this.initialized) return;
 
     try {
       const res = await this.fetchEvents();
@@ -166,9 +187,7 @@ export class PaymentEventIndexer {
   }
 
   private async fetchEvents(): Promise<rpc.Api.GetEventsResponse> {
-    const filters: rpc.Api.EventFilter[] = [
-      { type: "contract", contractIds: [this.contractId] },
-    ];
+    const filters: rpc.Api.EventFilter[] = [{ type: "contract", contractIds: [this.contractId] }];
     if (this.startLedger !== undefined) {
       return this.server.getEvents({ filters, startLedger: this.startLedger });
     }

--- a/tests/lib/stellar/indexer.test.ts
+++ b/tests/lib/stellar/indexer.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { PaymentEventIndexer } from "../../../lib/stellar/indexer";
+
+describe("PaymentEventIndexer startup retry (Issue #68)", () => {
+  it("retries getLatestLedger when initial call fails and recovers without 'no cursor' error", async () => {
+    let getLatestLedgerAttempts = 0;
+    let getEventsCalled = false;
+
+    const fakeServer = {
+      getLatestLedger: vi.fn().mockImplementation(async () => {
+        getLatestLedgerAttempts++;
+        if (getLatestLedgerAttempts === 1) {
+          throw new Error("RPC temporary network partition");
+        }
+        return { sequence: 100 };
+      }),
+      getEvents: vi.fn().mockImplementation(async () => {
+        getEventsCalled = true;
+        return {
+          latestLedger: 100,
+          cursor: "cursor-abc-123",
+          events: [],
+        };
+      }),
+    };
+
+    const indexer = new PaymentEventIndexer({ pollMs: 50 });
+    (indexer as unknown as { server: unknown }).server = fakeServer;
+
+    const errors: string[] = [];
+    const statuses: unknown[] = [];
+
+    indexer.start({
+      onEvent: () => {},
+      onError: (err) => errors.push(err.message),
+      onStatus: (st) => statuses.push(st),
+    });
+
+    // Wait for the first attempt to run and fail
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    expect(getLatestLedgerAttempts).toBe(1);
+    expect(getEventsCalled).toBe(false);
+    expect(errors.some((e) => e.includes("Could not reach the Stellar RPC (retrying)"))).toBe(true);
+    // Crucial: Must NEVER emit "no cursor or start ledger" error
+    expect(errors.some((e) => e.includes("no cursor or start ledger"))).toBe(false);
+    expect(indexer.status.retrying).toBe(true);
+
+    // Wait for second tick to succeed and begin polling
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(getLatestLedgerAttempts).toBeGreaterThanOrEqual(2);
+    expect(getEventsCalled).toBe(true);
+    expect(errors.some((e) => e.includes("no cursor or start ledger"))).toBe(false);
+    expect(indexer.status.lastCursor).toBe("cursor-abc-123");
+    expect(indexer.status.latestLedger).toBe(100);
+    expect(indexer.status.retrying).toBe(false);
+
+    indexer.stop();
+  });
+
+  it("handles continuous poll updates when initialized normally", async () => {
+    let callCount = 0;
+    const fakeServer = {
+      getLatestLedger: vi.fn().mockResolvedValue({ sequence: 200 }),
+      getEvents: vi.fn().mockImplementation(async () => {
+        callCount++;
+        return {
+          latestLedger: 200 + callCount,
+          cursor: `cursor-${callCount}`,
+          events: [],
+        };
+      }),
+    };
+
+    const indexer = new PaymentEventIndexer({ pollMs: 40 });
+    (indexer as unknown as { server: unknown }).server = fakeServer;
+
+    indexer.start({
+      onEvent: () => {},
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(callCount).toBeGreaterThanOrEqual(2);
+    expect(indexer.status.latestLedger).toBeGreaterThanOrEqual(202);
+    expect(indexer.status.retrying).toBe(false);
+
+    indexer.stop();
+  });
+
+  it("stops cleanly and ceases polling after stop() is called", async () => {
+    let getEventsCalls = 0;
+    const fakeServer = {
+      getLatestLedger: vi.fn().mockResolvedValue({ sequence: 300 }),
+      getEvents: vi.fn().mockImplementation(async () => {
+        getEventsCalls++;
+        return {
+          latestLedger: 300,
+          cursor: "cursor-300",
+          events: [],
+        };
+      }),
+    };
+
+    const indexer = new PaymentEventIndexer({ pollMs: 30 });
+    (indexer as unknown as { server: unknown }).server = fakeServer;
+
+    indexer.start({ onEvent: () => {} });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    indexer.stop();
+    const callsAtStop = getEventsCalls;
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(getEventsCalls).toBe(callsAtStop);
+    expect(indexer.status.running).toBe(false);
+  });
+});


### PR DESCRIPTION
### Overview
Closes #68

### Problem
In `lib/stellar/indexer.ts`, `initialize()` only assigned `startLedger` after a successful `server.getLatestLedger()`. If the initial RPC call failed due to a startup network blip or RPC outage:
1. It reported `onError` but proceeded to start the polling interval timer regardless.
2. Every subsequent `poll()` hit `fetchEvents()` with neither cursor nor start ledger, permanently throwing `"Indexer has no cursor or start ledger to poll from"`.
3. `recoverFromRetentionError()` was a no-op because `startLedger` remained `undefined`, causing components such as `StellarOrderWatch` to display a permanent unrecoverable error until the page was reloaded.

### Changes
1. **Deferred Polling & Startup Retry (`lib/stellar/indexer.ts`)**:
   - Replaced immediate unconditional interval start with a tick-driven initialization guard (`tick` + `ensureInitialized`).
   - The indexer defers event polling until `getLatestLedger()` succeeds and a valid `startLedger` is established.
   - If `getLatestLedger()` fails on startup, it surfaces the transient retrying error (`"Could not reach the Stellar RPC (retrying): ..."`), marks `retrying: true` in `status`, and retries on subsequent ticks without ever calling `fetchEvents()`.
   - Once the RPC recovers and resolves `getLatestLedger()`, `initialized` is flagged, `startLedger` is assigned, and event polling begins immediately without throwing any "no cursor or start ledger" error.
2. **Status Enrichment**:
   - Added optional `retrying?: boolean` field to `IndexerStatus` to inform consumers when the indexer is actively reconnecting during startup.
3. **Comprehensive Unit Tests (`tests/lib/stellar/indexer.test.ts`)**:
   - Simulated RPC startup outage with a mock server that rejects on the first `getLatestLedger` call and resolves on retry.
   - Confirmed indexer recovers cleanly, begins polling, updates cursor and ledgers, and emits 0 "no cursor or start ledger" errors.
   - Verified normal polling updates and clean cessation on `stop()`.

### Acceptance Criteria Verification
- [x] Unit test with fake RPC server whose `getLatestLedger` rejects once then resolves: indexer eventually starts polling with a start ledger.
- [x] No "no cursor or start ledger" error is emitted during outage or after recovery.
- [x] Passes vitest unit tests, type-check, prettier, and lint (verified 2x).
