### PR TITLE
fix(supabase): tighten RLS for admin-only product and storage writes (closes #5)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -109,9 +109,9 @@ The card payment form fields are UI-only placeholders. In production:
 
 Apply `supabase/schema.sql` so that:
 
-- Anyone can read products
-- Only authenticated users can write products / upload images
-- Tighten policies further for production (admin-only writes)
+- Anyone (including unauthenticated visitors) can read products and view product images
+- Only authorized administrators (`public.is_admin()`) can insert, update, or delete products and upload to storage
+- Authenticated non-admin users cannot mutate products or tamper with bucket objects
 
 Never expose the Supabase **service role** key in the browser.
 

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -13,3 +13,38 @@
 7. Restart `npm run dev`.
 
 Products live in the `products` table; images in the public `products` storage bucket.
+
+---
+
+### Admin Privileges and Row Level Security (RLS)
+
+The database enforces strict Row Level Security (RLS) via the `public.is_admin()` security definer function:
+- **Public access**: Unauthenticated (anon) users can read products (`select`) and view public product images in storage.
+- **Admin write access**: Only authenticated users recognized as admins can insert, update, or delete rows in the `products` table, or upload, update, or delete objects in the `products` storage bucket. Authenticated non-admins receive RLS permission violations if attempting direct mutations.
+
+To authorize an admin in Supabase to match your `NEXT_PUBLIC_ADMIN_EMAILS`, configure one of the following methods:
+
+#### Method 1: `public.admin_users` table (Recommended)
+Add the administrator's email to `public.admin_users`:
+
+```sql
+insert into public.admin_users (email)
+values ('admin@example.com')
+on conflict (email) do nothing;
+```
+
+#### Method 2: Custom JWT claim (`is_admin: true` in `app_metadata`)
+Assign `is_admin: true` to the user's `app_metadata` in Supabase Auth:
+
+```sql
+update auth.users
+set raw_app_meta_data = coalesce(raw_app_meta_data, '{}'::jsonb) || '{"is_admin": true}'::jsonb
+where email = 'admin@example.com';
+```
+
+Or via the Supabase Dashboard / Admin API:
+```javascript
+await supabase.auth.admin.updateUserById(userId, {
+  app_metadata: { is_admin: true }
+});
+```

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -12,7 +12,41 @@ create table if not exists public.products (
 
 create index if not exists products_created_at_idx on public.products (created_at desc);
 
--- Public read; authenticated write (tighten further for production admins)
+-- Admin users table: Server-side list of admin emails authorized for product mutations
+create table if not exists public.admin_users (
+  id uuid primary key default gen_random_uuid(),
+  email text unique not null,
+  created_at timestamptz not null default now()
+);
+
+alter table public.admin_users enable row level security;
+
+drop policy if exists "Admins can view admin_users" on public.admin_users;
+create policy "Admins can view admin_users"
+  on public.admin_users for select
+  to authenticated
+  using (
+    lower((auth.jwt() ->> 'email')) = lower(email)
+    or coalesce((auth.jwt() -> 'app_metadata' ->> 'is_admin')::boolean, false) = true
+  );
+
+-- Helper function: Evaluates true if the caller is an admin via JWT claims or admin_users table
+create or replace function public.is_admin()
+returns boolean
+language sql
+stable
+security definer
+as $$
+  select
+    coalesce((auth.jwt() -> 'app_metadata' ->> 'is_admin')::boolean, false) = true
+    or exists (
+      select 1 from public.admin_users
+      where lower(email) = lower(auth.jwt() ->> 'email')
+    );
+$$;
+
+-- Products Row Level Security:
+-- Public can read products; only admins can insert, update, or delete products.
 alter table public.products enable row level security;
 
 drop policy if exists "Public can read products" on public.products;
@@ -21,48 +55,57 @@ create policy "Public can read products"
   using (true);
 
 drop policy if exists "Authenticated users can insert products" on public.products;
-create policy "Authenticated users can insert products"
+drop policy if exists "Admins can insert products" on public.products;
+create policy "Admins can insert products"
   on public.products for insert
   to authenticated
-  with check (true);
+  with check (public.is_admin());
 
 drop policy if exists "Authenticated users can update products" on public.products;
-create policy "Authenticated users can update products"
+drop policy if exists "Admins can update products" on public.products;
+create policy "Admins can update products"
   on public.products for update
   to authenticated
-  using (true)
-  with check (true);
+  using (public.is_admin())
+  with check (public.is_admin());
 
 drop policy if exists "Authenticated users can delete products" on public.products;
-create policy "Authenticated users can delete products"
+drop policy if exists "Admins can delete products" on public.products;
+create policy "Admins can delete products"
   on public.products for delete
   to authenticated
-  using (true);
+  using (public.is_admin());
 
 -- Storage bucket for product images (create via Dashboard → Storage if needed)
 insert into storage.buckets (id, name, public)
 values ('products', 'products', true)
 on conflict (id) do update set public = true;
 
+-- Storage Objects Policies:
+-- Public can view images; only admins can upload, update, or delete product images.
 drop policy if exists "Public can view product images" on storage.objects;
 create policy "Public can view product images"
   on storage.objects for select
   using (bucket_id = 'products');
 
 drop policy if exists "Authenticated can upload product images" on storage.objects;
-create policy "Authenticated can upload product images"
+drop policy if exists "Admins can upload product images" on storage.objects;
+create policy "Admins can upload product images"
   on storage.objects for insert
   to authenticated
-  with check (bucket_id = 'products');
+  with check (bucket_id = 'products' and public.is_admin());
 
 drop policy if exists "Authenticated can update product images" on storage.objects;
-create policy "Authenticated can update product images"
+drop policy if exists "Admins can update product images" on storage.objects;
+create policy "Admins can update product images"
   on storage.objects for update
   to authenticated
-  using (bucket_id = 'products');
+  using (bucket_id = 'products' and public.is_admin())
+  with check (bucket_id = 'products' and public.is_admin());
 
 drop policy if exists "Authenticated can delete product images" on storage.objects;
-create policy "Authenticated can delete product images"
+drop policy if exists "Admins can delete product images" on storage.objects;
+create policy "Admins can delete product images"
   on storage.objects for delete
   to authenticated
-  using (bucket_id = 'products');
+  using (bucket_id = 'products' and public.is_admin());

--- a/tests/lib/supabase.test.ts
+++ b/tests/lib/supabase.test.ts
@@ -115,3 +115,42 @@ describe("lib/supabase", () => {
     );
   });
 });
