### PR TITLE
Fix admin orders event merge reducer (Resolves #73)

### DIFF
--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -9,6 +9,7 @@ import {
   OrderEvent,
   eventToOrder,
   OrderStatus,
+  mergeOrderEvent,
 } from "../../../lib/stellar/orders";
 import { NETWORK, CHECKOUT_CONTRACT_ID } from "../../../lib/stellar/config";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";
@@ -201,7 +202,7 @@ const OrdersManagementContent = () => {
             if (existing) {
               // Update status if the new event is more recent
               if (event.ledger > (existing.ledger || 0)) {
-                newMap.set(order.orderId, { ...existing, ...order });
+                newMap.set(order.orderId, mergeOrderEvent(existing, order));
               }
             } else {
               newMap.set(order.orderId, order);

--- a/lib/stellar/orders.ts
+++ b/lib/stellar/orders.ts
@@ -500,3 +500,12 @@ export function eventToOrder(
     txHash,
   };
 }
+export function mergeOrderEvent(existing: OrderEvent, incoming: OrderEvent): OrderEvent {
+  return {
+    ...existing,
+    status: incoming.status,
+    ledger: Math.max(existing.ledger, incoming.ledger),
+    txHash: incoming.txHash || existing.txHash,
+    timestamp: Math.max(existing.timestamp, incoming.timestamp),
+  };
+}

--- a/tests/lib/stellar/orders.test.ts
+++ b/tests/lib/stellar/orders.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { mergeOrderEvent, OrderEvent } from "../../../lib/stellar/orders";
+
+describe("mergeOrderEvent", () => {
+  it("merges a dispatch event over an existing Paid row, keeping buyer and tokenSymbol, while updating status to Shipped", () => {
+    const existingRow: OrderEvent = {
+      orderId: "order_123",
+      buyer: "buyer_addr_abc",
+      amount: "100.00",
+      amountRaw: 1000000000n,
+      token: "token_addr_xyz",
+      tokenSymbol: "USDC",
+      status: "Paid",
+      timestamp: 100000,
+      ledger: 100,
+      txHash: "tx_abc",
+    };
+
+    const dispatchEvent: OrderEvent = {
+      orderId: "order_123",
+      buyer: "merchant_addr", // the dispatch event derived from topic2 might incorrectly have the merchant as buyer
+      amount: "0.00",
+      amountRaw: 0n,
+      token: "",
+      tokenSymbol: "TOKEN",
+      status: "Shipped",
+      timestamp: 100050,
+      ledger: 101,
+      txHash: "tx_def",
+    };
+
+    const merged = mergeOrderEvent(existingRow, dispatchEvent);
+
+    // Lifecycle fields are carried forward
+    expect(merged.status).toBe("Shipped");
+    expect(merged.ledger).toBe(101);
+    expect(merged.txHash).toBe("tx_def");
+    expect(merged.timestamp).toBe(100050);
+
+    // Original payment properties are preserved
+    expect(merged.buyer).toBe("buyer_addr_abc");
+    expect(merged.tokenSymbol).toBe("USDC");
+    expect(merged.token).toBe("token_addr_xyz");
+    expect(merged.amount).toBe("100.00");
+    expect(merged.amountRaw).toBe(1000000000n);
+  });
+});


### PR DESCRIPTION
### Summary
This PR extracts the inline order merging logic from pp/admin/orders/page.tsx into a pure, testable helper function mergeOrderEvent located in lib/stellar/orders.ts. 

### Why
Previously, merging a new dispatch or refund event would incorrectly overwrite the uyer and 	okenSymbol properties due to a basic object spread ({ ...existing, ...order }). The new helper correctly carries forward the lifecycle fields (status, ledger, 	xHash) while safely preserving the original payment properties (uyer, 	oken, mount).

### Tests Performed
- Added isolated unit tests in 	ests/lib/stellar/orders.test.ts to strictly verify that a Shipped dispatch event correctly updates the status but leaves the uyer and 	okenSymbol completely intact.
- Verified local focus tests pass completely.
*(Note: Unrelated pre-existing upstream test failures related to time-mocking in other components were intentionally left unmodified to avoid unrelated refactors).*

Resolves #73