### PR TITLE
fix(sidebar): point shop sidebar links at real routes (closes #25)

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -1,12 +1,6 @@
 "use client";
 import Link from "next/link";
-import {
-  FaHome,
-  FaInfoCircle,
-  FaPhone,
-  FaShoppingCart,
-  FaList,
-} from "react-icons/fa";
+import { FaHome, FaInfoCircle, FaShoppingCart } from "react-icons/fa";
 import { FcSportsMode } from "react-icons/fc";
 import { useAuth } from "../lib/AuthContext";
 
@@ -24,25 +18,7 @@ export default function Sidebar() {
                 className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
               >
                 <FaHome className="mr-3" />
-                Men
-              </Link>
-            </li>
-            <li>
-              <Link
-                href="/about"
-                className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
-              >
-                <FaInfoCircle className="mr-3" />
-                Women
-              </Link>
-            </li>
-            <li>
-              <Link
-                href="/contact"
-                className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
-              >
-                <FaPhone className="mr-3" />
-                Kids
+                Home
               </Link>
             </li>
             <li>
@@ -51,7 +27,7 @@ export default function Sidebar() {
                 className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
               >
                 <FaShoppingCart className="mr-3" />
-                Casual
+                Shop
               </Link>
             </li>
             <li>
@@ -60,7 +36,7 @@ export default function Sidebar() {
                 className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
               >
                 <FcSportsMode className="mr-3" />
-                Sport
+                Collections
               </Link>
             </li>
             <li>
@@ -76,15 +52,6 @@ export default function Sidebar() {
                 ""
               )}
             </li>
-            <li>
-              <Link
-                href="/categories"
-                className="flex items-center p-4 hover:bg-gray-100 hover:text-purple-500 transition-colors duration-200"
-              >
-                <FaList className="mr-3" />
-                Categories
-              </Link>
-            </li>
           </ul>
         </nav>
       </aside>
@@ -94,14 +61,6 @@ export default function Sidebar() {
       <aside className="flex flex-col justify-center  w-10 bg-purple-600 text-gray-700 flex-shrink-0  sm:hidden  pt-10">
         <nav className="divide-y divide-gray-200">
           <ul className="py-6 space-y-14 px-2">
-            <li>
-              <Link
-                href="/categories"
-                className=" hover:text-white transition-colors duration-200"
-              >
-                <FaList className="mr-3" size={20} />
-              </Link>
-            </li>
             <li>
               <Link
                 href="/shop"


### PR DESCRIPTION
## Summary

Every link in the shop sidebar now points at a route that exists, and every label matches where it goes.

Closes #25.

## The dead links

`components/Sidebar.jsx` linked to three routes with no page under `app/`:

| Link | Target | Exists? |
| --- | --- | --- |
| "Women" | `/about` | no |
| "Kids" | `/contact` | no |
| "Categories" (desktop) | `/categories` | no |
| "Categories" (mobile) | `/categories` | no |

The full route table under `app/` is `/`, `/admin`, `/admin/orders`, `/blog`, `/checkout`, `/collections`, `/orders`, `/profile/login`, `/profile/orders`, `/shop`, `/shop/[id]`. Since the sidebar renders on every shop page via `app/shop/layout.jsx`, those four clicks landed on the not-found page.

Three surviving links also carried clothing-category labels that did not describe their destination: "Men" went to `/`, "Casual" to `/shop`, "Sport" to `/collections`.

## The change

Dead entries are removed rather than repointed — there is no existing route that means "Women", "Kids" or "Categories", and inventing a destination would just move the mismatch rather than fix it. The mislabelled entries are renamed to their actual target.

Desktop and mobile now carry the same four destinations:

| Label | Target |
| --- | --- |
| Home | `/` |
| Shop | `/shop` |
| Collections | `/collections` |
| Admin (when `isAdmin`) | `/admin` |

`FaPhone` and `FaList` are dropped from the `react-icons/fa` import since nothing renders them any more; leaving them would trip `next lint`'s unused-vars rule.

## Acceptance criteria

- [x] **No sidebar link lands on the not-found page** — the eight `href` values in the file are `/`, `/shop`, `/collections`, `/admin` across the two `<aside>` blocks, all present in the route table above.
- [x] **Each label matches its destination**, cross-checked against that table.
- [x] **`next lint`** — the only lint-visible risk from this change was the two icon imports left unreferenced by the removals; both are gone. No other identifier in the file became unused (`FaHome`, `FaInfoCircle`, `FaShoppingCart` and `FcSportsMode` are each still rendered twice, and `useAuth` is still called).

## Existing tests

`tests/components/Sidebar.test.tsx` asserts that exactly two Admin links render with `href="/admin"` when `isAdmin` is true, none otherwise, and that no search input or modal appears. All of that still holds: the admin entries in both `<aside>` blocks are untouched, and nothing was added.

Only `components/Sidebar.jsx` is modified.
