### PR TITLE
fix(docs): align Stellar testnet TOC and CONTRIBUTING anchors (#46)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,7 +219,7 @@ npm run build        # Production build must succeed
 
 If your PR touches the Stellar payment flow, describe in the PR how you tested
 it against testnet (Freighter + USDC faucet account). Follow the flow in the
-root [README](README.md#paying-with-usdc-testnet).
+root [README](README.md#paying-with-stellar-testnet).
 
 ## Commit Message Style
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ buyer ──pay──▶ contract (escrow) ──dispatch──▶ merchant
   - [Step 5 — Initialize with your merchant wallet](#step-5--initialize-with-your-merchant-wallet)
   - [Step 6 — Wire the deployed contract to the storefront](#step-6--wire-the-deployed-contract-to-the-storefront)
   - [Convenience script](#convenience-script)
-- [Paying with USDC (testnet)](#paying-with-usdc-testnet)
+- [Paying with Stellar (testnet)](#paying-with-stellar-testnet)
 - [Environment Variables Reference](#environment-variables-reference)
 - [Security Notes](#security-notes)
 - [Contributing](#contributing)


### PR DESCRIPTION
Closes #46

## Summary
- README TOC: "Paying with USDC (testnet)" / `#paying-with-usdc-testnet` → "Paying with Stellar (testnet)" / `#paying-with-stellar-testnet` to match the section heading.
- CONTRIBUTING.md link updated to the same anchor.
- Repo grep shows zero remaining `paying-with-usdc-testnet` references in these docs.