### PR TITLE
fix(sidebar): point sidebar links at real routes and align labels (closes #25)

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -4,13 +4,10 @@ import Link from "next/link";
 import {
   FaHome,
   FaInfoCircle,
-  FaPhone,
   FaShoppingCart,
-  FaRunning,
   FaList,
   FaSearch,
 } from "react-icons/fa";
-import { FaShoePrints } from "react-icons/fa6";
 import { FcSportsMode } from "react-icons/fc";
 import { useAuth } from "../lib/AuthContext";
 import Modal from "../components/Modal";
@@ -38,25 +35,7 @@ export default function Sidebar() {
                 className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
               >
                 <FaHome className="mr-3" />
-                Men
-              </Link>
-            </li>
-            <li>
-              <Link
-                href="/about"
-                className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
-              >
-                <FaInfoCircle className="mr-3" />
-                Women
-              </Link>
-            </li>
-            <li>
-              <Link
-                href="/contact"
-                className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
-              >
-                <FaPhone className="mr-3" />
-                Kids
+                Home
               </Link>
             </li>
             <li>
@@ -65,7 +44,7 @@ export default function Sidebar() {
                 className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
               >
                 <FaShoppingCart className="mr-3" />
-                Casual
+                Shop
               </Link>
             </li>
             <li>
@@ -74,7 +53,16 @@ export default function Sidebar() {
                 className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
               >
                 <FcSportsMode className="mr-3" />
-                Sport
+                Collections
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/blog"
+                className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
+              >
+                <FaList className="mr-3" />
+                Blog
               </Link>
             </li>
             <li>
@@ -90,15 +78,6 @@ export default function Sidebar() {
                 ""
               )}
             </li>
-            <li>
-              <Link
-                href="/categories"
-                className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
-              >
-                <FaList className="mr-3" />
-                Categories
-              </Link>
-            </li>
           </ul>
         </nav>
       </aside>
@@ -113,26 +92,38 @@ export default function Sidebar() {
             </li>
             <li>
               <Link
-                href="/categories"
+                href="/"
                 className=" hover:text-white transition-colors duration-200"
+                title="Home"
               >
-                <FaList className="mr-3" size={20} />
+                <FaHome className="mr-3" size={20} />
               </Link>
             </li>
             <li>
               <Link
                 href="/shop"
                 className="  hover:text-white transition-colors duration-200"
+                title="Shop"
               >
                 <FaShoppingCart className="mr-3" size={20} />
               </Link>
             </li>
             <li>
               <Link
-                href="/"
-                className=" hover:text-white transition-colors duration-200"
+                href="/collections"
+                className="hover:text-purple-500 transition-colors duration-200"
+                title="Collections"
               >
-                <FaHome className="mr-3" size={20} />
+                <FcSportsMode className="mr-3" size={20} />
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/blog"
+                className=" hover:text-white transition-colors duration-200"
+                title="Blog"
+              >
+                <FaList className="mr-3" size={20} />
               </Link>
             </li>
             <li>
@@ -140,6 +131,7 @@ export default function Sidebar() {
                 <Link
                   href="/admin"
                   className=" hover:text-white transition-colors duration-200"
+                  title="Admin"
                 >
                   <FaInfoCircle className="mr-3" size={20} />
                   Admin
@@ -147,14 +139,6 @@ export default function Sidebar() {
               ) : (
                 ""
               )}
-            </li>
-            <li>
-              <Link
-                href="/collections"
-                className="hover:text-purple-500 transition-colors duration-200"
-              >
-                <FcSportsMode className="mr-3" size={20} />
-              </Link>
             </li>
           </ul>
         </nav>

--- a/tests/components/Sidebar.test.tsx
+++ b/tests/components/Sidebar.test.tsx
@@ -60,4 +60,56 @@ describe("Sidebar component", () => {
     const adminLinks = screen.queryAllByRole("link", { name: /admin/i });
     expect(adminLinks.length).toBe(0);
   });
+
+  it("only links to real routes and does not contain broken links to /about, /contact, or /categories", () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAdmin: false,
+      loading: false,
+    });
+
+    const { container } = render(<Sidebar />);
+    const links = Array.from(container.querySelectorAll("a")).map((a) =>
+      a.getAttribute("href")
+    );
+
+    const brokenRoutes = ["/about", "/contact", "/categories"];
+    brokenRoutes.forEach((route) => {
+      expect(links).not.toContain(route);
+    });
+
+    const validRoutes = ["/", "/shop", "/collections", "/blog"];
+    links.forEach((href) => {
+      expect(validRoutes).toContain(href);
+    });
+  });
+
+  it("matches entry labels to their corresponding destinations", () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAdmin: false,
+      loading: false,
+    });
+
+    render(<Sidebar />);
+
+    const homeLinks = screen.getAllByRole("link", { name: "Home" });
+    expect(homeLinks.length).toBeGreaterThan(0);
+    homeLinks.forEach((link) => expect(link).toHaveAttribute("href", "/"));
+
+    const shopLinks = screen.getAllByRole("link", { name: "Shop" });
+    expect(shopLinks.length).toBeGreaterThan(0);
+    shopLinks.forEach((link) => expect(link).toHaveAttribute("href", "/shop"));
+
+    const collectionLinks = screen.getAllByRole("link", { name: "Collections" });
+    expect(collectionLinks.length).toBeGreaterThan(0);
+    collectionLinks.forEach((link) =>
+      expect(link).toHaveAttribute("href", "/collections")
+    );
+
+    const blogLinks = screen.getAllByRole("link", { name: "Blog" });
+    expect(blogLinks.length).toBeGreaterThan(0);
+    blogLinks.forEach((link) => expect(link).toHaveAttribute("href", "/blog"));
+  });
 });
+


### PR DESCRIPTION
### Summary of Changes (Closes #25)

#### 1. Dead & Broken Route Removal
- Removed non-existent routes that were causing 404 errors:
  - `/about` (previously mislabeled as "Women")
  - `/contact` (previously mislabeled as "Kids")
  - `/categories` (desktop and mobile sidebar entries)

#### 2. Valid Route Mapping & Label Alignment
- Aligned sidebar navigation with existing application routes:
  - **Home**: points to `/`
  - **Shop**: points to `/shop`
  - **Collections**: points to `/collections`
  - **Blog**: points to `/blog`
  - **Admin**: points to `/admin` (visible only when `isAdmin` is true)
- Synchronized mobile sidebar icon navigation to match the same valid route table.

#### 3. Verification & Tests
- Added unit tests in `tests/components/Sidebar.test.tsx`:
  - Asserted that broken routes (`/about`, `/contact`, `/categories`) are not present in rendered links.
  - Asserted all sidebar links point only to valid app routes.
  - Asserted each label (`Home`, `Shop`, `Collections`, `Blog`) correctly matches its destination route.
- Verified 2x passes:
  - `npm run lint` passes cleanly (0 errors).
  - `npm run type-check` (`tsc --noEmit --skipLibCheck`) passes cleanly.
  - `npx vitest run tests/components/Sidebar.test.tsx` (5/5 tests pass).
