### PR TITLE
docs: add missing EmailJS variables to README environment reference (closes #60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,10 @@ It prints the `NEXT_PUBLIC_CHECKOUT_CONTRACT_ID` to paste into `.env.local`.
 | `NEXT_PUBLIC_USDC_CONTRACT_ID`        | no       | USDC token contract (testnet default)     |
 | `NEXT_PUBLIC_NATIVE_ASSET_CONTRACT_ID`| no       | Native XLM SAC (verified testnet default) |
 | `PUBLIC_MERCHANT_ADDRESS`             | no       | Display-only merchant wallet (on-chain value is authoritative) |
+| `NEXT_PUBLIC_EMAILJS_SERVICE_ID`      | yes      | EmailJS service ID (for OTP and notifications) |
+| `NEXT_PUBLIC_EMAILJS_TEMPLATE_ID`     | yes      | EmailJS template ID                       |
+| `NEXT_PUBLIC_EMAILJS_PUBLIC_KEY`      | yes      | EmailJS public key                        |
+| `NEXT_PUBLIC_DEFAULT_RECIPIENT_EMAIL` | no       | Default recipient email for EMAILJS contact forms |
 | `NEXT_PUBLIC_SUPABASE_URL`            | yes      | Supabase project URL                      |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY`       | yes      | Supabase anon/public key                  |
 | `NEXT_PUBLIC_ADMIN_EMAILS`            | no       | Comma-separated admin emails              |


### PR DESCRIPTION
## Summary

Adds the four EmailJS configuration variables declared in `.env.local.example` to the `Environment Variables Reference` table in `README.md`, completing the documentation for OTP and contact notification setup.

Closes #60

### Changes
- Added table rows for:
  - `NEXT_PUBLIC_EMAILJS_SERVICE_ID` (required: yes) — EmailJS service ID (for OTP and notifications)
  - `NEXT_PUBLIC_EMAILJS_TEMPLATE_ID` (required: yes) — EmailJS template ID
  - `NEXT_PUBLIC_EMAILJS_PUBLIC_KEY` (required: yes) — EmailJS public key
  - `NEXT_PUBLIC_DEFAULT_RECIPIENT_EMAIL` (required: no) — Default recipient email for EMAILJS contact forms
- Preserved exact CRLF line endings to prevent line-ending churn across unaffected markdown sections or phantom diffs on repository media assets.

### Acceptance Criteria Verification
- [x] **All variables included**: All four EmailJS variables from `.env.local.example` now appear as formatted rows in `README.md`.
- [x] **grep verification**: `git grep -n "EMAILJS" README.md` returns **exactly 4 table rows** (lines 477–480).
- [x] **Zero line churn**: Strictly 1 file changed with exactly 4 insertions (`README.md | 4 ++++`).
