### PR TITLE
fix(stellar): reconcile mainnet rpc defaults across code and docs (closes #108)

### DIFF
--- a/lib/stellar/config.ts
+++ b/lib/stellar/config.ts
@@ -18,7 +18,7 @@ export const IS_MAINNET = NETWORK === "mainnet";
 export const RPC_URL =
   process.env.NEXT_PUBLIC_STELLAR_RPC_URL ??
   (IS_MAINNET
-    ? "https://soroban-rpc.stellar.org"
+    ? "https://soroban-rpc.mainnet.stellar.gateway.fm"
     : "https://soroban-testnet.stellar.org");
 
 export const NETWORK_PASSPHRASE =

--- a/tests/lib/env.test.ts
+++ b/tests/lib/env.test.ts
@@ -100,3 +100,49 @@ describe("validateEnv", () => {
     expect(config.admin.adminEmails).toContain("admin@store.org");
   });
 });
+
+describe("mainnet RPC defaults", () => {
+  const GATEWAY_FM = "https://soroban-rpc.mainnet.stellar.gateway.fm";
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function stubMainnetUnset() {
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_NETWORK", "mainnet");
+    vi.stubEnv("NEXT_PUBLIC_CHECKOUT_CONTRACT_ID", "CA1234567890TESTCONTRACTID");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://project.supabase.co");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key-123");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_SERVICE_ID", "service_abc");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_TEMPLATE_ID", "template_xyz");
+    vi.stubEnv("NEXT_PUBLIC_EMAILJS_PUBLIC_KEY", "pubkey_789");
+    // config.ts uses `??` (empty string is NOT nullish), so the var must be
+    // truly absent to exercise the compiled-in default.
+    delete process.env.NEXT_PUBLIC_STELLAR_RPC_URL;
+  }
+
+  it("validateEnv defaults to canonical gateway.fm mainnet RPC when unset", () => {
+    stubMainnetUnset();
+
+    expect(validateEnv().stellar.rpcUrl).toBe(GATEWAY_FM);
+  });
+
+  it("config.ts RPC_URL and env.ts resolve the same mainnet default (single source of truth)", async () => {
+    stubMainnetUnset();
+    const config = await import("../../lib/stellar/config");
+
+    expect(config.RPC_URL).toBe(GATEWAY_FM);
+    expect(validateEnv().stellar.rpcUrl).toBe(config.RPC_URL);
+  });
+
+  it("explicit NEXT_PUBLIC_STELLAR_RPC_URL override is respected", () => {
+    stubMainnetUnset();
+    vi.stubEnv("NEXT_PUBLIC_STELLAR_RPC_URL", "https://my-own-rpc.example/rpc");
+
+    expect(validateEnv().stellar.rpcUrl).toBe("https://my-own-rpc.example/rpc");
+  });
+});


### PR DESCRIPTION
## Summary (revised after live endpoint verification)

Reconciles the divergent mainnet RPC defaults to one canonical endpoint: https://soroban-rpc.mainnet.stellar.gateway.fm.

Closes #108

### Why gateway.fm (empirical, not preference)
- https://soroban-rpc.stellar.org is **unreachable**: curl returns 000 / DNS timeout, and SDF docs confirm they run no public JSON-RPC endpoint for mainnet (only Horizon + testnet RPC).
- https://soroban-rpc.mainnet.stellar.gateway.fm **responds live** (HTTP reply + resolves to real IPs) and is already the value in 2 of the 3 places (\lib/env.ts\, \docs/MAINNET_DEPLOYMENT.md\).
- So the true single-source fix is 1 line in \lib/stellar/config.ts\; env + docs already agreed.

### Changes
- **\lib/stellar/config.ts:21\**: mainnet default \soroban-rpc.stellar.org\ -> \soroban-rpc.mainnet.stellar.gateway.fm\ (1 line).
- **\	ests/lib/env.test.ts\**: new \mainnet RPC defaults\ suite (3 tests): validateEnv default, cross-module equality \config.RPC_URL === validateEnv().stellar.rpcUrl\, explicit override respected.

### Verification
- [x] \
px vitest run tests/lib/env.test.ts\: 14/14 pass
- [x] repo-wide search for \soroban-rpc.stellar.org\: 0 matches
- [x] \	sc --noEmit --skipLibCheck\: only 1 pre-existing error in untouched \components/Toast.jsx\ (TS8010)
- [x] diff isolated to 2 files, zero production behavior change except the 1 default string

Note: GrantFox milestone/bounty application for this issue to follow; happy to link the id here once acknowledged.

Stellar payout: GB4FTXNRXFSVDDNNT7HZUEWIAPWMATIR7K7UGE2A7NPIRYP2TPM6YPPY