### PR TITLE
feat(shop): add loading skeleton and empty state to products grid (closes #105)

### DIFF
--- a/app/shop/page.jsx
+++ b/app/shop/page.jsx
@@ -9,6 +9,7 @@ import Modal from "../../components/Modal";
 import Toast from "../../components/Toast";
 import useToast from "../../hooks/useToast";
 import { listProducts } from "../../lib/products";
+import { ProductGridSkeleton } from "../../components/Skeleton";
 
 export default function Products() {
   const { itemCount, cartItems, addToCart, removeFromCart, totalPrice } = useCart();
@@ -17,14 +18,19 @@ export default function Products() {
   const [isCheckingOut, setIsCheckingOut] = useState(false);
   const [products, setProducts] = useState([]);
   const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchProducts = async () => {
+      setLoading(true);
+      setError(null);
       try {
         const data = await listProducts();
         setProducts(data);
       } catch (err) {
         setError(err.message);
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -55,32 +61,40 @@ export default function Products() {
 
           {error && <p className="text-red-500 text-center">{error}</p>}
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
-            {products.map((prod) => (
-              <div key={prod.id} className="p-4 border rounded-lg shadow">
-                <Link href={`/shop/${prod.id}`}>
-                  <Image
-                    src={prod.img} // Ensure this URL is correct
-                    alt={prod.name}
-                    width={200}
-                    height={200}
-                    className="mb-2"
-                  />
-                  <h1 className="text-xl font-bold">{prod.name}</h1>
-                  <h2 className="text-lg">${prod.price}</h2>
-                </Link>
-                <button
-                  className="border-purple-800 rounded-full px-2 py-2 mt-2 border-2 hover:border-purple-600"
-                  onClick={() => {
-                    addToCart(prod);
-                    showToast("Item added to cart");
-                  }}
-                >
-                  <FaShoppingCart />
-                </button>
-              </div>
-            ))}
-          </div>
+          {loading ? (
+            <ProductGridSkeleton />
+          ) : products.length > 0 ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+              {products.map((prod) => (
+                <div key={prod.id} className="p-4 border rounded-lg shadow">
+                  <Link href={`/shop/${prod.id}`}>
+                    <Image
+                      src={prod.img} // Ensure this URL is correct
+                      alt={prod.name}
+                      width={200}
+                      height={200}
+                      className="mb-2"
+                    />
+                    <h1 className="text-xl font-bold">{prod.name}</h1>
+                    <h2 className="text-lg">${prod.price}</h2>
+                  </Link>
+                  <button
+                    className="border-purple-800 rounded-full px-2 py-2 mt-2 border-2 hover:border-purple-600"
+                    onClick={() => {
+                      addToCart(prod);
+                      showToast("Item added to cart");
+                    }}
+                  >
+                    <FaShoppingCart />
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : (
+            !error && (
+              <p className="text-center py-16 text-mova-ink/70">No products yet</p>
+            )
+          )}
         </section>
       </div>
 

--- a/tests/components/ShopPage.test.tsx
+++ b/tests/components/ShopPage.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Products from "../../app/shop/page";
+import { CartProvider } from "../../context/CartContext";
+import { listProducts } from "../../lib/products";
+
+vi.mock("../../lib/products", () => ({ listProducts: vi.fn() }));
+
+vi.mock("../../components/Toast", () => ({
+  default: ({ message, show }: { message: string; show: boolean }) =>
+    show ? <p role="status">{message}</p> : null,
+}));
+
+const product = {
+  id: "runner-42",
+  name: "Mova Runner",
+  price: 75,
+  img: "/images/shoe1.png",
+};
+
+function pendingProducts() {
+  let resolve!: (products: (typeof product)[]) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<(typeof product)[]>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  vi.mocked(listProducts).mockReturnValueOnce(promise);
+  return { resolve, reject };
+}
+
+function renderShop() {
+  return render(
+    <CartProvider>
+      <Products />
+    </CartProvider>
+  );
+}
+
+function skeletons() {
+  return screen.queryAllByRole("presentation", { hidden: true });
+}
+
+describe("Shop product loading states", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("shows ProductGridSkeleton while listProducts is pending", async () => {
+    const request = pendingProducts();
+    renderShop();
+
+    expect(listProducts).toHaveBeenCalledTimes(1);
+    expect(skeletons().length).toBeGreaterThan(0);
+    expect(screen.queryByText("No products yet")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+
+    await act(async () => request.resolve([]));
+  });
+
+  it("shows an explicit empty message when the catalogue resolves empty", async () => {
+    const request = pendingProducts();
+    renderShop();
+
+    await act(async () => request.resolve([]));
+
+    expect(screen.getByText("No products yet")).toBeInTheDocument();
+    expect(skeletons()).toHaveLength(0);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("renders product cards after a successful fetch", async () => {
+    const request = pendingProducts();
+    renderShop();
+
+    expect(skeletons().length).toBeGreaterThan(0);
+
+    await act(async () => request.resolve([product]));
+
+    const productLink = screen.getByRole("link", { name: /Mova Runner/ });
+    expect(productLink).toHaveAttribute("href", `/shop/${product.id}`);
+    expect(within(productLink).getByRole("img", { name: product.name })).toHaveAttribute(
+      "src",
+      product.img
+    );
+    expect(skeletons()).toHaveLength(0);
+    expect(screen.queryByText("No products yet")).not.toBeInTheDocument();
+
+    fireEvent.click(within(productLink.parentElement!).getByRole("button"));
+    expect(screen.getByRole("status")).toHaveTextContent("Item added to cart");
+  });
+
+  it("keeps the existing error state and hides the empty message on rejection", async () => {
+    const request = pendingProducts();
+    renderShop();
+
+    expect(skeletons().length).toBeGreaterThan(0);
+
+    await act(async () => request.reject(new Error("Catalogue unavailable")));
+
+    expect(screen.getByText("Catalogue unavailable")).toBeInTheDocument();
+    expect(skeletons()).toHaveLength(0);
+    expect(screen.queryByText("No products yet")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a `loading` flag around `listProducts()` in `app/shop/page.jsx`
- Render the existing `ProductGridSkeleton` while the fetch is pending (no more blank grid)
- Show an explicit **No products yet** empty state when the catalogue resolves empty
- Keep the existing error UI on rejection (empty message is suppressed when `error` is set)
- Add unit coverage in `tests/components/ShopPage.test.tsx` for loading / empty / success / error

Closes #105

## Test plan
- [x] `npx vitest run tests/components/ShopPage.test.tsx` (4/4 passed)
- [ ] Manual: open `/shop` with a slow network and confirm skeleton appears
- [ ] Manual: empty catalogue shows "No products yet"
- [ ] Manual: forced `listProducts` rejection still shows the red error line