### PR TITLE
test(cart): cover clearCart and cross-remount persistence

### DIFF
--- a/tests/context/CartContext.clearCart.test.tsx
+++ b/tests/context/CartContext.clearCart.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import React from "react";
+import { CartProvider, useCart } from "../../context/CartContext";
+
+describe("CartContext clearCart and cross-remount persistence", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(CartProvider, null, children);
+
+  const item1 = { id: "p1", name: "Shoe 1", price: 100 };
+  const item2 = { id: "p2", name: "Shoe 2", price: 50 };
+
+  it("resets every cart total when the cart is cleared", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.addToCart(item1);
+      result.current.addToCart(item2);
+    });
+
+    expect(result.current.itemCount).toBe(2);
+    expect(result.current.totalPrice).toBe(150);
+
+    act(() => {
+      result.current.clearCart();
+    });
+
+    expect(result.current.cartItems).toEqual([]);
+    expect(result.current.itemCount).toBe(0);
+    expect(result.current.totalPrice).toBe(0);
+  });
+
+  it("removes the stored keys rather than writing zeroes", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.addToCart(item1);
+    });
+
+    expect(localStorage.getItem("cartItems")).not.toBeNull();
+
+    act(() => {
+      result.current.clearCart();
+    });
+
+    // clearCart uses removeItem, so a later read sees an absent key rather than
+    // a stored "0". Asserting absence keeps that distinction pinned: writing
+    // zeroes instead would still pass a totals-only assertion.
+    expect(localStorage.getItem("cartItems")).toBeNull();
+    expect(localStorage.getItem("itemCount")).toBeNull();
+    expect(localStorage.getItem("totalPrice")).toBeNull();
+  });
+
+  it("is a safe no-op on an already empty cart", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    expect(() => {
+      act(() => {
+        result.current.clearCart();
+      });
+    }).not.toThrow();
+
+    expect(result.current.cartItems).toEqual([]);
+    expect(result.current.itemCount).toBe(0);
+    expect(result.current.totalPrice).toBe(0);
+  });
+
+  it("restores a stored cart when the provider is mounted again", () => {
+    const first = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      first.result.current.addToCart(item1);
+      first.result.current.addToCart(item2);
+    });
+    first.unmount();
+
+    const second = renderHook(() => useCart(), { wrapper });
+
+    expect(second.result.current.itemCount).toBe(2);
+    expect(second.result.current.totalPrice).toBe(150);
+    expect(second.result.current.cartItems).toHaveLength(2);
+  });
+
+  it("stays empty after a remount once the cart has been cleared", () => {
+    const first = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      first.result.current.addToCart(item1);
+    });
+    act(() => {
+      first.result.current.clearCart();
+    });
+    first.unmount();
+
+    // The user-visible guarantee: clearing has to survive the next mount, not
+    // just reset the totals held in memory.
+    const second = renderHook(() => useCart(), { wrapper });
+
+    expect(second.result.current.cartItems).toEqual([]);
+    expect(second.result.current.itemCount).toBe(0);
+    expect(second.result.current.totalPrice).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #29

## What this adds, and what already existed

The issue is written from the premise that `CartProvider` "has no tests". That is no longer true on `main` at `65d9dfb09c`, so before writing anything I mapped the eight requested cases against what is already there:

| requested case | status on `main` |
|---|---|
| add | covered — `CartContext.test.tsx` "adds and removes items correctly" |
| duplicate add | covered — "assigns unique cartItemId to duplicate items…" |
| remove existing | covered — same case as add |
| **remove missing** | covered — "leaves itemCount and totalPrice unchanged when removing an item not in the cart" |
| **double remove** | covered — "repeated remove calls can never produce a negative itemCount or totalPrice" |
| corrupt-storage hydration | covered — `CartContext.test.jsx`, both corrupt-JSON and non-array cases |
| **clear** | **not covered anywhere** |
| **persistence across remount** | **not covered anywhere** |

The two cases the acceptance criteria single out as the proof of the negative-`itemCount` fix — remove-missing and repeat-remove — are already present and already assert the `cartItems` / `itemCount` / `totalPrice` writes, which is the third criterion too.

So this PR adds the two that are genuinely missing rather than a second copy of the six that are not. I did not write to `tests/context/CartContext.test.jsx` as the issue suggests, because that path already holds the hydration suite and overwriting it would delete working coverage.

## Why `clearCart` was worth covering

`clearCart` is an exported part of the context value, it mutates all three pieces of state, and nothing exercises it. It also does something a totals-only assertion would miss:

```js
localStorage.removeItem("cartItems");
localStorage.removeItem("itemCount");
localStorage.removeItem("totalPrice");
```

It **removes** the keys rather than writing `"0"`. A test that only checked `itemCount === 0` would pass either way, so one case pins the absence directly — that distinction is what makes the cleared state survive the next mount instead of rehydrating from a stored zero.

## The change

New file `tests/context/CartContext.clearCart.test.tsx`, five cases, using the same `renderHook` + `wrapper` shape as the existing `CartContext.test.tsx`:

- `resets every cart total when the cart is cleared`
- `removes the stored keys rather than writing zeroes`
- `is a safe no-op on an already empty cart`
- `restores a stored cart when the provider is mounted again`
- `stays empty after a remount once the cart has been cleared`

The last one is the case worth having: it composes clear with persistence and asserts the actual user-visible guarantee, which is that clearing survives the next mount rather than only resetting the totals held in memory.

No source changes — `context/CartContext.jsx` is untouched.

## Verification

I do not have this project's toolchain installed here, so I have not run `npm run test` or `npm run type-check` myself and am not claiming those results. The file uses only the imports, provider wrapper and `localStorage` conventions already established by the three existing cart suites, and `tests/setup.ts` already supplies the jsdom `localStorage`. Please let CI run it; I will fix anything it surfaces.

If you would rather have all eight cases consolidated into one file even though six would be duplicates, say so and I will restructure — I took the narrower reading deliberately rather than assume it.
