### PR TITLE
docs: remove duplicated garbled README env sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,6 @@ Copy the template and fill in your values:
 cp .env.local.example .env.local
 ```
 
-A minimal Stellar-only configuration (the rest of the app runs with the existing
 A minimal Stellar-only configuration (fill Supabase values for auth/catalog):
 
 ```bash


### PR DESCRIPTION
## Summary
- Replace the duplicated/truncated README environment-setup sentences with one coherent line.

Closes #59