### PR TITLE
test(indexer): cover decodeEvent topic naming, filter and data shapes

### DIFF
--- a/tests/lib/stellar/indexer.test.ts
+++ b/tests/lib/stellar/indexer.test.ts
@@ -1,4 +1,7 @@
+import { xdr } from "@stellar/stellar-sdk";
 import { describe, expect, it, vi } from "vitest";
+
+import type { IndexedEvent } from "../../../lib/stellar/indexer";
 import { PaymentEventIndexer } from "../../../lib/stellar/indexer";
 
 describe("PaymentEventIndexer startup retry (Issue #68)", () => {
@@ -111,5 +114,176 @@ describe("PaymentEventIndexer startup retry (Issue #68)", () => {
     await new Promise((resolve) => setTimeout(resolve, 60));
     expect(getEventsCalls).toBe(callsAtStop);
     expect(indexer.status.running).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decodeEvent - topic naming, the watched-symbol filter and the data branches.
+//
+// decodeEvent is private and touches only pure ScVal values, so these drive it
+// through a cast with hand-built fixtures. No server is constructed and no
+// request is made.
+// ---------------------------------------------------------------------------
+
+const ORDER_ID_BYTES = Buffer.alloc(32, 0x05);
+const ORDER_ID_HEX = ORDER_ID_BYTES.toString("hex");
+
+type DecodeEvent = (raw: unknown) => IndexedEvent | null;
+
+function decoderFor(watchedSymbols?: string[]): DecodeEvent {
+  const indexer = new PaymentEventIndexer(watchedSymbols ? { watchedSymbols } : {});
+  const decode = (indexer as unknown as { decodeEvent: DecodeEvent }).decodeEvent;
+  return decode.bind(indexer);
+}
+
+function eventFixture(topic: xdr.ScVal[], value: xdr.ScVal) {
+  return {
+    id: "evt-1",
+    ledger: 42,
+    ledgerClosedAt: "2026-01-01T00:00:00Z",
+    txHash: "tx-1",
+    contractId: "C-contract",
+    topic,
+    value,
+  };
+}
+
+describe("PaymentEventIndexer.decodeEvent", () => {
+  it("drops an event whose symbol is not watched", () => {
+    const raw = eventFixture([xdr.ScVal.scvSymbol("transfer")], xdr.ScVal.scvString("ignored"));
+
+    expect(decoderFor()(raw)).toBeNull();
+  });
+
+  it("drops an event whose first topic is not a symbol", () => {
+    // A string topic still reads as "pay" once stringified, so the type check
+    // is the only thing keeping a non-symbol event out.
+    const raw = eventFixture([xdr.ScVal.scvString("pay")], xdr.ScVal.scvString("ignored"));
+
+    expect(decoderFor()(raw)).toBeNull();
+  });
+
+  it("drops an event with no topics at all", () => {
+    expect(decoderFor()(eventFixture([], xdr.ScVal.scvString("x")))).toBeNull();
+  });
+
+  it("names trailing topics topic1..topicN in order", () => {
+    const raw = eventFixture(
+      [
+        xdr.ScVal.scvSymbol("dispatch"),
+        xdr.ScVal.scvString("first"),
+        xdr.ScVal.scvString("second"),
+        xdr.ScVal.scvString("third"),
+      ],
+      xdr.ScVal.scvString("data"),
+    );
+
+    const decoded = decoderFor()(raw);
+
+    expect(decoded?.symbol).toBe("dispatch");
+    expect(decoded?.fields.topic1).toBe("first");
+    expect(decoded?.fields.topic2).toBe("second");
+    expect(decoded?.fields.topic3).toBe("third");
+    expect(decoded?.fields.topic4).toBeUndefined();
+  });
+
+  it("exposes a pay order id as topic4 in 64 hex characters", () => {
+    // Regression guard for StellarOrderWatch, which reads topic4 positionally.
+    // The pay layout is [pay, token, buyer, merchant, order_id]; the address
+    // slots are strings here because decodeEvent applies the same conversion to
+    // every topic, so their encoding is not what this case pins.
+    const raw = eventFixture(
+      [
+        xdr.ScVal.scvSymbol("pay"),
+        xdr.ScVal.scvString("token"),
+        xdr.ScVal.scvString("buyer"),
+        xdr.ScVal.scvString("merchant"),
+        xdr.ScVal.scvBytes(ORDER_ID_BYTES),
+      ],
+      xdr.ScVal.scvString("data"),
+    );
+
+    const decoded = decoderFor()(raw);
+
+    expect(decoded?.fields.topic4).toBe(ORDER_ID_HEX);
+    expect(decoded?.fields.topic4).toHaveLength(64);
+  });
+
+  it("merges map data under each entry's key name", () => {
+    const raw = eventFixture(
+      [xdr.ScVal.scvSymbol("pay")],
+      xdr.ScVal.scvMap([
+        new xdr.ScMapEntry({
+          key: xdr.ScVal.scvSymbol("amount"),
+          val: xdr.ScVal.scvString("10000"),
+        }),
+        new xdr.ScMapEntry({
+          key: xdr.ScVal.scvSymbol("timestamp"),
+          val: xdr.ScVal.scvString("1700000000"),
+        }),
+      ]),
+    );
+
+    const decoded = decoderFor()(raw);
+
+    expect(decoded?.fields.amount).toBe("10000");
+    expect(decoded?.fields.timestamp).toBe("1700000000");
+    expect(decoded?.fields.value).toBeUndefined();
+  });
+
+  it("joins vec data into a single comma-separated value field", () => {
+    const raw = eventFixture(
+      [xdr.ScVal.scvSymbol("refund")],
+      xdr.ScVal.scvVec([
+        xdr.ScVal.scvString("one"),
+        xdr.ScVal.scvString("two"),
+        xdr.ScVal.scvString("three"),
+      ]),
+    );
+
+    expect(decoderFor()(raw)?.fields.value).toBe("one,two,three");
+  });
+
+  it("puts scalar data in the value field", () => {
+    const raw = eventFixture(
+      [xdr.ScVal.scvSymbol("create_order")],
+      xdr.ScVal.scvBytes(ORDER_ID_BYTES),
+    );
+
+    expect(decoderFor()(raw)?.fields.value).toBe(ORDER_ID_HEX);
+  });
+
+  it("carries the envelope fields through unchanged", () => {
+    const raw = eventFixture([xdr.ScVal.scvSymbol("pay")], xdr.ScVal.scvString("data"));
+
+    const decoded = decoderFor()(raw);
+
+    expect(decoded?.id).toBe("evt-1");
+    expect(decoded?.ledger).toBe(42);
+    expect(decoded?.ledgerClosedAt).toBe("2026-01-01T00:00:00Z");
+    expect(decoded?.txHash).toBe("tx-1");
+    expect(decoded?.contractId).toBe("C-contract");
+  });
+
+  it("honours a caller-supplied watched-symbol list", () => {
+    const decode = decoderFor(["only_this"]);
+
+    expect(decode(eventFixture([xdr.ScVal.scvSymbol("pay")], xdr.ScVal.scvString("d")))).toBeNull();
+    expect(
+      decode(eventFixture([xdr.ScVal.scvSymbol("only_this")], xdr.ScVal.scvString("d")))?.symbol,
+    ).toBe("only_this");
+  });
+
+  it("watches exactly the four lifecycle symbols the contract documents", () => {
+    // This filter is the join between the contract and the decoder. A symbol
+    // missing from it is dropped silently rather than surfacing as an error, so
+    // the default list is worth pinning next to the layouts documented in
+    // contracts/checkout/src/events.rs.
+    const decode = decoderFor();
+
+    for (const symbol of ["pay", "create_order", "dispatch", "refund"]) {
+      const decoded = decode(eventFixture([xdr.ScVal.scvSymbol(symbol)], xdr.ScVal.scvString("d")));
+      expect(decoded?.symbol).toBe(symbol);
+    }
   });
 });

--- a/tests/lib/stellar/indexer.test.ts
+++ b/tests/lib/stellar/indexer.test.ts
@@ -175,7 +175,7 @@ describe("PaymentEventIndexer.decodeEvent", () => {
         xdr.ScVal.scvString("second"),
         xdr.ScVal.scvString("third"),
       ],
-      xdr.ScVal.scvString("data"),
+      xdr.ScVal.scvString("data")
     );
 
     const decoded = decoderFor()(raw);
@@ -200,7 +200,7 @@ describe("PaymentEventIndexer.decodeEvent", () => {
         xdr.ScVal.scvString("merchant"),
         xdr.ScVal.scvBytes(ORDER_ID_BYTES),
       ],
-      xdr.ScVal.scvString("data"),
+      xdr.ScVal.scvString("data")
     );
 
     const decoded = decoderFor()(raw);
@@ -221,7 +221,7 @@ describe("PaymentEventIndexer.decodeEvent", () => {
           key: xdr.ScVal.scvSymbol("timestamp"),
           val: xdr.ScVal.scvString("1700000000"),
         }),
-      ]),
+      ])
     );
 
     const decoded = decoderFor()(raw);
