### PR TITLE
ci: pin third-party GitHub Actions to release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: wasm32v1-none
@@ -119,7 +119,7 @@ jobs:
         run: npm audit --audit-level=high
 
       - name: Check for secrets
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.97.4
         with:
           extra_args: --only-verified
 
@@ -134,7 +134,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
 


### PR DESCRIPTION
## Summary
- Pin `dtolnay/rust-toolchain` to `@v1` and `trufflesecurity/trufflehog` to `@v3.97.4` so CI no longer tracks mutable `@master`/`@main`.

Closes #103