### PR TITLE
ci(contracts): add cargo fmt and clippy steps to contracts CI job (closes #52)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
   # Soroban contract checks
   contracts:
-    name: Soroban Contracts (Build, Test)
+    name: Soroban Contracts (Fmt, Clippy, Build, Test)
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -72,6 +72,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: wasm32v1-none
+          components: rustfmt, clippy
 
       - name: Cache Cargo
         uses: actions/cache@v4
@@ -86,6 +87,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-
             ${{ runner.os }}-cargo-
+
+      - name: Check Rust formatting
+        working-directory: contracts/checkout
+        run: cargo fmt -- --check
+
+      - name: Run Clippy
+        working-directory: contracts/checkout
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Build contracts
         working-directory: contracts/checkout

--- a/contracts/checkout/src/lib.rs
+++ b/contracts/checkout/src/lib.rs
@@ -163,7 +163,7 @@ impl Checkout {
         // transfer is derived from this invocation (it holds the funds).
         token_client.transfer(
             &buyer,
-            &MuxedAddress::from(&env.current_contract_address()),
+            MuxedAddress::from(&env.current_contract_address()),
             &amount,
         );
 
@@ -207,7 +207,7 @@ impl Checkout {
         // Release: contract -> merchant.
         token_client.transfer(
             &env.current_contract_address(),
-            &MuxedAddress::from(&merchant),
+            MuxedAddress::from(&merchant),
             &order.amount,
         );
 
@@ -249,7 +249,7 @@ impl Checkout {
         // Refund: contract -> buyer.
         token_client.transfer(
             &env.current_contract_address(),
-            &MuxedAddress::from(&order.buyer),
+            MuxedAddress::from(&order.buyer),
             &order.amount,
         );
 

--- a/contracts/checkout/src/storage.rs
+++ b/contracts/checkout/src/storage.rs
@@ -38,7 +38,10 @@ pub fn set_admin(env: &Env, admin: &Address) {
 }
 
 pub fn get_order(env: &Env, order_id: &BytesN<32>) -> Option<Order> {
-    let order: Option<Order> = env.storage().persistent().get(&DataKey::Order(order_id.clone()));
+    let order: Option<Order> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Order(order_id.clone()));
     if order.is_some() {
         extend_ttl(env, &DataKey::Order(order_id.clone()));
     }
@@ -46,7 +49,9 @@ pub fn get_order(env: &Env, order_id: &BytesN<32>) -> Option<Order> {
 }
 
 pub fn set_order(env: &Env, order_id: &BytesN<32>, order: &Order) {
-    env.storage().persistent().set(&DataKey::Order(order_id.clone()), order);
+    env.storage()
+        .persistent()
+        .set(&DataKey::Order(order_id.clone()), order);
     extend_ttl(env, &DataKey::Order(order_id.clone()));
 }
 


### PR DESCRIPTION
### Summary of Changes (Closes #52)

This PR resolves Issue #52 by adding `cargo fmt` and `cargo clippy` enforcement steps to the Soroban `contracts` job in `.github/workflows/ci.yml`, matching CONTRIBUTING.md guidelines.

### Changes Included:
1. **CI Workflow (`.github/workflows/ci.yml`)**:
   - Added `components: rustfmt, clippy` to `dtolnay/rust-toolchain` setup in the `contracts` job.
   - Added `Check Rust formatting` step: `cargo fmt -- --check`.
   - Added `Run Clippy` step: `cargo clippy --all-targets -- -D warnings`.
   - Updated job display name to `Soroban Contracts (Fmt, Clippy, Build, Test)`.

2. **Contract Formatting & Lint Fixes**:
   - Formatted `contracts/checkout/src/storage.rs` using `cargo fmt` to adhere to formatting standards.
   - Updated `contracts/checkout/src/lib.rs` to pass `MuxedAddress` without redundant borrows (`needless_borrows_for_generic_args`), ensuring `cargo clippy --all-targets -- -D warnings` exits 0 cleanly.

### Acceptance Criteria Passed
- [x] `.github/workflows/ci.yml` contains both `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings` steps
- [x] In `contracts/checkout`, `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings` both exit 0 cleanly
- [x] `cargo test` passes all 19 unit tests with 0 failures
- [x] `cargo build --release --target wasm32v1-none` builds successfully
