### PR TITLE
refactor(ui): extract duplicated showToast timer into shared useToast hook (closes #31)

### DIFF
--- a/app/(landingpage)/ContactUs.jsx
+++ b/app/(landingpage)/ContactUs.jsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import useToast from "../../hooks/useToast";
 import { FaGithub, FaTwitter, FaDiscord } from "react-icons/fa";
 import sendMail from "../../lib/sendmail";
 
@@ -30,7 +31,7 @@ const ContactUs = () => {
     email: "",
     message: "",
   });
-  const [toast, setToast] = useState({ show: false, message: "" });
+  const { toast, showToast, hideToast } = useToast(5000);
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -56,11 +57,6 @@ const ContactUs = () => {
     setIsLoading(false);
   };
 
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 5000);
-  };
-
   return (
     <div
       id="contact"
@@ -68,21 +64,16 @@ const ContactUs = () => {
     >
       <div className="max-w-5xl mx-auto">
         <div className="text-center mb-10">
-          <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
-            Get in Touch
-          </h2>
+          <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">Get in Touch</h2>
           <p className="text-white/90 max-w-xl mx-auto">
-            Questions, feedback, or want to contribute? Reach out through
-            any channel below.
+            Questions, feedback, or want to contribute? Reach out through any channel below.
           </p>
         </div>
 
         <div className="grid md:grid-cols-2 gap-8">
           {/* Social Links */}
           <div className="bg-white/10 backdrop-blur-sm rounded-xl p-8">
-            <h3 className="text-xl font-semibold text-white mb-6">
-              Connect with us
-            </h3>
+            <h3 className="text-xl font-semibold text-white mb-6">Connect with us</h3>
             <div className="space-y-4">
               {socialLinks.map((link) => (
                 <a
@@ -96,9 +87,7 @@ const ContactUs = () => {
                     <link.icon size={24} />
                   </span>
                   <div>
-                    <p className="font-semibold text-white group-hover:underline">
-                      {link.name}
-                    </p>
+                    <p className="font-semibold text-white group-hover:underline">{link.name}</p>
                     <p className="text-sm text-white/70">{link.description}</p>
                   </div>
                 </a>
@@ -114,91 +103,89 @@ const ContactUs = () => {
 
           {/* Contact Form */}
           <div className="bg-white shadow-lg rounded-xl p-8">
-            <h3 className="text-xl font-semibold text-gray-900 mb-6">
-              Send us a message
-            </h3>
-        <form onSubmit={handleSubmit}>
-          <div className="grid grid-cols-1 gap-4 mb-4">
-            <input
-              type="text"
-              name="name"
-              value={formData.name}
-              onChange={handleChange}
-              placeholder="Your Name"
-              className="border border-gray-300 rounded-lg p-3 text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
-              required
-            />
-            <input
-              type="email"
-              name="email"
-              value={formData.email}
-              onChange={handleChange}
-              placeholder="Your Email"
-              className="border border-gray-300 rounded-lg p-3 text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
-              required
-            />
-            <textarea
-              name="message"
-              value={formData.message}
-              onChange={handleChange}
-              placeholder="Your Message"
-              rows="4"
-              className="border border-gray-300 rounded-lg p-3 text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
-              required
-            />
-          </div>
-          {error && (
-            <div
-              role="alert"
-              aria-live="polite"
-              className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg"
-            >
-              {error}
-            </div>
-          )}
-          <button
-            type="submit"
-            className="w-full bg-purple-700 hover:bg-purple-600 text-white font-bold py-3 px-4 rounded-lg transition duration-300 ease-in-out flex items-center justify-center"
-            disabled={isLoading}
-          >
-            {isLoading ? (
-              <>
-                <svg
-                  className="animate-spin h-5 w-5 mr-3 text-white"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
+            <h3 className="text-xl font-semibold text-gray-900 mb-6">Send us a message</h3>
+            <form onSubmit={handleSubmit}>
+              <div className="grid grid-cols-1 gap-4 mb-4">
+                <input
+                  type="text"
+                  name="name"
+                  value={formData.name}
+                  onChange={handleChange}
+                  placeholder="Your Name"
+                  className="border border-gray-300 rounded-lg p-3 text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  required
+                />
+                <input
+                  type="email"
+                  name="email"
+                  value={formData.email}
+                  onChange={handleChange}
+                  placeholder="Your Email"
+                  className="border border-gray-300 rounded-lg p-3 text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  required
+                />
+                <textarea
+                  name="message"
+                  value={formData.message}
+                  onChange={handleChange}
+                  placeholder="Your Message"
+                  rows="4"
+                  className="border border-gray-300 rounded-lg p-3 text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  required
+                />
+              </div>
+              {error && (
+                <div
+                  role="alert"
+                  aria-live="polite"
+                  className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg"
                 >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
-                  ></circle>
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                  ></path>
-                </svg>
-                Sending...
-              </>
-            ) : (
-              "Send Message"
-            )}
-          </button>
-          {error && (
-            <p
-              role="alert"
-              aria-live="polite"
-              className="mt-4 text-center text-sm font-medium text-red-600"
-            >
-              {error}
-            </p>
-          )}
-        </form>
+                  {error}
+                </div>
+              )}
+              <button
+                type="submit"
+                className="w-full bg-purple-700 hover:bg-purple-600 text-white font-bold py-3 px-4 rounded-lg transition duration-300 ease-in-out flex items-center justify-center"
+                disabled={isLoading}
+              >
+                {isLoading ? (
+                  <>
+                    <svg
+                      className="animate-spin h-5 w-5 mr-3 text-white"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      ></circle>
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                      ></path>
+                    </svg>
+                    Sending...
+                  </>
+                ) : (
+                  "Send Message"
+                )}
+              </button>
+              {error && (
+                <p
+                  role="alert"
+                  aria-live="polite"
+                  className="mt-4 text-center text-sm font-medium text-red-600"
+                >
+                  {error}
+                </p>
+              )}
+            </form>
           </div>
         </div>
       </div>
@@ -206,10 +193,7 @@ const ContactUs = () => {
       {toast.show && (
         <div className="fixed bottom-5 right-5 bg-gray-800 text-white p-3 rounded shadow-lg transition-transform transform translate-y-0 ease-in-out duration-300">
           {toast.message}
-          <button
-            onClick={() => setToast({ show: false, message: "" })}
-            className="ml-4 text-purple-500"
-          >
+          <button onClick={hideToast} className="ml-4 text-purple-500">
             ✕
           </button>
         </div>

--- a/app/(landingpage)/Hero.jsx
+++ b/app/(landingpage)/Hero.jsx
@@ -3,17 +3,13 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../../lib/AuthContext";
 import Toast from "../../components/Toast";
+import useToast from "../../hooks/useToast";
 import Link from "next/link";
 
 export default function Hero() {
   const { user } = useAuth();
   const router = useRouter();
-  const [toast, setToast] = useState({ show: false, message: "" });
-
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 5000);
-  };
+  const { toast, showToast, hideToast } = useToast(5000);
 
   const handleProtectedLinkClick = (e, path) => {
     if (!user) {
@@ -40,8 +36,8 @@ export default function Hero() {
             Move in style. Pay on Stellar.
           </h1>
           <p className="mova-fade-up-delay-2 mt-4 max-w-xl text-base text-white/85 sm:text-lg">
-            Curated footwear with a checkout that takes cards or USDC — escrowed
-            on-chain until your order ships.
+            Curated footwear with a checkout that takes cards or USDC — escrowed on-chain until your
+            order ships.
           </p>
           <div className="mova-fade-up-delay-2 mt-10 flex flex-wrap items-center justify-center gap-4">
             <Link
@@ -60,11 +56,7 @@ export default function Hero() {
           </div>
         </div>
       </section>
-      <Toast
-        message={toast.message}
-        show={toast.show}
-        onClose={() => setToast({ show: false, message: "" })}
-      />
+      <Toast message={toast.message} show={toast.show} onClose={hideToast} />
     </>
   );
 }

--- a/app/(landingpage)/newsletter.jsx
+++ b/app/(landingpage)/newsletter.jsx
@@ -1,14 +1,11 @@
 import Toast from "../../components/Toast";
+import useToast from "../../hooks/useToast";
 import { useState } from "react";
 import { validateEmail } from "../../lib/validation";
 
 export default function Newsletter() {
-  const [toast, setToast] = useState({ show: false, message: "" });
+  const { toast, showToast, hideToast } = useToast(5000);
   const [email, setEmail] = useState("");
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 5000);
-  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -34,14 +31,10 @@ export default function Newsletter() {
         Stay in the Loop
       </h2>
       <p className="text-lg sm:text-xl text-gray-600 mb-8 text-center max-w-xl">
-        New shoe drops, Stellar integration updates, and insights on crypto
-        commerce — straight to your inbox. No spam, unsubscribe anytime.
+        New shoe drops, Stellar integration updates, and insights on crypto commerce — straight to
+        your inbox. No spam, unsubscribe anytime.
       </p>
-      <form
-        className="w-full max-w-md"
-        onSubmit={handleSubmit}
-        noValidate={true}
-      >
+      <form className="w-full max-w-md" onSubmit={handleSubmit} noValidate={true}>
         <div className="flex items-center border-b border-purple-700 py-2">
           <input
             type="email"
@@ -63,11 +56,7 @@ export default function Newsletter() {
           </button>
         </div>
       </form>
-      <Toast
-        message={toast.message}
-        show={toast.show}
-        onClose={() => setToast({ show: false, message: "" })}
-      />
+      <Toast message={toast.message} show={toast.show} onClose={hideToast} />
     </div>
   );
 }

--- a/app/admin/AddProductForm.jsx
+++ b/app/admin/AddProductForm.jsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import Toast from "../../components/Toast";
+import useToast from "../../hooks/useToast";
 import { createProduct, uploadProductImage } from "../../lib/products";
 
 const AddProductForm = ({ onProductAdded }) => {
@@ -8,12 +9,7 @@ const AddProductForm = ({ onProductAdded }) => {
   const [productPrice, setProductPrice] = useState("");
   const [productImage, setProductImage] = useState(null);
   const [loading, setLoading] = useState(false);
-
-  const [toast, setToast] = useState({ show: false, message: "" });
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 3000);
-  };
+  const { toast, showToast, hideToast } = useToast(3000);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -47,14 +43,10 @@ const AddProductForm = ({ onProductAdded }) => {
 
   return (
     <div className="max-w-2xl mx-auto mt-10 p-8 bg-white rounded-xl shadow-lg border border-purple-500">
-      <h1 className="text-3xl font-bold mb-6 text-center text-purple-500">
-        Add New Product
-      </h1>
+      <h1 className="text-3xl font-bold mb-6 text-center text-purple-500">Add New Product</h1>
       <form onSubmit={handleSubmit}>
         <div className="mb-6">
-          <label className="block text-gray-700 text-lg font-semibold">
-            Product Name
-          </label>
+          <label className="block text-gray-700 text-lg font-semibold">Product Name</label>
           <input
             type="text"
             className="w-full p-3 mt-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
@@ -64,9 +56,7 @@ const AddProductForm = ({ onProductAdded }) => {
           />
         </div>
         <div className="mb-6">
-          <label className="block text-gray-700 text-lg font-semibold">
-            Product Price
-          </label>
+          <label className="block text-gray-700 text-lg font-semibold">Product Price</label>
           <input
             type="number"
             className="w-full p-3 mt-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
@@ -76,9 +66,7 @@ const AddProductForm = ({ onProductAdded }) => {
           />
         </div>
         <div className="mb-6">
-          <label className="block text-gray-700 text-lg font-semibold">
-            Product Image
-          </label>
+          <label className="block text-gray-700 text-lg font-semibold">Product Image</label>
           <input
             type="file"
             accept="image/*"
@@ -97,11 +85,7 @@ const AddProductForm = ({ onProductAdded }) => {
           {loading ? "Adding Product..." : "Add Product"}
         </button>
       </form>
-      <Toast
-        message={toast.message}
-        show={toast.show}
-        onClose={() => setToast({ show: false, message: "" })}
-      />
+      <Toast message={toast.message} show={toast.show} onClose={hideToast} />
     </div>
   );
 };

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect } from "react";
 
 import Toast from "../../components/Toast";
+import useToast from "../../hooks/useToast";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";
 import { MdArrowBack } from "react-icons/md";
 import Link from "next/link";
@@ -35,7 +36,6 @@ import {
 } from "../../lib/validation";
 
 const Checkout = () => {
-
   // OTP is stored as a zero-padded 6-digit string so it always matches the format
   // shown in the email (e.g. "000042") and can be compared with exact string
   // equality instead of a loose numeric parse.
@@ -45,7 +45,7 @@ const Checkout = () => {
   const [totalPrice, setTotalPrice] = useState(0);
   const [cartItems, setCartItems] = useState<any[]>([]);
   const [isLoaded, setIsLoaded] = useState(false);
-  const [toast, setToast] = useState({ show: false, message: "" });
+  const { toast, showToast, hideToast } = useToast(5000);
   const [stage, setStage] = useState(1);
   const [isOtpSending, setIsOtpSending] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -61,19 +61,10 @@ const Checkout = () => {
     subject: "YOUR ORDER CONFIRMATION",
   });
 
-  const showToast = (message: string) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 5000);
-  };
-
-  const [orderId] = useState(() =>
-    `SS-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
-  );
+  const [orderId] = useState(() => `SS-${Date.now()}-${Math.floor(Math.random() * 1e6)}`);
 
   const handleStellarSuccess = (result: { amountUsd: number | string }) => {
-    showToast(
-      `USDC payment received ✓ $${Number(result.amountUsd).toFixed(2)} · order ${orderId}`
-    );
+    showToast(`USDC payment received ✓ $${Number(result.amountUsd).toFixed(2)} · order ${orderId}`);
     setStage(3);
     localStorage.removeItem("cartItems");
     localStorage.removeItem("itemCount");
@@ -103,9 +94,7 @@ const Checkout = () => {
       });
 
       setStage(2);
-      showToast(
-        "Form submitted successfully. OTP has been sent to your email."
-      );
+      showToast("Form submitted successfully. OTP has been sent to your email.");
     } catch (error) {
       setIsSubmitting(false);
       showToast("Failed to send OTP. Please try again.");
@@ -138,7 +127,7 @@ const Checkout = () => {
   const handleGoBack = () => {
     if (stage > 1) {
       setStage(stage - 1);
-      setIsSubmitting(false)
+      setIsSubmitting(false);
     }
   };
 
@@ -174,7 +163,8 @@ const Checkout = () => {
       <div className="container mx-auto px-4 py-16 my-10 max-w-lg text-center bg-white rounded-lg shadow-md border-2 border-purple-300">
         <h2 className="text-2xl font-bold text-gray-800 mb-3">Your cart is empty</h2>
         <p className="text-gray-600 mb-6">
-          Looks like you have not added any items to your cart yet. Please add items to proceed with checkout.
+          Looks like you have not added any items to your cart yet. Please add items to proceed with
+          checkout.
         </p>
         <Link
           href="/shop"
@@ -196,11 +186,7 @@ const Checkout = () => {
         >
           1
         </span>
-        <span
-          className={`w-20 h-1 sm:w-96 ${
-            stage >= 2 ? "bg-purple-700" : "bg-gray-200"
-          }`}
-        ></span>
+        <span className={`w-20 h-1 sm:w-96 ${stage >= 2 ? "bg-purple-700" : "bg-gray-200"}`}></span>
         <span
           className={`flex justify-center items-center w-8 h-8 sm:w-10 sm:h-10 border border-purple-700 rounded-full ${
             stage >= 2 ? "bg-purple-700 text-white" : "bg-white"
@@ -208,11 +194,7 @@ const Checkout = () => {
         >
           2
         </span>
-        <span
-          className={`w-20 h-1 sm:w-96 ${
-            stage >= 3 ? "bg-purple-700" : "bg-gray-200"
-          }`}
-        ></span>
+        <span className={`w-20 h-1 sm:w-96 ${stage >= 3 ? "bg-purple-700" : "bg-gray-200"}`}></span>
         <span
           className={`flex justify-center items-center w-8 h-8 sm:w-10 sm:h-10 border border-purple-700 rounded-full ${
             stage >= 3 ? "bg-purple-700 text-white" : "bg-white"
@@ -239,10 +221,7 @@ const Checkout = () => {
           </div>
           <div className="w-full md:w-1/2 px-4 p-4 rounded-md">
             {stage === 1 && (
-              <form
-                onSubmit={handleSubmit}
-                className="bg-white p-4 rounded shadow-md"
-              >
+              <form onSubmit={handleSubmit} className="bg-white p-4 rounded shadow-md">
                 <h2 className="text-2xl mb-4 text-center">Checkout</h2>
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                   <div className="mb-4">
@@ -325,7 +304,11 @@ const Checkout = () => {
                         onChange={(e) => {
                           let { value } = e.target;
                           value = value.replace(/[^0-9/]/g, "");
-                          if (value.length === 2 && !value.includes("/") && formData.expiryDate.length === 1) {
+                          if (
+                            value.length === 2 &&
+                            !value.includes("/") &&
+                            formData.expiryDate.length === 1
+                          ) {
                             value = value + "/";
                           }
                           if (value.length > 5) {
@@ -407,9 +390,9 @@ const Checkout = () => {
                 />
                 <StellarOrderWatch orderId={orderId} enabled={stage === 1} />
                 <p className="text-[11px] text-gray-400 text-center">
-                  Order #{orderId} · USDC (testnet) is escrowed by a Soroban smart
-                  contract until we ship, then released to our merchant wallet. Refunds
-                  go straight back on-chain. No card needed.
+                  Order #{orderId} · USDC (testnet) is escrowed by a Soroban smart contract until we
+                  ship, then released to our merchant wallet. Refunds go straight back on-chain. No
+                  card needed.
                 </p>
               </div>
             )}
@@ -421,9 +404,7 @@ const Checkout = () => {
                 <h2 className="text-2xl mb-4 text-center">Confirm OTP</h2>
                 <span className="text-md">An OTP was sent to your email</span>
                 <div className="mb-4">
-                  <label className="block text-gray-700">
-                    Please confirm OTP
-                  </label>
+                  <label className="block text-gray-700">Please confirm OTP</label>
                   <input
                     type="text"
                     name="otpConfirmation"
@@ -464,12 +445,8 @@ const Checkout = () => {
             {stage === 3 && (
               <div className="bg-white p-4 rounded shadow-md h-full flex flex-col justify-center items-center">
                 <h2 className="text-6xl mb-4 text-center">Order Completed.</h2>
-                <p className="text-center">
-                  Your order has been placed successfully.
-                </p>
-                <span className="text-center">
-                  Thanks for Shopping with us 🥰🥰🥰
-                </span>
+                <p className="text-center">Your order has been placed successfully.</p>
+                <span className="text-center">Thanks for Shopping with us 🥰🥰🥰</span>
                 <Link
                   href="/shop"
                   className="text-center mt-8 py-2 bg-purple-700 hover:bg-purple-500 rounded-md px-2"
@@ -481,12 +458,7 @@ const Checkout = () => {
           </div>
         </div>
       </div>
-      <Toast
-        message={toast.message}
-        show={toast.show}
-        onClose={() => setToast({ show: false, message: "" })}
-        time={4000}
-      />
+      <Toast message={toast.message} show={toast.show} onClose={hideToast} time={4000} />
     </>
   );
 };

--- a/app/profile/login/page.jsx
+++ b/app/profile/login/page.jsx
@@ -4,13 +4,14 @@ import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import { login, loginWithGoogle, signup } from "../../../lib/auth";
 import Toast from "../../../components/Toast";
+import useToast from "../../../hooks/useToast";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";
 import { FcGoogle } from "react-icons/fc";
 import { FaRegEye, FaRegEyeSlash } from "react-icons/fa";
 import img from "../../../public/images/welcome-mova.png";
 
 const AuthPage = () => {
-  const [toast, setToast] = useState({ show: false, message: "" });
+  const { toast, showToast, hideToast } = useToast(3000);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -20,11 +21,6 @@ const AuthPage = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [isLoginMode, setIsLoginMode] = useState(true);
-
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 3000);
-  };
 
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -244,11 +240,7 @@ const AuthPage = () => {
           </div>
         </div>
       </div>
-      <Toast
-        message={toast.message}
-        show={toast.show}
-        onClose={() => setToast({ show: false, message: "" })}
-      />
+      <Toast message={toast.message} show={toast.show} onClose={hideToast} />
     </section>
   );
 };

--- a/app/shop/[id]/page.jsx
+++ b/app/shop/[id]/page.jsx
@@ -6,17 +6,17 @@ import { useCart } from "../../../context/CartContext";
 import Modal from "../../../components/Modal";
 import Toast from "../../../components/Toast";
 import Cart from "../../../components/Cart";
+import useToast from "../../../hooks/useToast";
 import { getProductById } from "../../../lib/products";
 import LoadingSpinner from "../../../components/LoadingSpinner";
 
 const ProductPage = ({ params }) => {
-  const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } =
-    useCart();
+  const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } = useCart();
+  const { toast, showToast, hideToast } = useToast(3000);
   const [product, setProduct] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [showModal, setShowModal] = useState(false);
-  const [toast, setToast] = useState({ show: false, message: "" });
   const { id } = params;
 
   useEffect(() => {
@@ -39,11 +39,6 @@ const ProductPage = ({ params }) => {
       fetchProduct();
     }
   }, [id]);
-
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 3000);
-  };
 
   const handleCheckout = () => {
     if (cartItems.length > 0) {
@@ -70,12 +65,7 @@ const ProductPage = ({ params }) => {
         {!loading && !error && product && (
           <>
             <h1 className="text-4xl font-bold mb-4">{product.name}</h1>
-            <Image
-              src={product.img}
-              alt={product.name}
-              width={400}
-              height={400}
-            />
+            <Image src={product.img} alt={product.name} width={400} height={400} />
             <div className="flex space-x-4 items-center my-4">
               <h2 className="text-4xl">${product.price}</h2>
               <button
@@ -92,11 +82,7 @@ const ProductPage = ({ params }) => {
         )}
       </div>
 
-      <Toast
-        message={toast.message}
-        show={toast.show}
-        onClose={() => setToast({ show: false, message: "" })}
-      />
+      <Toast message={toast.message} show={toast.show} onClose={hideToast} />
       <Modal show={showModal} onClose={closeModal}>
         <h2 className="text-2xl mb-4">Cart Items</h2>
         {cartItems.length === 0 ? (
@@ -104,10 +90,7 @@ const ProductPage = ({ params }) => {
         ) : (
           <div>
             {cartItems.map((item) => (
-              <div
-                key={item.id}
-                className="flex justify-between items-center mb-2"
-              >
+              <div key={item.id} className="flex justify-between items-center mb-2">
                 <div className="w-16 h-16 flex-shrink-0">
                   <Image
                     src={item.img}
@@ -132,11 +115,7 @@ const ProductPage = ({ params }) => {
         <div className="flex justify-between items-center mt-4 mx-5 sm:mx-10">
           <div>
             {cartItems.length > 0 && <strong>Total:</strong>}
-            {totalPrice ? (
-              <span className="ml-2 font-bold ">${totalPrice.toFixed(2)}</span>
-            ) : (
-              ""
-            )}
+            {totalPrice ? <span className="ml-2 font-bold ">${totalPrice.toFixed(2)}</span> : ""}
           </div>
           {cartItems.length > 0 && (
             <button

--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -7,13 +7,13 @@ import { FaShoppingCart } from "react-icons/fa";
 import Cart from "../../components/Cart";
 import Modal from "../../components/Modal";
 import Toast from "../../components/Toast";
+import useToast from "../../hooks/useToast";
 import { listProducts } from "../../lib/products";
 
 export default function Products() {
-  const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } =
-    useCart();
+  const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } = useCart();
+  const { toast, showToast, hideToast } = useToast(3000);
   const [showModal, setShowModal] = useState(false);
-  const [toast, setToast] = useState({ show: false, message: "" });
   const [isCheckingOut, setIsCheckingOut] = useState(false);
   const [products, setProducts] = useState([]);
   const [error, setError] = useState(null);
@@ -30,11 +30,6 @@ export default function Products() {
 
     fetchProducts();
   }, []);
-
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 3000);
-  };
 
   const handleCheckout = (e) => {
     setIsCheckingOut(true);
@@ -89,11 +84,7 @@ export default function Products() {
         </section>
       </div>
 
-      <Toast
-        message={toast.message}
-        show={toast.show}
-        onClose={() => setToast({ show: false, message: "" })}
-      />
+      <Toast message={toast.message} show={toast.show} onClose={hideToast} />
       <Modal show={showModal} onClose={closeModal}>
         <h2 className="text-2xl mb-4">Cart Items</h2>
         {cartItems.length === 0 ? (
@@ -101,10 +92,7 @@ export default function Products() {
         ) : (
           <div>
             {cartItems.map((item) => (
-              <div
-                key={item.id}
-                className="flex justify-between items-center mb-2"
-              >
+              <div key={item.id} className="flex justify-between items-center mb-2">
                 <div className="w-16 h-16 flex-shrink-0">
                   <Image
                     src={item.img} // Ensure this URL is correct
@@ -129,11 +117,7 @@ export default function Products() {
         <div className="flex justify-between items-center mt-4 mx-5 sm:mx-10">
           <div>
             {cartItems.length > 0 && <strong>Total:</strong>}
-            {totalPrice ? (
-              <span className="ml-2 font-bold ">${totalPrice.toFixed(2)}</span>
-            ) : (
-              ""
-            )}
+            {totalPrice ? <span className="ml-2 font-bold ">${totalPrice.toFixed(2)}</span> : ""}
           </div>
           {cartItems.length > 0 && (
             <button

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -6,6 +6,7 @@ import { AiOutlineMenu, AiOutlineClose } from "react-icons/ai";
 import { useAuth } from "../lib/AuthContext";
 import { logout } from "../lib/auth";
 import Toast from "../components/Toast";
+import useToast from "../hooks/useToast";
 import { useRouter } from "next/navigation";
 import { TfiAngleRight } from "react-icons/tfi";
 
@@ -47,16 +48,10 @@ function Navbar() {
     links.forEach((link) => link.addEventListener("click", handleLinkClick));
 
     return () => {
-      links.forEach((link) =>
-        link.removeEventListener("click", handleLinkClick)
-      );
+      links.forEach((link) => link.removeEventListener("click", handleLinkClick));
     };
   }, [router]);
-  const [toast, setToast] = useState({ show: false, message: "" });
-  const showToast = (message) => {
-    setToast({ show: true, message });
-    setTimeout(() => setToast({ show: false, message: "" }), 3000);
-  };
+  const { toast, showToast, hideToast } = useToast(3000);
 
   const [showNav, setShowNav] = useState(false);
   const { user } = useAuth();
@@ -138,9 +133,7 @@ function Navbar() {
                   ) : (
                     <div className="h-8 w-8 rounded-full bg-mova-mist" />
                   )}
-                  <span className="text-md font-medium text-mova-ink">
-                    {user.displayName}
-                  </span>
+                  <span className="text-md font-medium text-mova-ink">{user.displayName}</span>
                 </div>
                 <button
                   onClick={handleLogout}
@@ -222,9 +215,7 @@ function Navbar() {
                     ) : (
                       <div className="h-8 w-8 rounded-full bg-mova-mist" />
                     )}
-                    <span className="text-sm font-medium text-mova-ink">
-                      {user.displayName}
-                    </span>
+                    <span className="text-sm font-medium text-mova-ink">{user.displayName}</span>
                   </div>
                   <button
                     onClick={() => {
@@ -254,11 +245,7 @@ function Navbar() {
           </div>
         )}
 
-        <Toast
-          message={toast.message}
-          show={toast.show}
-          onClose={() => setToast({ show: false, message: "" })}
-        />
+        <Toast message={toast.message} show={toast.show} onClose={hideToast} />
       </nav>
     </>
   );

--- a/hooks/useToast.js
+++ b/hooks/useToast.js
@@ -1,0 +1,62 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Shared toast hook for managing toast notification state and dismiss timing.
+ * Cleans up pending dismiss timers on unmount to prevent state updates on unmounted components.
+ *
+ * @param {number} [autoHideMs=3000] - Duration in milliseconds before auto-dismissing.
+ * @returns {{
+ *   toast: { show: boolean, message: string },
+ *   showToast: (message: string) => void,
+ *   hideToast: () => void,
+ *   setToast: React.Dispatch<React.SetStateAction<{ show: boolean, message: string }>>
+ * }}
+ */
+export function useToast(autoHideMs = 3000) {
+  const [toast, setToast] = useState({ show: false, message: "" });
+  const timerRef = useRef(null);
+
+  const hideToast = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setToast({ show: false, message: "" });
+  }, []);
+
+  const showToast = useCallback(
+    (message) => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+      setToast({ show: true, message });
+      if (autoHideMs && autoHideMs > 0) {
+        timerRef.current = setTimeout(() => {
+          timerRef.current = null;
+          setToast({ show: false, message: "" });
+        }, autoHideMs);
+      }
+    },
+    [autoHideMs]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, []);
+
+  return {
+    toast,
+    showToast,
+    hideToast,
+    setToast,
+  };
+}
+
+export default useToast;

--- a/tests/hooks/useToast.test.jsx
+++ b/tests/hooks/useToast.test.jsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useToast } from "../../hooks/useToast";
+
+describe("useToast hook (Issue #31)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("initializes with toast hidden and empty message", () => {
+    const { result } = renderHook(() => useToast());
+    expect(result.current.toast).toEqual({ show: false, message: "" });
+  });
+
+  it("shows toast with provided message and auto-hides after specified delay", () => {
+    const { result } = renderHook(() => useToast(3000));
+
+    act(() => {
+      result.current.showToast("Item added successfully");
+    });
+
+    expect(result.current.toast).toEqual({
+      show: true,
+      message: "Item added successfully",
+    });
+
+    // Advance halfway: toast still visible
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(result.current.toast.show).toBe(true);
+
+    // Advance remaining time: toast auto-hides
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(result.current.toast).toEqual({ show: false, message: "" });
+  });
+
+  it("hideToast immediately dismisses toast and cancels pending auto-hide timer", () => {
+    const { result } = renderHook(() => useToast(3000));
+
+    act(() => {
+      result.current.showToast("Temporary alert");
+    });
+    expect(result.current.toast.show).toBe(true);
+
+    act(() => {
+      result.current.hideToast();
+    });
+    expect(result.current.toast).toEqual({ show: false, message: "" });
+
+    // Advancing timers should not cause any issues
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(result.current.toast.show).toBe(false);
+  });
+
+  it("consecutive showToast calls reset the auto-hide timer with the latest message", () => {
+    const { result } = renderHook(() => useToast(3000));
+
+    act(() => {
+      result.current.showToast("First message");
+    });
+    expect(result.current.toast.message).toBe("First message");
+
+    // Advance 2 seconds
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // Fire second toast
+    act(() => {
+      result.current.showToast("Second message");
+    });
+    expect(result.current.toast).toEqual({
+      show: true,
+      message: "Second message",
+    });
+
+    // Advance another 2 seconds (4 seconds total since first toast, 2s since second)
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    // Second toast must still be visible!
+    expect(result.current.toast.show).toBe(true);
+    expect(result.current.toast.message).toBe("Second message");
+
+    // Advance remaining 1 second
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.toast.show).toBe(false);
+  });
+
+  it("cleans up pending timer on unmount to prevent state updates on unmounted component", () => {
+    const { result, unmount } = renderHook(() => useToast(5000));
+
+    act(() => {
+      result.current.showToast("Unmount test");
+    });
+    expect(result.current.toast.show).toBe(true);
+
+    // Unmount before timer finishes
+    unmount();
+
+    // Fast-forward time past the 5s timer
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(6000);
+      });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
### Overview
Closes #31

### Problem
The identical `showToast` pattern (`setToast` plus a raw `setTimeout` of 3–5 seconds that is never cancelled) was copy-pasted across 9 client files:
- `components/Navbar.jsx`
- `app/(landingpage)/Hero.jsx`
- `app/(landingpage)/newsletter.jsx`
- `app/(landingpage)/ContactUs.jsx`
- `app/shop/page.jsx`
- `app/shop/[id]/page.jsx`
- `app/admin/AddProductForm.jsx`
- `app/profile/login/page.jsx`
- `app/checkout/page.tsx`

Because these timers were never cleared when components unmounted, unmounting while a toast was active risked React state-update warnings on unmounted components. Furthermore, `components/Toast.jsx` already manages self-dismissal via its `time` prop, creating conflicting redundant timers.

### Changes
1. **Shared `useToast` Hook (`hooks/useToast.js`)**:
   - Created a clean, reusable `useToast(autoHideMs = 3000)` hook returning `{ toast, showToast, hideToast, setToast }`.
   - Safely cleans up pending timers on unmount using `useEffect` cleanup to prevent unmounted component state updates.
   - Clears and resets pending timers on consecutive toast triggers.
2. **Refactored All 9 Client Files**:
   - Replaced duplicate `useState` and `setTimeout` toast implementations across all 9 listed files with `useToast`.
   - Wired `onClose` callbacks to `hideToast`.
   - Confirmed 0 occurrences of `setTimeout(() => setToast` remain in the repository.
3. **Unit Tests (`tests/hooks/useToast.test.jsx`)**:
   - Verified initial state, auto-hide delay with fake timers, immediate dismissal via `hideToast`, consecutive toast timer resets, and unmount timer cleanup.

### Acceptance Criteria Verification
- [x] `rg` for `'setTimeout(() => setToast'` no longer matches the listed files (0 matches across repo).
- [x] Unmounting a page within the toast window produces no React state-update warning.
- [x] All tests, type-check, prettier check, and `next lint` pass with 0 errors (verified 2x).
