### PR TITLE
docs: fix dead 'Paying with USDC (testnet)' anchors in README and CONTRIBUTING (closes #46)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,7 +219,7 @@ npm run build        # Production build must succeed
 
 If your PR touches the Stellar payment flow, describe in the PR how you tested
 it against testnet (Freighter + USDC faucet account). Follow the flow in the
-root [README](README.md#paying-with-usdc-testnet).
+root [README](README.md#paying-with-stellar-testnet).
 
 ## Commit Message Style
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ buyer ──pay──▶ contract (escrow) ──dispatch──▶ merchant
   - [Step 5 — Initialize with your merchant wallet](#step-5--initialize-with-your-merchant-wallet)
   - [Step 6 — Wire the deployed contract to the storefront](#step-6--wire-the-deployed-contract-to-the-storefront)
   - [Convenience script](#convenience-script)
-- [Paying with USDC (testnet)](#paying-with-usdc-testnet)
+- [Paying with Stellar (testnet)](#paying-with-stellar-testnet)
 - [Environment Variables Reference](#environment-variables-reference)
 - [Security Notes](#security-notes)
 - [Contributing](#contributing)


### PR DESCRIPTION
### Summary of Changes (Closes #46)

#### Context
`README.md`'s table of contents linked to `[Paying with USDC (testnet)](#paying-with-usdc-testnet)` (line 84), but the actual body heading is `## Paying with Stellar (testnet)` (line 448), whose canonical GitHub slug is `#paying-with-stellar-testnet`. `CONTRIBUTING.md:222` also deep-linked to the same non-existent anchor (`README.md#paying-with-usdc-testnet`), causing both links to dead-end on rendered GitHub pages.

#### Implementation Details
- **`README.md`**: Updated the Table of Contents entry from `- [Paying with USDC (testnet)](#paying-with-usdc-testnet)` to `- [Paying with Stellar (testnet)](#paying-with-stellar-testnet)`.
- **`CONTRIBUTING.md`**: Updated the manual payment testing link from `root [README](README.md#paying-with-usdc-testnet)` to `root [README](README.md#paying-with-stellar-testnet)`.
- Preserved original line terminators with zero extraneous diff noise (strictly +1/-1 in each file).

#### Acceptance Criteria Verification
- `grep 'paying-with-usdc-testnet' README.md CONTRIBUTING.md`: **0 matches** (clean).
- `grep 'paying-with-stellar-testnet' README.md CONTRIBUTING.md`: **2 matches** (TOC entry & CONTRIBUTING link).
- Every TOC deep link in `README.md` resolves to an existing heading slug (**24/24 verified**).
