### PR TITLE
fix(landingpage): render slider images once with unique keys (closes #75)

### DIFF
--- a/app/(landingpage)/Slider.jsx
+++ b/app/(landingpage)/Slider.jsx
@@ -12,9 +12,9 @@ const Slider = () => {
   return (
     <section className="py-14 overflow-hidden bg-mova-surface/60">
       <div className="flex gap-6 overflow-x-auto px-6 md:px-10 pb-2">
-        {[...images, ...images].map((src, index) => (
+        {images.map((src) => (
           <Image
-            key={index}
+            key={src}
             src={src}
             alt="Mova Store footwear"
             width={240}

--- a/tests/(landingpage)/landingpage.test.tsx
+++ b/tests/(landingpage)/landingpage.test.tsx
@@ -4,9 +4,48 @@ import React from "react";
 import FAQ from "../../app/(landingpage)/FAQ";
 import Newsletter from "../../app/(landingpage)/newsletter";
 import ContactUs from "../../app/(landingpage)/ContactUs";
+import Slider from "../../app/(landingpage)/Slider";
 import * as sendMailModule from "../../lib/sendmail";
 
 describe("Landing Page Components", () => {
+  describe("Slider Component", () => {
+    it("renders each image once without duplicating DOM elements (5 images, not 10)", () => {
+      render(<Slider />);
+
+      const images = screen.getAllByRole("img");
+      expect(images).toHaveLength(5);
+
+      const sources = images.map((img) => img.getAttribute("src"));
+      expect(new Set(sources).size).toBe(5);
+    });
+
+    it("renders images with stable unique keys without duplicate key console warnings", () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      render(<Slider />);
+
+      const duplicateKeyWarnings = consoleErrorSpy.mock.calls
+        .map((call) => call[0])
+        .filter(
+          (msg) =>
+            typeof msg === "string" &&
+            (msg.includes("two children with the same key") ||
+              msg.includes("duplicate key") ||
+              msg.includes("Encountered two children with the same key"))
+        );
+
+      expect(duplicateKeyWarnings).toHaveLength(0);
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("renders exactly 5 image children in the horizontal scroll container", () => {
+      const { container } = render(<Slider />);
+      const scrollContainer = container.querySelector(".overflow-x-auto");
+      expect(scrollContainer).toBeInTheDocument();
+      expect(scrollContainer?.children).toHaveLength(5);
+    });
+  });
+
   describe("FAQ Component", () => {
     it("asserts exactly one panel is open and aria-expanded toggles", () => {
       render(<FAQ />);


### PR DESCRIPTION
## Summary

Eliminates DOM duplication and React key collisions in the landing page `Slider` component by rendering the image list directly with stable, unique `key={src}` attributes instead of duplicating array nodes.

Closes #75

### Changes
- **`app/(landingpage)/Slider.jsx`**:
  - Removed `[...images, ...images]` array duplication.
  - Replaced index-based `key={index}` with stable, unique `key={src}`.
  - The horizontal scroll container now mounts exactly 5 `<img>` elements instead of 10.
- **`tests/(landingpage)/landingpage.test.tsx`**:
  - Added unit test suite covering:
    - DOM count assertions (exactly 5 `<img>` elements, 5 unique sources).
    - Verification that `console.error` receives no duplicate React key warnings.
    - Verification that container holds exactly 5 children.

### Acceptance Criteria Verification
- [x] Rendering `<Slider />` produces no duplicate-key console warning.
- [x] The container renders exactly 5 `<img>` elements, not 10.
- [x] Looping effect / horizontal scroll operates cleanly without duplicated DOM nodes.
