### PR TITLE
fix(docs): replace duplicated Stellar env intro (#59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,6 @@ Copy the template and fill in your values:
 cp .env.local.example .env.local
 ```
 
-A minimal Stellar-only configuration (the rest of the app runs with the existing
 A minimal Stellar-only configuration (fill Supabase values for auth/catalog):
 
 ```bash


### PR DESCRIPTION
Closes #59

## Summary
Replaces the two garbled/duplicated sentences above the Stellar env snippet in README with one coherent intro:

> A minimal Stellar-only configuration (fill Supabase values for auth/catalog):