### PR TITLE
fix(sidebar): remove inert search input and unused modal (closes #79)

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -1,37 +1,23 @@
 "use client";
-import { useState } from "react";
 import Link from "next/link";
 import {
   FaHome,
   FaInfoCircle,
   FaPhone,
   FaShoppingCart,
-  FaRunning,
   FaList,
-  FaSearch,
 } from "react-icons/fa";
-import { FaShoePrints } from "react-icons/fa6";
 import { FcSportsMode } from "react-icons/fc";
 import { useAuth } from "../lib/AuthContext";
-import Modal from "../components/Modal";
+
 export default function Sidebar() {
-  const { user, isAdmin } = useAuth();
-  const [showModal, setShowModal] = useState(false);
-  const openModal = () => setShowModal(true);
-  const closeModal = () => setShowModal(false);
-  
+  const { isAdmin } = useAuth();
+
   return (
     <>
       <aside className="w-64 bg-white text-gray-700 flex-shrink-0  hidden sm:block pt-10">
         <nav className="divide-y divide-gray-200">
           <ul className="px-5 py-6 space-y-2">
-            <li onClick={openModal}>
-              <input
-                type="text"
-                className="w-full bg-gray-100 rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent placeholder-gray-500"
-                placeholder="Search Shoes"
-              />
-            </li>
             <li>
               <Link
                 href="/"
@@ -108,9 +94,6 @@ export default function Sidebar() {
       <aside className="flex flex-col justify-center  w-10 bg-purple-600 text-gray-700 flex-shrink-0  sm:hidden  pt-10">
         <nav className="divide-y divide-gray-200">
           <ul className="py-6 space-y-14 px-2">
-            <li className=" hover:text-white transition-colors duration-200">
-              <FaSearch size={20} className="mr-3" />
-            </li>
             <li>
               <Link
                 href="/categories"
@@ -159,13 +142,6 @@ export default function Sidebar() {
           </ul>
         </nav>
       </aside>
-      <Modal show={showModal} onClose={closeModal}>
-        <input
-          type="text"
-          className="w-full bg-gray-100 rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent placeholder-gray-500"
-          placeholder="Search Shoes"
-        />
-      </Modal>
     </>
   );
 }

--- a/tests/components/Sidebar.test.tsx
+++ b/tests/components/Sidebar.test.tsx
@@ -60,4 +60,18 @@ describe("Sidebar component", () => {
     const adminLinks = screen.queryAllByRole("link", { name: /admin/i });
     expect(adminLinks.length).toBe(0);
   });
+
+  it("does not render inert search input or search modal", () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAdmin: false,
+      loading: false,
+    });
+
+    render(<Sidebar />);
+
+    expect(screen.queryByPlaceholderText("Search Shoes")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+  });
 });
+


### PR DESCRIPTION
### Summary of Changes (Closes #79)

This PR resolves Issue #79 by removing the inert, non-functional desktop search input, mobile search icon, and unused modal in `components/Sidebar.jsx`.

### Changes Included:
1. **Removed Inert Search Elements from `components/Sidebar.jsx`**:
   - Removed the desktop search `<input placeholder="Search Shoes" />` wrapped in `<li onClick={openModal}>` that immediately opened an empty modal on focus/click.
   - Removed the unused `<Modal show={showModal} onClose={closeModal}>` containing a duplicate disconnected input.
   - Removed the mobile `<FaSearch />` icon.
   - Cleaned up unused state (`showModal`, `openModal`, `closeModal`) and unused icon imports.

2. **Test Suite**:
   - Added unit test in `tests/components/Sidebar.test.tsx` ensuring that neither the inert search input nor the unused modal are rendered in `Sidebar`.

### Acceptance Criteria Passed
- [x] Focusing the input no longer opens a duplicate modal (inert elements removed cleanly)
- [x] No dead search placeholder remains in `Sidebar`
- [x] `npm run lint` (`next lint`) passes with 0 errors
- [x] `npm run type-check` (`tsc --noEmit --skipLibCheck`) passes cleanly
- [x] Unit tests pass (4/4 in `Sidebar.test.tsx`)
