### PR TITLE
fix(footer): correct Terms of Use typo and map legal/support links (#80)

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -8,25 +8,25 @@ export default function Footer() {
       <section className="container mx-auto flex h-28 flex-col items-center justify-between divide-black text-center font-normal sm:flex-row sm:divide-x-2 sm:divide-white/30">
         <span className="my-10 hidden gap-2 text-sm sm:my-0 sm:flex">
           <Link
-            href="/"
+            href="/terms"
             className="transition hover:underline hover:underline-offset-1"
           >
-            Term of use
+            Terms of Use
           </Link>
           <Link
-            href="/"
+            href="/privacy"
             className="transition hover:underline hover:underline-offset-1"
           >
             Privacy Policy
           </Link>
           <Link
-            href="/"
+            href="/#aboutus"
             className="transition hover:underline hover:underline-offset-1"
           >
             About us
           </Link>
           <Link
-            href="/"
+            href="/#contact"
             className="transition hover:underline hover:underline-offset-1"
           >
             24/7 Customer Service


### PR DESCRIPTION
Fixes #80
/claim #80

## Summary
Fixes footer links in `components/Footer.jsx` that were hardcoded to `/` (bouncing user to root) and corrects the grammar typo 'Term of use' to 'Terms of Use'.

## Changes
- Corrected 'Term of use' typo to 'Terms of Use'.
- Routed 'About us' to `/#aboutus` and '24/7 Customer Service' to `/#contact`.
- Mapped legal links to dedicated `/terms` and `/privacy` targets.