### PR TITLE
fix(landing): render the slider images once with stable keys

### DIFF
--- a/app/(landingpage)/Slider.jsx
+++ b/app/(landingpage)/Slider.jsx
@@ -12,9 +12,9 @@ const Slider = () => {
   return (
     <section className="py-14 overflow-hidden bg-mova-surface/60">
       <div className="flex gap-6 overflow-x-auto px-6 md:px-10 pb-2">
-        {[...images, ...images].map((src, index) => (
+        {images.map((src) => (
           <Image
-            key={index}
+            key={src}
             src={src}
             alt="Mova Store footwear"
             width={240}

--- a/tests/(landingpage)/landingpage.test.tsx
+++ b/tests/(landingpage)/landingpage.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import FAQ from "../../app/(landingpage)/FAQ";
 import Newsletter from "../../app/(landingpage)/newsletter";
 import ContactUs from "../../app/(landingpage)/ContactUs";
+import Slider from "../../app/(landingpage)/Slider";
 import * as sendMailModule from "../../lib/sendmail";
 
 describe("Landing Page Components", () => {
@@ -34,6 +35,34 @@ describe("Landing Page Components", () => {
       // Click the second FAQ item again - should collapse
       fireEvent.click(buttons[1]);
       expect(buttons[1].getAttribute("aria-expanded")).toBe("false");
+    });
+  });
+
+  describe("Slider Component", () => {
+    it("renders each image once instead of a duplicated strip", () => {
+      render(<Slider />);
+
+      const imgs = screen.getAllByRole("img");
+      expect(imgs).toHaveLength(5);
+
+      const sources = imgs.map((img) => img.getAttribute("src"));
+      expect(new Set(sources).size).toBe(sources.length);
+    });
+
+    it("keys the strip without colliding, so keying by src stays safe", () => {
+      // Guards the plausible half-fix: switching key={index} to key={src} while
+      // still rendering [...images, ...images] turns unique index keys into
+      // genuinely duplicated ones.
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      render(<Slider />);
+
+      const duplicateKeyWarnings = consoleError.mock.calls
+        .map((call) => String(call[0]))
+        .filter((message) => message.includes("two children with the same key"));
+      expect(duplicateKeyWarnings).toHaveLength(0);
+
+      consoleError.mockRestore();
     });
   });
 


### PR DESCRIPTION
Closes #75

## What

`app/(landingpage)/Slider.jsx` renders `[...images, ...images]`, so the same five Unsplash URLs are mounted twice — ten `<img>` elements and ten image requests for five distinct pictures.

## One correction to the issue's stated cause

The issue attributes this to duplicate React keys. That part does not reproduce: `key={index}` over the **doubled** array produces indices `0…9`, which are all distinct, so React emits no duplicate-key warning today. I checked before writing the fix rather than repeating the claim.

The real cost is the duplication itself — twice the DOM nodes and twice the network requests — and index keys being positional rather than identity-based. Both acceptance criteria that matter are unaffected by the correction.

Worth noting because it changes the fix: the container is `overflow-x-auto`, a manually scrollable strip with no animation. There is no marquee here, so the second copy is not serving a seamless loop — it is simply unused. That makes the issue's conditional branch ("if a seamless marquee loop is intended, implement it with CSS animation") not applicable, and adding an animation would introduce a behaviour the component never had. I have not added one.

## The change

```diff
-{[...images, ...images].map((src, index) => (
+{images.map((src) => (
   <Image
-    key={index}
+    key={src}
```

One file, +2/−2. The rendered strip keeps its existing classes, spacing and scroll behaviour; it just stops rendering the second copy.

## Verification

Two cases added to `tests/(landingpage)/landingpage.test.tsx`, matching the existing suite's Testing Library style. `next/image` is already mocked to a plain `<img>` in `tests/setup.ts`, so element counts are directly assertable:

| case | asserts |
|---|---|
| `renders each image once instead of a duplicated strip` | exactly 5 `<img>`, all `src` values distinct — fails on `main`, which renders 10 |
| `keys the strip without colliding, so keying by src stays safe` | no "two children with the same key" warning |

The second case is deliberate rather than decorative. Because index keys are already unique on `main`, it passes there — it exists to guard the plausible half-fix of switching `key={index}` to `key={src}` while leaving `[...images, ...images]` in place, which converts unique keys into genuinely duplicated ones. The first case is the one that discriminates the bug.

I do not have this project's toolchain installed here, so I have not run `npm run test`, `npm run type-check`, `npm run lint` or `npm run format:check` myself and am not claiming those results. The change is two lines in one component plus a test file written against the suite's existing imports and conventions. Please let CI run them; I will fix anything they surface.
