### PR TITLE
fix(toast): respect display duration and keep JSX parseable

### DIFF
--- a/components/Toast.jsx
+++ b/components/Toast.jsx
@@ -7,28 +7,22 @@ const Toast = ({ message, show, onClose, time = 3000 }) => {
     if (show) {
       setVisible(true);
 
+      let exitTimer = null;
       const timer = setTimeout(() => {
         setVisible(false);
-      }, time);
-
-      let exitTimer: ReturnType<typeof setTimeout> | null = null;
-      const scheduleExit = () => {
         exitTimer = setTimeout(() => {
           onClose();
         }, 300);
-      };
-
-      const exitScheduler = setTimeout(scheduleExit, 0);
+      }, time);
 
       return () => {
         clearTimeout(timer);
-        clearTimeout(exitScheduler);
         if (exitTimer !== null) clearTimeout(exitTimer);
       };
     } else {
       setVisible(false);
     }
-  }, [show, onClose, time]);
+  }, [show, onClose, time, message]);
 
   return (
     <div

--- a/tests/components/Toast.test.jsx
+++ b/tests/components/Toast.test.jsx
@@ -1,57 +1,90 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, fireEvent, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import Toast from "../../components/Toast";
 
-describe("Toast exit-timer cleanup", () => {
+const advance = (milliseconds) => act(() => vi.advanceTimersByTime(milliseconds));
+
+describe("Toast display and exit timers", () => {
+  beforeEach(() => vi.useFakeTimers());
+
   afterEach(() => {
+    cleanup();
     vi.useRealTimers();
   });
 
-  it("does not call onClose for a fresh toast shown within the exit window", () => {
-    vi.useFakeTimers();
-    const onCloseA = vi.fn();
-    const onCloseB = vi.fn();
-
-    const { rerender } = render(<Toast message="A" show={true} onClose={onCloseA} time={3000} />);
-
-    // Re-show with new toast B within 300ms exit window
-    rerender(<Toast message="B" show={true} onClose={onCloseB} time={3000} />);
-
-    // Advance past the 3000ms display + 300ms exit for A
-    vi.advanceTimersByTime(3500);
-
-    // B should still be visible and its onClose should NOT have been called
-    expect(onCloseB).not.toHaveBeenCalled();
-    expect(screen.getByText("B")).toBeInTheDocument();
-  });
-
-  it("does not call onClose after unmounting mid-exit", () => {
-    vi.useFakeTimers();
+  it.each([3000, 1000])("waits %i ms before exiting, then closes after 300 ms", (time) => {
     const onClose = vi.fn();
+    render(<Toast message="Saved" show={true} onClose={onClose} time={time} />);
 
-    const { unmount } = render(<Toast message="test" show={true} onClose={onClose} time={3000} />);
-
-    // Advance to just before the exit timer fires
-    vi.advanceTimersByTime(3100);
-
-    // Unmount while the toast is in its exit phase
-    unmount();
-
-    // Advance past the 300ms exit window
-    vi.advanceTimersByTime(400);
-
+    advance(time - 1);
+    expect(screen.getByText("Saved")).toHaveClass("translate-x-0", "opacity-100");
     expect(onClose).not.toHaveBeenCalled();
+
+    advance(1);
+    expect(screen.getByText("Saved")).toHaveClass("translate-x-full", "opacity-0");
+    expect(onClose).not.toHaveBeenCalled();
+
+    advance(299);
+    expect(onClose).not.toHaveBeenCalled();
+    advance(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    advance(time);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("calls onClose after the full display + exit duration when not interrupted", () => {
-    vi.useFakeTimers();
+  it("cancels the old exit when a new message uses the same close callback", () => {
     const onClose = vi.fn();
+    const { rerender } = render(<Toast message="A" show={true} onClose={onClose} />);
 
-    render(<Toast message="test" show={true} onClose={onClose} time={3000} />);
+    advance(3100);
+    rerender(<Toast message="B" show={true} onClose={onClose} />);
+    advance(200);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText("B")).toHaveClass("opacity-100");
 
-    // Advance past display (3000) + exit (300)
-    vi.advanceTimersByTime(3500);
-
+    advance(2800);
+    expect(screen.getByText("B")).toHaveClass("opacity-0");
+    expect(onClose).not.toHaveBeenCalled();
+    advance(300);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels the previous callback when the callback changes during exit", () => {
+    const previousClose = vi.fn();
+    const nextClose = vi.fn();
+    const { rerender } = render(<Toast message="Saved" show={true} onClose={previousClose} />);
+
+    advance(3100);
+    rerender(<Toast message="Saved" show={true} onClose={nextClose} />);
+    advance(200);
+    expect(previousClose).not.toHaveBeenCalled();
+    expect(nextClose).not.toHaveBeenCalled();
+
+    advance(3100);
+    expect(previousClose).not.toHaveBeenCalled();
+    expect(nextClose).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([1000, 3100])("cancels pending callbacks when hidden at %i ms", (elapsed) => {
+    const onClose = vi.fn();
+    const { rerender } = render(<Toast message="Saved" show={true} onClose={onClose} />);
+
+    advance(elapsed);
+    rerender(<Toast message="Saved" show={false} onClose={onClose} />);
+    advance(4000);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText("Saved")).toHaveClass("opacity-0");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each([1000, 3100])("cleans up both timers when unmounted at %i ms", (elapsed) => {
+    const onClose = vi.fn();
+    const { unmount } = render(<Toast message="Saved" show={true} onClose={onClose} />);
+
+    advance(elapsed);
+    unmount();
+    advance(4000);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
   });
 });


### PR DESCRIPTION
The Toast exit timer starts immediately, so `onClose` runs after roughly 300 ms even when `time` is 3000 ms. The component also contains a TypeScript variable annotation in a `.jsx` file, which stops Next lint and TypeScript parsing.

Schedule the 300 ms exit timer after the display timeout, keep both timer handles available to effect cleanup, and use JavaScript syntax. A changed message restarts the display period and cancels the previous exit callback.

The eight component regression cases cover default/custom display durations, changed messages with a stable callback, callback replacement, hiding, and unmounting during both timer phases. They all fail on the original component and all pass with this change. Related timer-cleanup context: #23.

Validation on Node 24.19.0 / Vitest 1.6.1, based on main `65d9dfb09cbf544edbd0d6ac2954219427f734c7`:

- Focused Toast tests: 8/8 pass.
- Prettier for both changed files and `git diff --check`: pass.
- Full `npm run lint` and `npm run type-check`: pass; existing lint warnings remain.
- `npm run build`: passes with the CI dummy environment values.
- Full frontend suite: 224 pass, 9 fail, plus an empty validation test file. Remaining failures are in unchanged cart, ContactUs, checkout, and product-update tests.

Only `components/Toast.jsx` and its existing test file change. Prepared with Codex assistance.