### PR TITLE
test(contracts): assert exact topics and data for lifecycle events (closes #91)

### DIFF
--- a/contracts/checkout/src/events.rs
+++ b/contracts/checkout/src/events.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{contractevent, Address, BytesN};
 ///
 /// Topics: `pay`, token, buyer, merchant, order_id
 /// Data:   `{ amount }` (i128, raw token units)
-#[contractevent]
+#[contractevent(topics = ["pay"])]
 pub struct PaymentReceived {
     /// The SEP-41 token contract used for the payment.
     #[topic]
@@ -26,7 +26,7 @@ pub struct PaymentReceived {
 ///
 /// Topics: `create_order`, token, buyer, order_id
 /// Data:   `{ amount, timestamp }`
-#[contractevent]
+#[contractevent(topics = ["create_order"])]
 pub struct OrderCreated {
     /// The SEP-41 token the buyer intends to pay with.
     #[topic]
@@ -47,7 +47,7 @@ pub struct OrderCreated {
 ///
 /// Topics: `dispatch`, order_id, merchant
 /// Data:   `{ amount }`
-#[contractevent]
+#[contractevent(topics = ["dispatch"])]
 pub struct OrderShipped {
     /// The 32-byte order id that was dispatched.
     #[topic]
@@ -63,7 +63,7 @@ pub struct OrderShipped {
 ///
 /// Topics: `refund`, order_id, buyer
 /// Data:   `{ amount }`
-#[contractevent]
+#[contractevent(topics = ["refund"])]
 pub struct OrderRefunded {
     /// The 32-byte order id that was refunded.
     #[topic]

--- a/contracts/checkout/src/lib.rs
+++ b/contracts/checkout/src/lib.rs
@@ -163,7 +163,7 @@ impl Checkout {
         // transfer is derived from this invocation (it holds the funds).
         token_client.transfer(
             &buyer,
-            &MuxedAddress::from(&env.current_contract_address()),
+            MuxedAddress::from(&env.current_contract_address()),
             &amount,
         );
 
@@ -207,7 +207,7 @@ impl Checkout {
         // Release: contract -> merchant.
         token_client.transfer(
             &env.current_contract_address(),
-            &MuxedAddress::from(&merchant),
+            MuxedAddress::from(&merchant),
             &order.amount,
         );
 
@@ -249,7 +249,7 @@ impl Checkout {
         // Refund: contract -> buyer.
         token_client.transfer(
             &env.current_contract_address(),
-            &MuxedAddress::from(&order.buyer),
+            MuxedAddress::from(&order.buyer),
             &order.amount,
         );
 

--- a/contracts/checkout/src/storage.rs
+++ b/contracts/checkout/src/storage.rs
@@ -38,7 +38,10 @@ pub fn set_admin(env: &Env, admin: &Address) {
 }
 
 pub fn get_order(env: &Env, order_id: &BytesN<32>) -> Option<Order> {
-    let order: Option<Order> = env.storage().persistent().get(&DataKey::Order(order_id.clone()));
+    let order: Option<Order> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Order(order_id.clone()));
     if order.is_some() {
         extend_ttl(env, &DataKey::Order(order_id.clone()));
     }
@@ -46,7 +49,9 @@ pub fn get_order(env: &Env, order_id: &BytesN<32>) -> Option<Order> {
 }
 
 pub fn set_order(env: &Env, order_id: &BytesN<32>, order: &Order) {
-    env.storage().persistent().set(&DataKey::Order(order_id.clone()), order);
+    env.storage()
+        .persistent()
+        .set(&DataKey::Order(order_id.clone()), order);
     extend_ttl(env, &DataKey::Order(order_id.clone()));
 }
 

--- a/contracts/checkout/src/test.rs
+++ b/contracts/checkout/src/test.rs
@@ -434,20 +434,167 @@ fn test_set_merchant_changes_escrow_destination() {
 
 #[test]
 fn test_events_emitted() {
+    extern crate std;
+    use crate::events::{OrderCreated, OrderShipped, PaymentReceived};
+    use soroban_sdk::Event;
+    use soroban_sdk::FromVal;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, token, merchant, buyer, checkout) = setup_usdc(&env);
+    let id = order_id(&env, 5);
+
+    // 1. Order creation step
+    client.create_order(&buyer, &id, &token, &10_000);
+    let create_events = env.events().all().filter_by_contract(&checkout);
+    let expected_create = OrderCreated {
+        token: token.clone(),
+        buyer: buyer.clone(),
+        order_id: id.clone(),
+        amount: 10_000,
+        timestamp: env.ledger().timestamp(),
+    };
+    assert_eq!(
+        create_events,
+        std::vec![expected_create.to_xdr(&env, &checkout)]
+    );
+    let raw_create = create_events.events();
+    assert_eq!(raw_create.len(), 1);
+    match &raw_create[0].body {
+        soroban_sdk::xdr::ContractEventBody::V0(v0) => {
+            assert_eq!(
+                v0.topics[0],
+                soroban_sdk::xdr::ScVal::Symbol(soroban_sdk::xdr::ScSymbol(
+                    "create_order".try_into().unwrap()
+                ))
+            );
+            assert_eq!(v0.topics.len(), 4);
+        }
+    }
+
+    // 2. Pay step
+    client.pay(&token, &buyer, &id, &10_000);
+    let pay_events = env.events().all().filter_by_contract(&checkout);
+    let expected_pay = PaymentReceived {
+        token: token.clone(),
+        buyer: buyer.clone(),
+        merchant: merchant.clone(),
+        order_id: id.clone(),
+        amount: 10_000,
+    };
+    assert_eq!(pay_events, std::vec![expected_pay.to_xdr(&env, &checkout)]);
+    let raw_pay = pay_events.events();
+    assert_eq!(raw_pay.len(), 1);
+    match &raw_pay[0].body {
+        soroban_sdk::xdr::ContractEventBody::V0(v0) => {
+            assert_eq!(
+                v0.topics[0],
+                soroban_sdk::xdr::ScVal::Symbol(soroban_sdk::xdr::ScSymbol(
+                    "pay".try_into().unwrap()
+                ))
+            );
+            assert_eq!(v0.topics.len(), 5);
+            assert_eq!(
+                v0.topics[1],
+                soroban_sdk::xdr::ScVal::from_val(&env, &token.to_val())
+            );
+            assert_eq!(
+                v0.topics[2],
+                soroban_sdk::xdr::ScVal::from_val(&env, &buyer.to_val())
+            );
+            assert_eq!(
+                v0.topics[3],
+                soroban_sdk::xdr::ScVal::from_val(&env, &merchant.to_val())
+            );
+            assert_eq!(
+                v0.topics[4],
+                soroban_sdk::xdr::ScVal::from_val(&env, &id.to_val())
+            );
+        }
+    }
+
+    // 3. Dispatch step
+    client.dispatch(&id);
+    let dispatch_events = env.events().all().filter_by_contract(&checkout);
+    let expected_dispatch = OrderShipped {
+        order_id: id.clone(),
+        merchant: merchant.clone(),
+        amount: 10_000,
+    };
+    assert_eq!(
+        dispatch_events,
+        std::vec![expected_dispatch.to_xdr(&env, &checkout)]
+    );
+    let raw_dispatch = dispatch_events.events();
+    assert_eq!(raw_dispatch.len(), 1);
+    match &raw_dispatch[0].body {
+        soroban_sdk::xdr::ContractEventBody::V0(v0) => {
+            assert_eq!(
+                v0.topics[0],
+                soroban_sdk::xdr::ScVal::Symbol(soroban_sdk::xdr::ScSymbol(
+                    "dispatch".try_into().unwrap()
+                ))
+            );
+            assert_eq!(v0.topics.len(), 3);
+            assert_eq!(
+                v0.topics[1],
+                soroban_sdk::xdr::ScVal::from_val(&env, &id.to_val())
+            );
+            assert_eq!(
+                v0.topics[2],
+                soroban_sdk::xdr::ScVal::from_val(&env, &merchant.to_val())
+            );
+        }
+    }
+}
+
+#[test]
+fn test_refund_event_emitted() {
+    extern crate std;
+    use crate::events::OrderRefunded;
+    use soroban_sdk::{Event, FromVal};
+
     let env = Env::default();
     env.mock_all_auths();
 
     let (client, token, _, buyer, checkout) = setup_usdc(&env);
-    let id = order_id(&env, 5);
+    let id = order_id(&env, 9);
 
     client.create_order(&buyer, &id, &token, &10_000);
     client.pay(&token, &buyer, &id, &10_000);
-    client.dispatch(&id);
 
-    // At least one contract event should be recorded for the lifecycle.
-    let events = env.events().all().filter_by_contract(&checkout);
-    assert!(
-        !events.events().is_empty(),
-        "expected contract events for create/pay/dispatch"
+    // Lifecycle step: refund
+    client.refund(&id);
+    let refund_events = env.events().all().filter_by_contract(&checkout);
+    let expected_refund = OrderRefunded {
+        order_id: id.clone(),
+        buyer: buyer.clone(),
+        amount: 10_000,
+    };
+    assert_eq!(
+        refund_events,
+        std::vec![expected_refund.to_xdr(&env, &checkout)]
     );
+    let raw_refund = refund_events.events();
+    assert_eq!(raw_refund.len(), 1);
+    match &raw_refund[0].body {
+        soroban_sdk::xdr::ContractEventBody::V0(v0) => {
+            assert_eq!(
+                v0.topics[0],
+                soroban_sdk::xdr::ScVal::Symbol(soroban_sdk::xdr::ScSymbol(
+                    "refund".try_into().unwrap()
+                ))
+            );
+            assert_eq!(v0.topics.len(), 3);
+            assert_eq!(
+                v0.topics[1],
+                soroban_sdk::xdr::ScVal::from_val(&env, &id.to_val())
+            );
+            assert_eq!(
+                v0.topics[2],
+                soroban_sdk::xdr::ScVal::from_val(&env, &buyer.to_val())
+            );
+        }
+    }
 }


### PR DESCRIPTION
### Summary of Changes (Closes #91)

#### 1. Explicit Event Topic Derivation
- Configured explicit prefix topic symbols in `contracts/checkout/src/events.rs`:
  - `#[contractevent(topics = ["create_order"])]` for `OrderCreated`
  - `#[contractevent(topics = ["pay"])]` for `PaymentReceived`
  - `#[contractevent(topics = ["dispatch"])]` for `OrderShipped`
  - `#[contractevent(topics = ["refund"])]` for `OrderRefunded`
- This ensures the contract events emitted on-chain match the symbol and topic structure required by `lib/stellar/indexer.ts`, `lib/stellar/events.ts`, and `contracts/checkout/README.md`.

#### 2. Strengthened Test Assertions in `contracts/checkout/src/test.rs`
- Extended `test_events_emitted` to assert events step-by-step per lifecycle invocation:
  - **`create_order`**: Asserts first topic is `Symbol("create_order")`, 4 topics total, and matches `expected_create.to_xdr(&env, &checkout)`.
  - **`pay`**: Asserts first topic is `Symbol("pay")`, 5 topics total, matches `expected_pay.to_xdr(&env, &checkout)`, and strictly asserts the topic payload ordering expected by frontend indexers: `token`, `buyer`, `merchant`, `order_id`.
  - **`dispatch`**: Asserts first topic is `Symbol("dispatch")`, 3 topics total (`dispatch`, `order_id`, `merchant`), and matches `expected_dispatch.to_xdr(&env, &checkout)`.
- Added `test_refund_event_emitted` verifying the refund lifecycle event:
  - Asserts first topic is `Symbol("refund")`, 3 topics total (`refund`, `order_id`, `buyer`), and matches `expected_refund.to_xdr(&env, &checkout)`.

#### 3. Verification & Clippy
- Removed needless borrows on `MuxedAddress` in `contracts/checkout/src/lib.rs`.
- Formatted `storage.rs` with `cargo fmt`.
- Ran 2x verification passes:
  - `cargo fmt -- --check` passes cleanly.
  - `cargo clippy --all-targets -- -D warnings` passes with 0 warnings.
  - `cargo test` passes cleanly (20/20 unit tests pass).
  - `cargo build --release --target wasm32v1-none` compiles cleanly.
  - `npm run lint` and `npm run type-check` pass cleanly.
