### PR TITLE
test(checkout): assert exact topics and data for lifecycle events (closes #91)

### DIFF
--- a/contracts/checkout/src/test.rs
+++ b/contracts/checkout/src/test.rs
@@ -3,6 +3,7 @@
 use soroban_sdk::testutils::{Address as _, Events};
 use soroban_sdk::token::{StellarAssetClient, TokenClient};
 use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env};
+use soroban_sdk::hex;
 
 use crate::errors::Error;
 use crate::order::Status;
@@ -437,17 +438,134 @@ fn test_events_emitted() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (client, token, _, buyer, checkout) = setup_usdc(&env);
+    let (client, token, merchant, buyer, checkout) = setup_usdc(&env);
     let id = order_id(&env, 5);
+    let amount = 10_000_i128;
 
-    client.create_order(&buyer, &id, &token, &10_000);
-    client.pay(&token, &buyer, &id, &10_000);
+    client.create_order(&buyer, &id, &token, &amount);
+    client.pay(&token, &buyer, &id, &amount);
     client.dispatch(&id);
 
-    // At least one contract event should be recorded for the lifecycle.
-    let events = env.events().all().filter_by_contract(&checkout);
-    assert!(
-        !events.events().is_empty(),
-        "expected contract events for create/pay/dispatch"
+    // Collect all contract-level events (one per lifecycle step).
+    let contract_events: Vec<_> = env
+        .events()
+        .all()
+        .filter_by_contract(&checkout)
+        .events()
+        .collect();
+    assert_eq!(contract_events.len(), 3, "expected 3 lifecycle events");
+
+    // Helper: read topic symbols as strings.
+    fn topic_symbols(ev: &soroban_sdk::Event) -> Vec<String> {
+        ev.topic()
+            .iter()
+            .map(|v| v.symbol().to_string())
+            .collect()
+    }
+    // Helper: read topic[1] as an Address string.
+    fn topic_address(ev: &soroban_sdk::Event, idx: usize) -> String {
+        ev.topic()[idx].address().unwrap().to_string()
+    }
+    // Helper: read topic[N<32>] as hex bytes string.
+    fn topic_bytes_n(ev: &soroban_sdk::Event, idx: usize) -> String {
+        let b = ev.topic()[idx].bytesn().unwrap();
+        b.iter().map(|b| format!("{:02x}", b)).collect()
+    }
+    // Helper: read data as i128.
+    fn data_i128(ev: &soroban_sdk::Event) -> i128 {
+        ev.data().i128().unwrap()
+    }
+
+    // --- Event 0: OrderCreated (create_order) ---
+    // Topics: "create_order", token, buyer, order_id
+    let ev0 = &contract_events[0];
+    let syms0 = topic_symbols(ev0);
+    assert_eq!(syms0[0], "create_order", "event 0 must be OrderCreated");
+    assert_eq!(syms0[1], token.to_string(), "token topic mismatch");
+    assert_eq!(syms0[2], buyer.to_string(), "buyer topic mismatch");
+    assert_eq!(
+        topic_bytes_n(ev0, 3),
+        soroban_sdk::hex::encode(id.to_array()),
+        "order_id topic mismatch"
     );
+    assert_eq!(data_i128(ev0), amount, "OrderCreated data amount mismatch");
+
+    // --- Event 1: PaymentReceived (pay) ---
+    // Topics: "pay", token, buyer, merchant, order_id
+    let ev1 = &contract_events[1];
+    let syms1 = topic_symbols(ev1);
+    assert_eq!(syms1[0], "pay", "event 1 must be PaymentReceived");
+    assert_eq!(syms1[1], token.to_string(), "pay token topic mismatch");
+    assert_eq!(syms1[2], buyer.to_string(), "pay buyer topic mismatch");
+    assert_eq!(syms1[3], merchant.to_string(), "pay merchant topic mismatch");
+    assert_eq!(
+        topic_bytes_n(ev1, 4),
+        soroban_sdk::hex::encode(id.to_array()),
+        "pay order_id topic mismatch"
+    );
+    assert_eq!(data_i128(ev1), amount, "PaymentReceived data amount mismatch");
+
+    // --- Event 2: OrderShipped (dispatch) ---
+    // Topics: "dispatch", order_id, merchant
+    let ev2 = &contract_events[2];
+    let syms2 = topic_symbols(ev2);
+    assert_eq!(syms2[0], "dispatch", "event 2 must be OrderShipped");
+    assert_eq!(
+        topic_bytes_n(ev2, 1),
+        soroban_sdk::hex::encode(id.to_array()),
+        "dispatch order_id topic mismatch"
+    );
+    assert_eq!(syms2[2], merchant.to_string(), "dispatch merchant topic mismatch");
+    assert_eq!(data_i128(ev2), amount, "OrderShipped data amount mismatch");
+}
+
+/// Test that the refund lifecycle emits a correctly-shaped OrderRefunded event.
+#[test]
+fn test_refund_event_emitted() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, token, _, buyer, checkout) = setup_usdc(&env);
+    let id = order_id(&env, 8);
+    let amount = 100_000_i128;
+
+    client.pay(&token, &buyer, &id, &amount);
+    client.refund(&id);
+
+    let contract_events: Vec<_> = env
+        .events()
+        .all()
+        .filter_by_contract(&checkout)
+        .events()
+        .collect();
+    // pay + refund = 2 events
+    assert_eq!(contract_events.len(), 2, "expected pay + refund events");
+
+    fn topic_symbols(ev: &soroban_sdk::Event) -> Vec<String> {
+        ev.topic()
+            .iter()
+            .map(|v| v.symbol().to_string())
+            .collect()
+    }
+    fn topic_bytes_n(ev: &soroban_sdk::Event, idx: usize) -> String {
+        let b = ev.topic()[idx].bytesn().unwrap();
+        b.iter().map(|b| format!("{:02x}", b)).collect()
+    }
+    fn data_i128(ev: &soroban_sdk::Event) -> i128 {
+        ev.data().i128().unwrap()
+    }
+
+    let ev_refund = &contract_events[1];
+    let syms = topic_symbols(ev_refund);
+    assert_eq!(syms[0], "refund", "event must be OrderRefunded");
+    assert_eq!(
+        topic_bytes_n(ev_refund, 1),
+        soroban_sdk::hex::encode(id.to_array()),
+        "refund order_id topic mismatch"
+    );
+    assert_eq!(
+        syms[2], buyer.to_string(),
+        "refund buyer topic mismatch"
+    );
+    assert_eq!(data_i128(ev_refund), amount, "OrderRefunded data amount mismatch");
 }


### PR DESCRIPTION
## Problem

`test_events_emitted` in `contracts/checkout/src/test.rs` only asserts that at least one contract event was recorded. The exact topic layout that the JS indexer (`lib/stellar/indexer.ts`) depends on — symbols, order of topics, and data fields — is never locked down by the contract test suite.

## Fix

Extended `test_events_emitted` to assert, per lifecycle step:

- **Event 0 (OrderCreated)**: topic[0]=`create_order`, topic[1]=token, topic[2]=buyer, topic[3]=order_id (hex), data=amount
- **Event 1 (PaymentReceived)**: topic[0]=`pay`, topic[1]=token, topic[2]=buyer, topic[3]=merchant, topic[4]=order_id (hex), data=amount
- **Event 2 (OrderShipped)**: topic[0]=`dispatch`, topic[1]=order_id (hex), topic[2]=merchant, data=amount

Added new test `test_refund_event_emitted` for the refund lifecycle:
- topic[0]=`refund`, topic[1]=order_id (hex), topic[2]=buyer, data=amount

All assertions match the topic layout documented in `contracts/checkout/src/events.rs`.

## Notes

- Rust toolchain not available locally; CI will run `cargo test` on push.
- Added `use soroban_sdk::hex` import for hex encoding helpers.
