### PR TITLE
ci: install cargo-audit from prebuilt binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,9 @@ jobs:
           toolchain: stable
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
 
       - name: Run cargo audit
         working-directory: contracts/checkout


### PR DESCRIPTION
## Summary

- Replace the source compilation of `cargo-audit` with `taiki-e/install-action@v2`.
- Configure the action explicitly with `tool: cargo-audit` so the Rust security job uses a prebuilt binary.

Closes #104.

## Validation

- Verified the workflow YAML structure on macOS with Ruby's YAML parser.
- Confirmed the `rust-security` job retains the existing toolchain and audit steps.
- Confirmed `cargo install cargo-audit --locked` is removed.
- Ran `git diff --check` successfully.

This is a competing implementation for the bounty; no issue claim comment was posted.