### PR TITLE
feat(orders): implement buyer order history page and on-chain verification (closes #2)

### DIFF
--- a/app/orders/page.tsx
+++ b/app/orders/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import React, { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import { useAuth } from "../../lib/AuthContext";
+import { BuyerOrder, fetchBuyerOrders } from "../../lib/buyer-orders";
+import OrderCard from "../../components/OrderCard";
+import { MdShoppingBag, MdRefresh, MdLockOutline } from "react-icons/md";
+import { SiStellar } from "react-icons/si";
+
+export default function BuyerOrdersPage() {
+  const { user, loading: authLoading } = useAuth();
+  const [orders, setOrders] = useState<BuyerOrder[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadOrders = useCallback(async () => {
+    setLoading(true);
+    try {
+      const userIdentifier = user?.email || user?.uid;
+      const data = await fetchBuyerOrders(userIdentifier);
+      setOrders(data);
+    } catch (err) {
+      console.error("Error fetching orders:", err);
+      setOrders([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (!authLoading) {
+      loadOrders();
+    }
+  }, [authLoading, loadOrders]);
+
+  return (
+    <div className="min-h-screen py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto">
+      {/* Page Header */}
+      <div className="flex flex-wrap items-center justify-between gap-4 mb-8 pb-6 border-b border-purple-100">
+        <div>
+          <h1 className="text-3xl font-display font-bold text-mova-ink flex items-center gap-3">
+            <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-purple-600 text-white shadow-mova">
+              <MdShoppingBag size={22} />
+            </span>
+            My Orders
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Track and verify your footwear orders and Stellar smart contract transactions.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={loadOrders}
+            disabled={loading}
+            aria-label="Refresh orders list"
+            className="flex items-center gap-1.5 px-3 py-2 rounded-lg border border-purple-200 text-purple-700 bg-purple-50 hover:bg-purple-100 text-sm font-medium transition-colors disabled:opacity-50"
+          >
+            <MdRefresh size={18} className={loading ? "animate-spin" : ""} />
+            <span>Refresh</span>
+          </button>
+          <Link
+            href="/shop"
+            className="px-4 py-2 rounded-lg bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold shadow-sm transition-colors"
+          >
+            Shop Shoes
+          </Link>
+        </div>
+      </div>
+
+      {/* Guest Notice if unauthenticated */}
+      {!authLoading && !user && (
+        <div className="mb-6 p-4 rounded-xl bg-purple-50 border border-purple-200 flex flex-wrap items-center justify-between gap-3 text-sm text-purple-900">
+          <div className="flex items-center gap-2">
+            <MdLockOutline size={20} className="text-purple-600 flex-shrink-0" />
+            <span>
+              You are viewing guest orders stored on this device. Sign in to view your complete multi-device history.
+            </span>
+          </div>
+          <Link
+            href="/profile/login"
+            className="px-3 py-1.5 rounded-lg bg-purple-600 text-white font-medium hover:bg-purple-700 text-xs transition-colors"
+          >
+            Log In
+          </Link>
+        </div>
+      )}
+
+      {/* Content Area */}
+      {loading ? (
+        /* Loading Skeletons */
+        <div className="space-y-4">
+          {[1, 2, 3].map((n) => (
+            <div
+              key={n}
+              className="bg-white rounded-xl border border-purple-100 p-6 shadow-sm animate-pulse space-y-4"
+            >
+              <div className="flex justify-between items-center">
+                <div className="h-4 w-40 bg-purple-100 rounded" />
+                <div className="h-6 w-20 bg-purple-100 rounded-full" />
+              </div>
+              <div className="space-y-2 pt-2">
+                <div className="h-12 w-full bg-purple-50 rounded-lg" />
+              </div>
+              <div className="pt-2 flex justify-between">
+                <div className="h-4 w-28 bg-purple-100 rounded" />
+                <div className="h-4 w-24 bg-purple-100 rounded" />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : orders.length > 0 ? (
+        /* Orders List */
+        <div className="space-y-5">
+          {orders.map((order) => (
+            <OrderCard key={order.orderId || order.id} order={order} />
+          ))}
+        </div>
+      ) : (
+        /* Empty State */
+        <div className="text-center py-16 px-4 bg-white rounded-2xl border border-purple-100 shadow-sm">
+          <div className="mx-auto w-16 h-16 rounded-2xl bg-purple-50 flex items-center justify-center text-purple-600 mb-4">
+            <MdShoppingBag size={32} />
+          </div>
+          <h2 className="text-xl font-bold text-gray-900 mb-2">No orders found</h2>
+          <p className="text-gray-500 max-w-sm mx-auto text-sm mb-6">
+            You haven&apos;t placed any orders yet. Browse our curated footwear collection and pay with card or Stellar.
+          </p>
+          <Link
+            href="/shop"
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-purple-600 hover:bg-purple-700 text-white font-medium shadow-mova transition-transform hover:-translate-y-0.5"
+          >
+            <span>Explore Shop</span>
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/profile/orders/page.tsx
+++ b/app/profile/orders/page.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+import BuyerOrdersPage from "../../orders/page";
+
+export default BuyerOrdersPage;

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -122,6 +122,11 @@ function Navbar() {
             <Link href="#contact" className={navLinkClass}>
               Contact Us
             </Link>
+            {user && (
+              <Link href="/orders" className={navLinkClass}>
+                Orders
+              </Link>
+            )}
           </div>
           <div className="flex items-center gap-4">
             {user ? (
@@ -195,6 +200,7 @@ function Navbar() {
                 { href: "#aboutus", label: "About Us", onClick: closeNavOnClick },
                 { href: "/blog", label: "Blog", onClick: closeNavOnClick },
                 { href: "#contact", label: "Contact Us", onClick: closeNavOnClick },
+                ...(user ? [{ href: "/orders", label: "My Orders", onClick: closeNavOnClick }] : []),
               ].map((item) => (
                 <Link
                   key={item.label}

--- a/components/OrderCard.tsx
+++ b/components/OrderCard.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import React, { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { SiStellar } from "react-icons/si";
+import { FaCreditCard, FaExternalLinkAlt, FaCheckCircle, FaCopy, FaCheck } from "react-icons/fa";
+import { MdLocalShipping, MdPayment, MdPending, MdCancel } from "react-icons/md";
+import { BuyerOrder, verifyOrderOnChain } from "../lib/buyer-orders";
+import { NETWORK } from "../lib/stellar/config";
+
+interface OrderCardProps {
+  order: BuyerOrder;
+}
+
+export default function OrderCard({ order }: OrderCardProps) {
+  const [copied, setCopied] = useState(false);
+  const [verifying, setVerifying] = useState(false);
+  const [onChainResult, setOnChainResult] = useState<{
+    verified?: boolean;
+    onChainStatus?: string;
+  } | null>(null);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(order.orderId);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleVerify = async () => {
+    setVerifying(true);
+    try {
+      const res = await verifyOrderOnChain(order.orderId);
+      setOnChainResult(res);
+    } catch {
+      setOnChainResult({ verified: false });
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  const formattedDate = new Date(order.createdAt).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  const getStatusBadge = (status: string) => {
+    switch (status) {
+      case "Shipped":
+      case "Completed":
+        return (
+          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-emerald-100 text-emerald-800">
+            <MdLocalShipping size={14} /> {status}
+          </span>
+        );
+      case "Paid":
+        return (
+          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-purple-100 text-purple-800">
+            <MdPayment size={14} /> Paid
+          </span>
+        );
+      case "Refunded":
+        return (
+          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-rose-100 text-rose-800">
+            <MdCancel size={14} /> Refunded
+          </span>
+        );
+      default:
+        return (
+          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-amber-100 text-amber-800">
+            <MdPending size={14} /> {status || "Pending"}
+          </span>
+        );
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-xl border border-purple-100 shadow-sm hover:shadow-md transition-shadow overflow-hidden">
+      {/* Card Header */}
+      <div className="bg-purple-50/60 p-4 sm:p-5 border-b border-purple-100 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-500 font-medium">Order ID:</span>
+            <span className="font-mono text-sm font-bold text-mova-ink">{order.orderId}</span>
+            <button
+              type="button"
+              onClick={handleCopy}
+              title="Copy Order ID"
+              aria-label="Copy Order ID"
+              className="text-gray-400 hover:text-purple-600 transition-colors p-1"
+            >
+              {copied ? <FaCheck className="text-green-600" size={12} /> : <FaCopy size={12} />}
+            </button>
+          </div>
+          <span className="text-xs text-gray-500">{formattedDate}</span>
+        </div>
+
+        <div className="flex items-center gap-3">
+          {getStatusBadge(order.status)}
+          <div className="text-right">
+            <span className="text-xs text-gray-500 block">Total</span>
+            <span className="text-base font-bold text-purple-700">
+              ${order.total.toFixed(2)}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Items Section */}
+      <div className="p-4 sm:p-5 divide-y divide-gray-100">
+        {order.items && order.items.length > 0 ? (
+          order.items.map((item, idx) => (
+            <div key={idx} className="py-3 first:pt-0 last:pb-0 flex items-center justify-between gap-4">
+              <div className="flex items-center gap-3">
+                {item.img ? (
+                  /* eslint-disable-next-line @next/next/no-img-element */
+                  <img
+                    src={item.img}
+                    alt={item.name}
+                    className="w-12 h-12 rounded-lg object-cover bg-gray-50 border border-purple-50"
+                  />
+                ) : (
+                  <div className="w-12 h-12 rounded-lg bg-purple-100 flex items-center justify-center text-purple-600 font-bold text-sm">
+                    {item.name?.slice(0, 1) || "M"}
+                  </div>
+                )}
+                <div>
+                  <h4 className="text-sm font-semibold text-gray-900">{item.name}</h4>
+                  <span className="text-xs text-gray-500">Qty: {item.quantity || 1}</span>
+                </div>
+              </div>
+              <span className="text-sm font-medium text-gray-800">
+                ${Number(item.price).toFixed(2)}
+              </span>
+            </div>
+          ))
+        ) : (
+          <div className="py-2 text-xs text-gray-400 italic">No item details recorded</div>
+        )}
+      </div>
+
+      {/* Payment Details Footer */}
+      <div className="bg-gray-50/70 p-4 sm:p-5 border-t border-gray-100 flex flex-wrap items-center justify-between gap-3 text-xs">
+        <div className="flex items-center gap-2">
+          {order.paymentMethod === "stellar" ? (
+            <div className="flex items-center gap-2 text-purple-700 font-medium">
+              <SiStellar size={16} />
+              <span>
+                Paid with Stellar ({order.tokenSymbol || "USDC"}
+                {order.tokenAmount ? ` · ~${order.tokenAmount.toFixed(2)} ${order.tokenSymbol}` : ""})
+              </span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 text-gray-700 font-medium">
+              <FaCreditCard size={15} />
+              <span>Paid with Card</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 flex-wrap">
+          {order.txHash && (
+            <a
+              href={`https://stellar.expert/explorer/${NETWORK}/tx/${order.txHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-purple-600 hover:text-purple-800 underline font-medium"
+            >
+              <span>View On Explorer</span>
+              <FaExternalLinkAlt size={10} />
+            </a>
+          )}
+
+          {order.paymentMethod === "stellar" && (
+            <button
+              type="button"
+              onClick={handleVerify}
+              disabled={verifying}
+              className="inline-flex items-center gap-1 px-2.5 py-1 rounded bg-purple-100 hover:bg-purple-200 text-purple-700 font-medium transition-colors disabled:opacity-50"
+            >
+              {verifying ? "Verifying…" : onChainResult ? (onChainResult.verified ? "Verified ✓" : "Not Found") : "Verify Contract"}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/buyer-orders.ts
+++ b/lib/buyer-orders.ts
@@ -1,0 +1,185 @@
+/**
+ * Buyer Order Management
+ *
+ * Provides utilities for storing, querying, and verifying past buyer orders
+ * via Supabase and local storage, with on-chain Stellar verification.
+ */
+
+import { supabase } from "./supabase";
+import { readOrder } from "./stellar/orders";
+
+export interface OrderItem {
+  id?: string | number;
+  name: string;
+  price: number;
+  quantity?: number;
+  img?: string;
+}
+
+export interface BuyerOrder {
+  id: string;
+  orderId: string;
+  userId?: string;
+  userEmail?: string;
+  createdAt: string;
+  total: number;
+  status: "Pending" | "Paid" | "Shipped" | "Refunded" | "Completed";
+  paymentMethod: "stellar" | "card";
+  tokenSymbol?: string;
+  tokenAmount?: number;
+  txHash?: string;
+  ledger?: number;
+  items: OrderItem[];
+}
+
+const STORAGE_KEY = "mova_buyer_orders";
+
+/**
+ * Saves an order to Supabase and syncs to local storage cache.
+ */
+export async function saveBuyerOrder(order: BuyerOrder): Promise<BuyerOrder> {
+  // 1. Cache to localStorage
+  try {
+    const cached = getCachedBuyerOrders();
+    const existingIndex = cached.findIndex((o) => o.orderId === order.orderId);
+    if (existingIndex >= 0) {
+      cached[existingIndex] = order;
+    } else {
+      cached.unshift(order);
+    }
+    if (typeof window !== "undefined") {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(cached));
+    }
+  } catch (err) {
+    console.warn("Failed to cache order to localStorage:", err);
+  }
+
+  // 2. Try persisting to Supabase if table exists
+  try {
+    if (supabase) {
+      await supabase.from("orders").insert([
+        {
+          id: order.id,
+          order_id: order.orderId,
+          user_id: order.userId || null,
+          user_email: order.userEmail || null,
+          total: order.total,
+          status: order.status,
+          payment_method: order.paymentMethod,
+          token_symbol: order.tokenSymbol || null,
+          token_amount: order.tokenAmount || null,
+          tx_hash: order.txHash || null,
+          items: order.items,
+          created_at: order.createdAt,
+        },
+      ]);
+    }
+  } catch (err) {
+    // Supabase table may not exist yet in dev or offline; local cache ensures continuity
+    console.warn("Could not insert order into Supabase, kept in local cache:", err);
+  }
+
+  return order;
+}
+
+/**
+ * Retrieves all cached orders from localStorage.
+ */
+export function getCachedBuyerOrders(): BuyerOrder[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Fetches past orders for an authenticated user.
+ */
+export async function fetchBuyerOrders(userEmailOrId?: string): Promise<BuyerOrder[]> {
+  let orders: BuyerOrder[] = [];
+
+  // Try querying Supabase first
+  try {
+    if (supabase && userEmailOrId) {
+      const isEmail = userEmailOrId.includes("@");
+      const query = supabase
+        .from("orders")
+        .select("*")
+        .order("created_at", { ascending: false });
+
+      const res = isEmail
+        ? await query.eq("user_email", userEmailOrId)
+        : await query.eq("user_id", userEmailOrId);
+
+      if (res.data && Array.isArray(res.data) && res.data.length > 0) {
+        orders = res.data.map((row: any) => ({
+          id: row.id || row.order_id,
+          orderId: row.order_id || row.id,
+          userId: row.user_id,
+          userEmail: row.user_email,
+          createdAt: row.created_at || new Date().toISOString(),
+          total: Number(row.total) || 0,
+          status: row.status || "Paid",
+          paymentMethod: row.payment_method || "stellar",
+          tokenSymbol: row.token_symbol || "USDC",
+          tokenAmount: row.token_amount ? Number(row.token_amount) : undefined,
+          txHash: row.tx_hash,
+          ledger: row.ledger,
+          items: Array.isArray(row.items) ? row.items : [],
+        }));
+      }
+    }
+  } catch (err) {
+    console.warn("Supabase query failed, falling back to cached orders:", err);
+  }
+
+  // Fallback to localStorage cached orders
+  if (orders.length === 0) {
+    const cached = getCachedBuyerOrders();
+    if (userEmailOrId) {
+      orders = cached.filter(
+        (o) =>
+          !o.userEmail ||
+          !o.userId ||
+          o.userEmail === userEmailOrId ||
+          o.userId === userEmailOrId
+      );
+    } else {
+      orders = cached;
+    }
+  }
+
+  return orders;
+}
+
+/**
+ * Cross-references an order with the Soroban smart contract to verify on-chain status.
+ */
+export async function verifyOrderOnChain(orderId: string): Promise<{
+  verified: boolean;
+  onChainStatus?: string;
+  buyer?: string;
+  amountDisplay?: string;
+  tokenSymbol?: string;
+}> {
+  try {
+    const onChain = await readOrder(orderId);
+    if (!onChain) {
+      return { verified: false };
+    }
+    return {
+      verified: onChain.status !== "Unknown",
+      onChainStatus: onChain.status,
+      buyer: onChain.buyer,
+      amountDisplay: onChain.amountDisplay,
+      tokenSymbol: onChain.tokenSymbol,
+    };
+  } catch {
+    return { verified: false };
+  }
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -66,3 +66,40 @@ create policy "Authenticated can delete product images"
   on storage.objects for delete
   to authenticated
   using (bucket_id = 'products');
+
+-- Orders table (tracks buyer purchases and Stellar payments)
+create table if not exists public.orders (
+  id uuid primary key default gen_random_uuid(),
+  order_id text not null unique,
+  user_id uuid references auth.users(id),
+  user_email text,
+  total numeric(12, 2) not null check (total >= 0),
+  status text not null default 'Paid' check (status in ('Pending', 'Paid', 'Shipped', 'Refunded', 'Completed')),
+  payment_method text not null default 'stellar' check (payment_method in ('stellar', 'card')),
+  token_symbol text default 'USDC',
+  token_amount numeric(18, 7),
+  tx_hash text,
+  items jsonb default '[]'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists orders_user_id_idx on public.orders (user_id);
+create index if not exists orders_user_email_idx on public.orders (user_email);
+create index if not exists orders_created_at_idx on public.orders (created_at desc);
+
+alter table public.orders enable row level security;
+
+-- Users can view their own orders; admins can view all orders
+drop policy if exists "Users can read own orders" on public.orders;
+create policy "Users can read own orders"
+  on public.orders for select
+  to authenticated
+  using (auth.uid() = user_id or auth.email() = user_email);
+
+-- Authenticated users or guest checkout can create order records
+drop policy if exists "Users can insert orders" on public.orders;
+create policy "Users can insert orders"
+  on public.orders for insert
+  to authenticated, anon
+  with check (true);
+

--- a/tests/lib/buyer-orders.test.ts
+++ b/tests/lib/buyer-orders.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  saveBuyerOrder,
+  getCachedBuyerOrders,
+  fetchBuyerOrders,
+  verifyOrderOnChain,
+  BuyerOrder,
+} from "../../lib/buyer-orders";
+import * as stellarOrders from "../../lib/stellar/orders";
+
+vi.mock("../../lib/supabase", () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({
+        data: [
+          {
+            id: "db-1",
+            order_id: "SS-DB-1",
+            user_email: "buyer@example.com",
+            total: 120,
+            status: "Paid",
+            payment_method: "stellar",
+            token_symbol: "USDC",
+            tx_hash: "abcd1234efgh5678",
+            created_at: "2026-09-05T08:00:00.000Z",
+            items: [{ name: "Nike Air Max", price: 120, quantity: 1 }],
+          },
+        ],
+        error: null,
+      }),
+    })),
+  },
+}));
+
+describe("Buyer Orders Management", () => {
+  const sampleOrder: BuyerOrder = {
+    id: "ord-1",
+    orderId: "SS-101",
+    userEmail: "buyer@example.com",
+    userId: "user-123",
+    total: 89.99,
+    status: "Paid",
+    paymentMethod: "stellar",
+    tokenSymbol: "XLM",
+    tokenAmount: 750,
+    txHash: "mock-stellar-tx-hash",
+    createdAt: "2026-09-05T08:00:00.000Z",
+    items: [{ name: "Running Shoes", price: 89.99, quantity: 1 }],
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("saves an order and caches it in localStorage", async () => {
+    const saved = await saveBuyerOrder(sampleOrder);
+    expect(saved.orderId).toBe("SS-101");
+
+    const cached = getCachedBuyerOrders();
+    expect(cached.length).toBe(1);
+    expect(cached[0].orderId).toBe("SS-101");
+    expect(cached[0].tokenSymbol).toBe("XLM");
+  });
+
+  it("updates an existing order when same orderId is saved again", async () => {
+    await saveBuyerOrder(sampleOrder);
+    const updated: BuyerOrder = { ...sampleOrder, status: "Shipped" };
+    await saveBuyerOrder(updated);
+
+    const cached = getCachedBuyerOrders();
+    expect(cached.length).toBe(1);
+    expect(cached[0].status).toBe("Shipped");
+  });
+
+  it("fetches orders from Supabase when available", async () => {
+    const orders = await fetchBuyerOrders("buyer@example.com");
+    expect(orders.length).toBe(1);
+    expect(orders[0].orderId).toBe("SS-DB-1");
+    expect(orders[0].total).toBe(120);
+  });
+
+  it("falls back to local cache when Supabase returns empty", async () => {
+    await saveBuyerOrder(sampleOrder);
+    // Query with no user email should fallback to local cache
+    const orders = await fetchBuyerOrders(undefined);
+    expect(orders.length).toBe(1);
+    expect(orders[0].orderId).toBe("SS-101");
+  });
+
+  it("verifies order on-chain via readOrder", async () => {
+    vi.spyOn(stellarOrders, "readOrder").mockResolvedValueOnce({
+      orderId: "SS-101",
+      orderIdHash: "010203",
+      buyer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+      amount: BigInt(899900000),
+      amountDisplay: "89.99",
+      token: "C...",
+      tokenSymbol: "USDC",
+      timestamp: 1725523200,
+      status: "Paid",
+    });
+
+    const verification = await verifyOrderOnChain("SS-101");
+    expect(verification.verified).toBe(true);
+    expect(verification.onChainStatus).toBe("Paid");
+  });
+
+  it("returns verified false when on-chain order is not found or Unknown", async () => {
+    vi.spyOn(stellarOrders, "readOrder").mockResolvedValueOnce(null);
+    const verification = await verifyOrderOnChain("UNKNOWN-1");
+    expect(verification.verified).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description
Implements the buyer order history page requested in #2, allowing authenticated users to view past orders, item details, payment methods, transaction receipts, and cross-reference on-chain status via Soroban smart contracts.

Closes #2

## Changes
- **New Routes**:
  - Created  (`app/orders/page.tsx`) with user auth gating, loading skeletons, responsive cards, and empty state.
  - Added  (`app/profile/orders/page.tsx`) re-exporting the orders view.
- **Component**:
  - Built `components/OrderCard.tsx` matching the purple Mova Store theme.
  - Displays order ID with copy button, date/time, item thumbnails/names/quantities/prices, and payment badges.
  - For Stellar transactions, links transaction hash to Stellar Expert block explorer and includes an interactive "Verify Contract" button calling Soroban RPC.
- **Data & Verification Layer**:
  - Built `lib/buyer-orders.ts` with `BuyerOrder` types, `saveBuyerOrder`, `fetchBuyerOrders` (queries Supabase with resilient localStorage fallback), and `verifyOrderOnChain` (queries Soroban contract via `readOrder`).
  - Added `public.orders` schema and RLS policies in `supabase/schema.sql`.
- **Navigation**:
  - Added "Orders" link for authenticated users in desktop and mobile navigation in `components/Navbar.jsx`.
- **Unit Tests**:
  - Added comprehensive test suite in `tests/lib/buyer-orders.test.ts` verifying saving, local storage caching, Supabase querying, and contract verification (6/6 passing).

## Verification
- `npm test tests/lib/buyer-orders.test.ts`: Passed (6/6 tests passing)
- `npm run type-check`: Passed (clean)
- `npm run lint`: Passed (clean)