### PR TITLE
fix(cart): preserve row identity in both shop modals

### DIFF
--- a/app/shop/[id]/page.jsx
+++ b/app/shop/[id]/page.jsx
@@ -89,8 +89,11 @@ const ProductPage = ({ params }) => {
           <p>Your cart is empty.</p>
         ) : (
           <div>
-            {cartItems.map((item) => (
-              <div key={item.id} className="flex justify-between items-center mb-2">
+            {cartItems.map((item, index) => (
+              <div
+                key={item.cartItemId || item.lineId || `${item.id}-${index}`}
+                className="flex justify-between items-center mb-2"
+              >
                 <div className="w-16 h-16 flex-shrink-0">
                   <Image
                     src={item.img}

--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -91,8 +91,11 @@ export default function Products() {
           <p>Your cart is empty.</p>
         ) : (
           <div>
-            {cartItems.map((item) => (
-              <div key={item.id} className="flex justify-between items-center mb-2">
+            {cartItems.map((item, index) => (
+              <div
+                key={item.cartItemId || item.lineId || `${item.id}-${index}`}
+                className="flex justify-between items-center mb-2"
+              >
                 <div className="w-16 h-16 flex-shrink-0">
                   <Image
                     src={item.img} // Ensure this URL is correct

--- a/tests/components/ShopCartRows.test.tsx
+++ b/tests/components/ShopCartRows.test.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ShopPage from "../../app/shop/page";
+import ProductPage from "../../app/shop/[id]/page";
+import { useCart } from "../../context/CartContext";
+import { getProductById, listProducts } from "../../lib/products";
+
+vi.mock("../../context/CartContext", () => ({ useCart: vi.fn() }));
+vi.mock("../../lib/products", () => ({ listProducts: vi.fn(), getProductById: vi.fn() }));
+vi.mock("../../components/Toast", () => ({ default: () => null }));
+
+const product = { id: "runner-42", name: "Mova Runner", price: 75, img: "/images/shoe1.png" };
+type CartRow = typeof product & { cartItemId?: string; lineId?: string };
+const removeFromCart = vi.fn();
+
+function setCartRows(cartItems: CartRow[]) {
+  vi.mocked(useCart).mockReturnValue({
+    cartItems,
+    itemCount: cartItems.length,
+    totalPrice: cartItems.reduce((sum, item) => sum + item.price, 0),
+    addToCart: vi.fn(),
+    removeFromCart,
+  });
+}
+
+describe.each([
+  { name: "shop page", page: <ShopPage /> },
+  { name: "product page", page: <ProductPage params={{ id: product.id }} /> },
+])("$name cart rows", ({ page }) => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listProducts).mockResolvedValue([]);
+    vi.mocked(getProductById).mockResolvedValue(product);
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function expectUniqueRowKeys() {
+    const warnings = consoleError.mock.calls.filter((args) =>
+      args.some((arg) => typeof arg === "string" && arg.includes("same key"))
+    );
+    expect(warnings).toHaveLength(0);
+  }
+
+  describe.each(["cartItemId", "lineId"] as const)("with %s identities", (idField) => {
+    it.each([0, 1])(
+      "keeps the other row's DOM identity when row %i is removed",
+      async (removedIndex) => {
+        const rows: CartRow[] = [
+          { ...product, [idField]: "first-line" },
+          { ...product, [idField]: "second-line" },
+        ];
+        setCartRows(rows);
+        const view = render(page);
+        await act(async () => {});
+        fireEvent.click(screen.getByRole("button", { name: "2" }));
+
+        const buttons = screen.getAllByRole("button", { name: "Remove" });
+        expect(buttons).toHaveLength(2);
+        expectUniqueRowKeys();
+
+        fireEvent.click(buttons[removedIndex]);
+        expect(removeFromCart).toHaveBeenCalledTimes(1);
+        expect(removeFromCart.mock.calls[0][0]).toBe(rows[removedIndex]);
+
+        // Feed back the context's next value; this test exercises the actual
+        // modal consumer, while CartContext tests own the removal algorithm.
+        const remainingIndex = 1 - removedIndex;
+        setCartRows([rows[remainingIndex]]);
+        view.rerender(React.cloneElement(page));
+
+        const remainingButton = screen.getByRole("button", { name: "Remove" });
+        expect(remainingButton).toBe(buttons[remainingIndex]);
+        fireEvent.click(remainingButton);
+        expect(removeFromCart).toHaveBeenCalledTimes(2);
+        expect(removeFromCart.mock.calls[1][0]).toBe(rows[remainingIndex]);
+        expectUniqueRowKeys();
+      }
+    );
+  });
+
+  it("renders legacy duplicate products without key warnings and routes each callback", async () => {
+    const rows = [{ ...product }, { ...product }];
+    setCartRows(rows);
+    render(page);
+    await act(async () => {});
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+
+    const buttons = screen.getAllByRole("button", { name: "Remove" });
+    expect(buttons).toHaveLength(2);
+    expectUniqueRowKeys();
+
+    fireEvent.click(buttons[1]);
+    fireEvent.click(buttons[0]);
+    expect(removeFromCart.mock.calls[0][0]).toBe(rows[1]);
+    expect(removeFromCart.mock.calls[1][0]).toBe(rows[0]);
+  });
+});


### PR DESCRIPTION
Both shop cart modals currently key rows by product ID. When two cart lines contain the same product, React receives duplicate keys and can reuse the removed row's DOM for the remaining line. Both pages now prefer `cartItemId`, then `lineId`, with a product/index fallback for legacy rows.

This restores the consumer contract introduced by Ranjeet2063 in #335. It complements the CartContext identity creation/removal work in #353; this PR changes only the two modal consumers. The legacy fallback avoids duplicate keys but does not provide stable identity when legacy rows are reordered or removed. Full duplicate-row removal also needs the context behavior.

Validation on base `65d9dfb`:

- Ten tests render the actual shop and product pages, cover both identity formats and either removal order, verify exact callback objects, and preserve the remaining identified row's DOM node. All ten fail with the original keys and pass with this patch.
- Focused ESLint, Prettier and diff checks pass.
- Full frontend suite: 227 passed, 11 failed, plus an empty validation test file; failures are in unchanged tests.
- Full lint, type-check and build stop at the existing TypeScript annotation in `components/Toast.jsx:14`, addressed separately by #388.

Related to the completed #24/#335 work; this is an ordinary regression follow-up with no new bounty claim.