### PR TITLE
fix(ui): replace legacy Image props on collections page

### DIFF
--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -1,9 +1,8 @@
 import Image from 'next/image';
-import shoeImage1 from "/public/images/shoe4.png";
-import shoeImage2 from "/public/images/shoe3.png";
+import shoeImage1 from "/public/images/shoe1.png";
+import shoeImage2 from "/public/images/shoe2.png";
 import shoeImage3 from "/public/images/shoe3.png";
 import shoeImage4 from "/public/images/shoe4.png";
-import shoeImage5 from "/public/images/shoe5.png";
 const shoes = [
   {
     id: 1,
@@ -15,19 +14,19 @@ const shoes = [
     id: 2,
     name: "Basketball Shoes",
     price: "$129.99",
-    imageUrl: shoeImage1,
+    imageUrl: shoeImage2,
   },
   {
     id: 3,
     name: "Casual Sneakers",
     price: "$79.99",
-    imageUrl: shoeImage1,
+    imageUrl: shoeImage3,
   },
   {
     id: 4,
     name: "Formal Shoes",
     price: "$149.99",
-    imageUrl: shoeImage1,
+    imageUrl: shoeImage4,
   },
 ];
 
@@ -42,8 +41,8 @@ export default function ShoesCollection() {
               <Image
                 src={shoe.imageUrl}
                 alt={shoe.name}
-                layout="fill"
-                objectFit="cover"
+                fill
+                style={{ objectFit: 'cover' }}
                 className="rounded-t-lg"
               />
             </div>


### PR DESCRIPTION
## Summary
- Replace deprecated `layout`/`objectFit` Image props with `fill` + `style.objectFit`.
- Use distinct product images and drop unused imports.

Closes #26