### PR TITLE
docs: remove duplicate sentence fragment in environment setup (closes #59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,6 @@ Copy the template and fill in your values:
 cp .env.local.example .env.local
 ```
 
-A minimal Stellar-only configuration (the rest of the app runs with the existing
 A minimal Stellar-only configuration (fill Supabase values for auth/catalog):
 
 ```bash


### PR DESCRIPTION
## Summary

Removes the duplicate truncated sentence fragment from the environment setup section in `README.md`, leaving a single, coherent introductory sentence before the minimal configuration code block.

Closes #59

### Changes
- **`README.md` (lines 274–275)**: Removed the broken fragment `"A minimal Stellar-only configuration (the rest of the app runs with the existing"`. The text now flows naturally as `"A minimal Stellar-only configuration (fill Supabase values for auth/catalog):"`.
- **Line Ending Hygiene**: Preserved exact CRLF line endings, preventing line-ending churn across unaffected markdown sections or phantom binary diffs on media assets.

### Acceptance Criteria Verification
- [x] **Coherent single sentence**: Text between the `cp` command and the env snippet is now a single grammatical sentence.
- [x] **Single match**: `git grep -n "minimal Stellar-only configuration" README.md` returns **exactly 1 line** (line 274).
- [x] **Surgical diff**: Strictly 1 file changed, 1 deletion (`README.md | 1 -`).
