### PR TITLE
fix(landing): unique Slider keys without duplicated images

### DIFF
--- a/app/(landingpage)/Slider.jsx
+++ b/app/(landingpage)/Slider.jsx
@@ -12,9 +12,9 @@ const Slider = () => {
   return (
     <section className="py-14 overflow-hidden bg-mova-surface/60">
       <div className="flex gap-6 overflow-x-auto px-6 md:px-10 pb-2">
-        {[...images, ...images].map((src, index) => (
+        {images.map((src) => (
           <Image
-            key={index}
+            key={src}
             src={src}
             alt="Mova Store footwear"
             width={240}


### PR DESCRIPTION
## Summary
- Stop spreading `[...images, ...images]` in `app/(landingpage)/Slider.jsx` so the strip renders exactly 5 images
- Use stable `key={src}` instead of index-based keys to avoid React duplicate-key warnings

Closes #75

## Test plan
- [ ] Open landing page and confirm Slider shows 5 footwear images
- [ ] Confirm no duplicate-key warning in the browser console
- [ ] Optional: search the DOM for Unsplash image nodes under the Slider section (expect 5)