+
+describe("supabase/schema.sql RLS policies", () => {
+  it("enforces admin-only writes and public reads for products and storage", async () => {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const schemaPath = path.resolve(__dirname, "../../supabase/schema.sql");
+    const sql = fs.readFileSync(schemaPath, "utf-8");
+
+    // Table definitions
+    expect(sql).toContain("create table if not exists public.products");
+    expect(sql).toContain("create table if not exists public.admin_users");
+    expect(sql).toContain("alter table public.admin_users enable row level security;");
+    expect(sql).toContain("alter table public.products enable row level security;");
+
+    // Server-side helper function
+    expect(sql).toContain("create or replace function public.is_admin()");
+    expect(sql).toContain("security definer");
+
+    // Products table policies
+    expect(sql).toContain('create policy "Public can read products"');
+    expect(sql).toContain('create policy "Admins can insert products"');
+    expect(sql).toContain('create policy "Admins can update products"');
+    expect(sql).toContain('create policy "Admins can delete products"');
+    expect(sql).toContain("with check (public.is_admin())");
+
+    // Permissive policies are explicitly dropped
+    expect(sql).toContain('drop policy if exists "Authenticated users can insert products"');
+    expect(sql).toContain('drop policy if exists "Authenticated users can update products"');
+    expect(sql).toContain('drop policy if exists "Authenticated users can delete products"');
+
+    // Storage bucket and object policies
+    expect(sql).toContain("insert into storage.buckets");
+    expect(sql).toContain('create policy "Public can view product images"');
+    expect(sql).toContain('create policy "Admins can upload product images"');
+    expect(sql).toContain('create policy "Admins can update product images"');
+    expect(sql).toContain('create policy "Admins can delete product images"');
+    expect(sql).toContain("bucket_id = 'products' and public.is_admin()");
+  });
+});


### PR DESCRIPTION
### Summary of Changes (Closes #5)

#### 1. Server-Side Admin Verification Function & Table
- Created `public.admin_users` table with Row Level Security enabled.
- Defined `public.is_admin()` `SECURITY DEFINER` function in `supabase/schema.sql` to verify administrator status server-side either via:
  - Custom JWT claim (`auth.jwt() -> 'app_metadata' ->> 'is_admin'`), OR
  - Email match against `public.admin_users` (`lower(email) = lower(auth.jwt() ->> 'email')`).

#### 2. Products Table RLS Hardening
- Preserved public read access (`using (true)`) so anonymous users and visitors can browse products.
- Replaced permissive authenticated policies (`Authenticated users can insert/update/delete products`) with strict admin-only policies:
  - `Admins can insert products`: gated on `public.is_admin()`.
  - `Admins can update products`: gated on `public.is_admin()` for both `using` and `with check`.
  - `Admins can delete products`: gated on `public.is_admin()`.

#### 3. Storage Bucket Policy Hardening
- Preserved public image downloads/views for `bucket_id = 'products'`.
- Restricted image upload, update, and deletion in `storage.objects` to admins only via `bucket_id = 'products' and public.is_admin()`.

#### 4. Documentation & Tests
- Updated `supabase/README.md` with step-by-step instructions on configuring admins via `public.admin_users` and `app_metadata` custom claims.
- Updated `SECURITY.md` to reflect the tightened RLS security architecture.
- Added unit tests in `tests/lib/supabase.test.ts` verifying that `schema.sql` properly defines `admin_users`, `is_admin()`, and the admin-only write policies while keeping public select.
- Ran 2x verification passes:
  - `npm run lint` passes cleanly (0 errors).
  - `npm run type-check` (`tsc --noEmit --skipLibCheck`) passes cleanly.
  - `npx vitest run tests/lib/supabase.test.ts` (5/5 tests pass).
