### PR TITLE
ci: install cargo-audit via prebuilt binary action (closes #104)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,9 @@ jobs:
           toolchain: stable
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
 
       - name: Run cargo audit
         working-directory: contracts/checkout


### PR DESCRIPTION
### Summary of Changes (Closes #104)

- Replaces the compilation from source of \cargo-audit\ (\cargo install cargo-audit --locked\) in \.github/workflows/ci.yml\ with \	aiki-e/install-action@v2\.
- Configures \with: tool: cargo-audit\ to download the official prebuilt binary directly from GitHub releases.
- Eliminates ~3–4 minutes of compilation overhead on every pipeline run while preserving the complete \cargo audit\ security step under \contracts/checkout\.

### Acceptance Criteria Checklist
- [x] \cargo install cargo-audit\ is completely removed from \ci.yml\.
- [x] Prebuilt binary artifact is resolved directly in seconds via \	aiki-e/install-action@v2\.
- [x] Validated YAML structure with \yaml.safe_load\.