@@ -238,7 +238,7 @@ describe("PaymentEventIndexer.decodeEvent", () => {
         xdr.ScVal.scvString("one"),
         xdr.ScVal.scvString("two"),
         xdr.ScVal.scvString("three"),
-      ]),
+      ])
     );
 
     expect(decoderFor()(raw)?.fields.value).toBe("one,two,three");
@@ -247,7 +247,7 @@ describe("PaymentEventIndexer.decodeEvent", () => {
   it("puts scalar data in the value field", () => {
     const raw = eventFixture(
       [xdr.ScVal.scvSymbol("create_order")],
-      xdr.ScVal.scvBytes(ORDER_ID_BYTES),
+      xdr.ScVal.scvBytes(ORDER_ID_BYTES)
     );
 
     expect(decoderFor()(raw)?.fields.value).toBe(ORDER_ID_HEX);
@@ -270,7 +270,7 @@ describe("PaymentEventIndexer.decodeEvent", () => {
 
     expect(decode(eventFixture([xdr.ScVal.scvSymbol("pay")], xdr.ScVal.scvString("d")))).toBeNull();
     expect(
-      decode(eventFixture([xdr.ScVal.scvSymbol("only_this")], xdr.ScVal.scvString("d")))?.symbol,
+      decode(eventFixture([xdr.ScVal.scvSymbol("only_this")], xdr.ScVal.scvString("d")))?.symbol
     ).toBe("only_this");
   });
 


### PR DESCRIPTION
Closes #85

## What already existed

`tests/lib/stellar/indexer.test.ts` is present on `main`, but its three cases all cover the startup-retry path from #68 — `decodeEvent` itself has no coverage. So this appends a new `describe` block rather than creating the file the issue describes; overwriting it would delete the #68 suite.

## The cases

`decodeEvent` is private and touches only pure `ScVal` values, so the tests reach it through a cast and drive it with hand-built fixtures. No server is contacted and no request is made — the constructor is left to build its own `rpc.Server`, which is never used because `decodeEvent` is called directly.

| case | asserts |
|---|---|
| drops an event whose symbol is not watched | the `watchedSymbols` filter |
| drops an event whose first topic is not a symbol | the `scvSymbol` type check — a `scvString("pay")` still stringifies to `pay`, so the type check is the only thing keeping it out |
| drops an event with no topics at all | the empty-topic guard |
| names trailing topics `topic1..topicN` in order | positional naming, and that `topic4` is absent when only three trailing topics exist |
| exposes a pay order id as `topic4` in 64 hex characters | the acceptance criterion, and the regression guard for `StellarOrderWatch` |
| merges map data under each entry's key name | the `scvMap` branch, and that it does **not** also set `value` |
| joins vec data into a comma-separated `value` | the `scvVec` branch |
| puts scalar data in `value` | the fallback branch |
| carries the envelope fields through unchanged | id, ledger, ledgerClosedAt, txHash, contractId |
| honours a caller-supplied watched-symbol list | the constructor option, both directions |
| watches exactly the four lifecycle symbols the contract documents | the default filter |

## Two notes on the fixtures

**Addresses are represented as strings.** The pay layout is `[pay, token, buyer, merchant, order_id]`, and the three address slots are `scvString` rather than `scvAddress`. `decodeEvent` applies the same `scValToString` to every trailing topic regardless of type, so address encoding is not what this case pins — the order id at `topic4` is. Using placeholder strings keeps the fixture from depending on a hand-written strkey.

**The last case is deliberate rather than decorative.** The watched-symbol list is the join between the contract and this decoder, and a symbol missing from it is dropped *silently* — `decodeEvent` returns `null` and the poll loop simply sees nothing, with no error anywhere. That makes the default list worth pinning next to the layouts documented in `contracts/checkout/src/events.rs`. I raised the same coupling from the contract side in #368.

## Verification

No source changes — `lib/stellar/indexer.ts` is untouched.

I do not have this project's toolchain installed in this environment, so I have not run `npm run test` or `npm run type-check` myself and am not claiming those results. The file uses the imports, `vitest` style and cast-to-reach-internals pattern already established by the existing suite in the same file. Please let CI run it; I will fix anything it surfaces.
