### PR TITLE
ci: pin rust-toolchain and trufflehog to release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: wasm32v1-none
@@ -119,7 +119,7 @@ jobs:
         run: npm audit --audit-level=high
 
       - name: Check for secrets
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.97.4
         with:
           extra_args: --only-verified
 
@@ -134,7 +134,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
 


### PR DESCRIPTION
## Summary
- Pin `dtolnay/rust-toolchain@master` → `@v1` (only released tag; matches `@vN` style of other actions in the file)
- Pin `trufflesecurity/trufflehog@main` → `@v3.97.4` (latest release)
- No `@main` / `@master` action refs remain in `ci.yml`

Closes #103

## Test plan
- [ ] Confirm `ci.yml` has no `uses: ...@main` or `uses: ...@master`
- [ ] Contracts / security jobs resolve `dtolnay/rust-toolchain@v1` and `trufflesecurity/trufflehog@v3.97.4`